### PR TITLE
Bug: Fix Issue with Raw Text Imports

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -6,6 +6,18 @@ This is a pre-release version and APIs will change quickly. Before `1.0` release
 
 Please note after `1.0` Semver will be followed using normal protocols.
 
+# Version 0.13.3 - 07.16.2025
+
+* **Bug** - Fix issue with empty file `dist/.js` in npm package build.
+* **Improvement/Bug** - `@semanti-ui/core` was using raw text imports i.e.
+```javascript
+import template from './button.html?raw' assert { type: 'txt' };
+```
+
+These imports may not be processed downstream properly in Vite when using esmodules unless `optimize.excludeDeps` included `@semantic-ui/core`.
+
+We've now linked the ESM build to a build that inlines raw text imports to prevent issues with downstream builds.
+
 # Version 0.13.2 - 07.15.2025
 
 * **Bug** - Remove unused dependency `@semantic-ui/esbuild-log`

--- a/internal-packages/scripts/src/build-specs.js
+++ b/internal-packages/scripts/src/build-specs.js
@@ -1,0 +1,35 @@
+import { buildESM } from './build-esm.js';
+
+/*
+  This exports specs files to dist/ folder for consuming via package exports
+  Builds both specs.js and component-specs.js to avoid downstream issues with raw text imports
+  Only builds ESM version since specs are just JSON data exports
+*/
+export const buildSpecs = async ({
+  watch = false,
+} = {}) => {
+
+  const config = {
+    watch,
+    type: 'javascript',
+    entryPoints: ['./src/specs/specs.js', './src/specs/component-specs.js'],
+    entryNames: '[name]', // preserves original filename
+    outbase: 'src/specs',
+    outdir: 'dist',
+    log: { header: 'Specs', text: 'Build ESM' },
+  };
+
+  await buildESM(config);
+
+};
+
+
+// Wrapped for NPM wireit consumption
+if (import.meta.url === `file://${process.argv[1]}`) {
+  (async function() {
+
+    const result = await buildSpecs();
+    process.exit();
+
+  })();
+}

--- a/internal-packages/scripts/src/build-ui-components.js
+++ b/internal-packages/scripts/src/build-ui-components.js
@@ -21,6 +21,10 @@ export const buildUIComponents = async ({
     entryPoints: ['./src/components/**/index.js'],
     entryNames: '[dir]', // button.js,
     outbase: 'src/components',
+    filterEntries: (path) => {
+      // Exclude root-level src/components/index.js to avoid empty filename issue
+      return !path.endsWith('src/components/index.js');
+    }
   };
 
   if(includeESM) {

--- a/internal-packages/scripts/src/lib/build.js
+++ b/internal-packages/scripts/src/lib/build.js
@@ -1,6 +1,8 @@
 import { resolve, dirname } from 'path';
 import fs from 'fs/promises';
+
 import * as esbuild from 'esbuild';
+import glob from 'tiny-glob';
 
 import { resolveBareImports } from '@semantic-ui/esbuild-resolve-bare-imports';
 import { log as logPlugin } from '@semantic-ui/esbuild-log';
@@ -45,6 +47,7 @@ export const getESBuildConfig = async function({
   outdir = '', // custom outdir
   outfile = '', // custom out file,
   entryPoints = [], // custom entrypionts
+  filterEntries = null, // optional function to filter entry points
   plugins = [], // custom additional plugins
   sourcemap = true, // whether to include source maps
   onLoad = null, // callback function after build
@@ -113,7 +116,21 @@ export const getESBuildConfig = async function({
 
     // naive main entrypoint evaluation
     if(entryPoints.length) {
-      config.entryPoints = entryPoints;
+      // If filterEntries is provided and entryPoints contains glob patterns
+      if(filterEntries && entryPoints.some(ep => ep.includes('*'))) {
+        const resolvedEntries = [];
+        for(const pattern of entryPoints) {
+          if(pattern.includes('*')) {
+            const globEntries = await getEntryPoints(pattern, filterEntries);
+            resolvedEntries.push(...globEntries);
+          } else {
+            resolvedEntries.push(pattern);
+          }
+        }
+        config.entryPoints = resolvedEntries;
+      } else {
+        config.entryPoints = entryPoints;
+      }
     }
     else if(readEntrypoints) {
       const entry = packageFile.module || packageFile.main;
@@ -303,3 +320,16 @@ export const watch = async (...args) => {
     ...args
   });
 };
+
+/**
+ * Asynchronously resolves entry points from a glob pattern.
+ *
+ * @param {string} globPattern - The glob pattern to resolve.
+ * @param {function(string): boolean} [filter] - An optional function to filter the resolved paths.
+ * @returns {Promise<string[]>} A promise that resolves to an array of file paths.
+ */
+async function getEntryPoints(globPattern, filter = () => true) {
+  const pattern = globPattern.replace(/\\/g, '/');
+  const allEntries = await glob(pattern);
+  return allEntries.filter(filter);
+}

--- a/package.json
+++ b/package.json
@@ -112,6 +112,9 @@
   },
   "scripts": {
     "build": "wireit",
+    "build:ui": "wireit",
+    "build:ui-deps": "wireit",
+    "build:ui-components": "wireit",
     "dev": "wireit",
     "dev:workspace": "node ./internal-packages/scripts/src/build-ai-workspace.js --serve",
     "mcp": "wireit",
@@ -143,6 +146,13 @@
       "command": "node ./internal-packages/scripts/src/build-ui-framework.js",
       "dependencies": [
         "build:packages",
+        "build:ui-deps",
+        "build:ui-components"
+      ]
+    },
+    "build:ui": {
+      "command": "node ./internal-packages/scripts/src/build-ui-framework.js",
+      "dependencies": [
         "build:ui-deps",
         "build:ui-components"
       ]

--- a/package.json
+++ b/package.json
@@ -16,10 +16,10 @@
   "exports": {
     ".": {
       "types": "./types/index.d.ts",
-      "import": "./src/components/index.js",
+      "import": "./dist/semantic-ui.js",
       "browser": "./dist/cdn/semantic-ui.min.js",
       "bundled": "./dist/semantic-ui.min.js",
-      "default": "./src/components/index.js"
+      "default": "./dist/semantic-ui.js"
     },
     "./css": {
       "import": "./src/css/all.css",
@@ -50,64 +50,64 @@
       "default": "./examples/index.js"
     },
     "./button": {
-      "import": "./src/components/button/index.js",
+      "import": "./dist/button.js",
       "browser": "./dist/cdn/button.min.js",
       "bundled": "./dist/bundled/button.min.js",
-      "default": "./src/components/button/index.js"
+      "default": "./dist/button.js"
     },
     "./card": {
-      "import": "./src/components/card/index.js",
+      "import": "./dist/card.js",
       "browser": "./dist/cdn/card.min.js",
       "bundled": "./dist/bundled/card.min.js",
-      "default": "./src/components/card/index.js"
+      "default": "./dist/card.js"
     },
     "./container": {
-      "import": "./src/components/container/index.js",
+      "import": "./dist/container.js",
       "browser": "./dist/cdn/container.min.js",
       "bundled": "./dist/bundled/container.min.js",
-      "default": "./src/components/container/index.js"
+      "default": "./dist/container.js"
     },
     "./icon": {
-      "import": "./src/components/icon/index.js",
+      "import": "./dist/icon.js",
       "browser": "./dist/cdn/icon.min.js",
       "bundled": "./dist/bundled/icon.min.js",
-      "default": "./src/components/icon/index.js"
+      "default": "./dist/icon.js"
     },
     "./input": {
-      "import": "./src/components/input/index.js",
+      "import": "./dist/input.js",
       "browser": "./dist/cdn/input.min.js",
       "bundled": "./dist/bundled/input.min.js",
-      "default": "./src/components/input/index.js"
+      "default": "./dist/input.js"
     },
     "./label": {
-      "import": "./src/components/label/index.js",
+      "import": "./dist/label.js",
       "browser": "./dist/cdn/label.min.js",
       "bundled": "./dist/bundled/label.min.js",
-      "default": "./src/components/label/index.js"
+      "default": "./dist/label.js"
     },
     "./menu": {
-      "import": "./src/components/menu/index.js",
+      "import": "./dist/menu.js",
       "browser": "./dist/cdn/menu.min.js",
       "bundled": "./dist/bundled/menu.min.js",
-      "default": "./src/components/menu/index.js"
+      "default": "./dist/menu.js"
     },
     "./modal": {
-      "import": "./src/components/modal/index.js",
+      "import": "./dist/modal.js",
       "browser": "./dist/cdn/modal.min.js",
       "bundled": "./dist/bundled/modal.min.js",
-      "default": "./src/components/modal/index.js"
+      "default": "./dist/modal.js"
     },
     "./rail": {
-      "import": "./src/components/rail/index.js",
+      "import": "./dist/rail.js",
       "browser": "./dist/cdn/rail.min.js",
       "bundled": "./dist/bundled/rail.min.js",
-      "default": "./src/components/rail/index.js"
+      "default": "./dist/rail.js"
     },
     "./segment": {
-      "import": "./src/components/segment/index.js",
+      "import": "./dist/segment.js",
       "browser": "./dist/cdn/segment.min.js",
       "bundled": "./dist/bundled/segment.min.js",
-      "default": "./src/components/segment/index.js"
+      "default": "./dist/segment.js"
     }
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -38,12 +38,12 @@
       "default": "./src/css/tokens.css"
     },
     "./specs": {
-      "import": "./src/specs/specs.js",
-      "default": "./src/specs/specs.js"
+      "import": "./dist/specs.js",
+      "default": "./dist/specs.js"
     },
     "./component-specs": {
-      "import": "./src/specs/component-specs.js",
-      "default": "./src/specs/component-specs.js"
+      "import": "./dist/component-specs.js",
+      "default": "./dist/component-specs.js"
     },
     "./examples": {
       "import": "./examples/index.js",
@@ -115,6 +115,7 @@
     "build:ui": "wireit",
     "build:ui-deps": "wireit",
     "build:ui-components": "wireit",
+    "build:specs": "wireit",
     "dev": "wireit",
     "dev:workspace": "node ./internal-packages/scripts/src/build-ai-workspace.js --serve",
     "mcp": "wireit",
@@ -147,14 +148,16 @@
       "dependencies": [
         "build:packages",
         "build:ui-deps",
-        "build:ui-components"
+        "build:ui-components",
+        "build:specs"
       ]
     },
     "build:ui": {
       "command": "node ./internal-packages/scripts/src/build-ui-framework.js",
       "dependencies": [
         "build:ui-deps",
-        "build:ui-components"
+        "build:ui-components",
+        "build:specs"
       ]
     },
     "build:packages": {
@@ -183,6 +186,9 @@
     },
     "build:ui-components": {
       "command": "node ./internal-packages/scripts/src/build-ui-components.js"
+    },
+    "build:specs": {
+      "command": "node ./internal-packages/scripts/src/build-specs.js"
     },
     "build:ui-framework": {
       "command": "node ./internal-packages/scripts/src/build-ui-framework.js"


### PR DESCRIPTION
Adds fix for npm package failing in Vite due to raw text imports.

ESM endpoints now use a dist version that inlines them.