### PR TITLE
Feat: CDN /load endpoint with natural language attributes

### DIFF
--- a/ai/plans/ROADMAP.md
+++ b/ai/plans/ROADMAP.md
@@ -89,6 +89,7 @@ TOKEN FINALIZATION (the gate)
 | 2 | Docs Deploy 0.18.0 | 4h | agent | Build + smoke test. Menu trimming done on `docs/shippable`. |
 | 3 | State from Settings | 8h | pair | ~25 lines. API design + implement. |
 | 4 | [Rename Tooltip → Popover](rename-tooltip-to-popover.md) | 4h | agent | Mechanical rename across ~40 files. Partially resolves #21 (naming conventions). |
+| 5 | [CDN Load Endpoint](cdn-load-endpoint.md) | 8-16h (1-2d) | pair | Unified `/load` script — import map + CSS + icons + fonts in one tag. CSS layer splitting, loader generation. Active. |
 
 ## Up Next (unblocked after "Do Next" or independent)
 

--- a/ai/plans/cdn-load-endpoint.md
+++ b/ai/plans/cdn-load-endpoint.md
@@ -1,0 +1,384 @@
+# CDN Load Endpoint
+
+## Goal
+
+Replace the current `importmap.js` / `importmap.json` endpoints with a unified `/load` endpoint that serves as the single entry point for using Semantic UI from the CDN. The loader injects an import map and optionally loads packages, CSS (tokens only or full page styles), icon sets, and fonts — collapsing up to four separate tags into one.
+
+The endpoint should embody SUI's natural language philosophy: every attribute reads as a declarative instruction, not a technical configuration.
+
+## Target Snippet
+
+```html
+<!-- Full page setup (own the page) -->
+<script src="https://cdn.semantic-ui.com/load" packages="core" css="all" icons="lucide" fonts="lato"></script>
+<ui-button primary>Click Me</ui-button>
+
+<!-- Embedding into an existing page (tokens only, no global styles) -->
+<script src="https://cdn.semantic-ui.com/load" packages="core" css icons="lucide"></script>
+<ui-button primary>Click Me</ui-button>
+```
+
+One line of setup. One line of markup.
+
+## Design Decisions (Settled)
+
+### Endpoint naming: `/load` not `/loader` or `/importmap`
+
+**Decision:** The endpoint is `/load`.
+
+**Rationale:** Read the tag as a sentence — "script source: CDN load packages core, css, icons lucide, fonts lato." `load` is a verb that forms a grammatical sentence with the attributes that follow it. `loader` is a noun next to other nouns (`loader packages core` doesn't parse as English). `importmap` describes the mechanism, not the intent.
+
+**Ecosystem context:** The term "loader" has deep lineage (SystemJS, RequireJS, the original ES Module Loader spec, Node's `--loader` flag). But the endpoint name should describe what the user is *doing*, not what the infrastructure *is*. The user is loading packages, not configuring a loader.
+
+### Attribute naming: `packages` not `load`
+
+**Decision:** The attribute for selecting JS packages is `packages="core"` (or `packages="core,query,reactivity"`).
+
+**Rationale:** Originally considered `load="core"` but the endpoint is already named `/load` — `load` + `load` overloads the word. `packages` describes the *what*, not the *action*. It reads naturally: "load packages core." For combo sub-selection within a package: `packages="core/button,modal"`.
+
+### CSS attribute: `css` not `tokens`, with two tiers
+
+**Decision:** The attribute is `css` (not `tokens`). It supports two tiers:
+
+```html
+css              → tokens only (pure custom properties, zero side effects)
+css="all"        → tokens + reset (normalize) + base (page-level styling)
+```
+
+**Why `css` not `tokens`:** `tokens` is technically more accurate (the bare attribute serves a stylesheet of pure CSS custom properties), but the person writing this tag doesn't know what tokens are yet. Their mental model is "I need CSS for this to look right." When they forget the attribute and components look broken, `css` leads to "oh, I forgot the CSS" while `tokens` leads to "what are tokens?" — a documentation detour.
+
+**Why bare `css` is safe to recommend unconditionally:** The token stylesheet (`tokens.css`) is pure custom property declarations. It doesn't style any elements. It can't conflict with anything. The variables sit inert until a component's Shadow DOM references them. Someone dropping a `<ui-button>` into an existing WordPress page or React app gets working components with zero visual side effects on their existing styles.
+
+**Why components don't need the reset or base:** Shadow DOM boundaries prevent external selectors from reaching inside components. The reset (normalize.css) targets specific elements (`h1`, `button`, `input`, etc.) — none of these selectors match elements inside a shadow root. The only things that cross the boundary are inherited properties on `html`/`body` (`line-height: 1.15`, `-webkit-text-size-adjust: 100%`), both of which SUI components override internally via their own scoped CSS and token references.
+
+**Why `css="all"` is opt-in:** The base stylesheet sets `body` background, font family, text color, heading sizes, link styles, scrollbar appearance, smooth scrolling, `text-wrap: pretty`, `field-sizing: content`, and `interpolate-size: allow-keywords`. These are modern best practices that designers would turn on by default in a fresh project, but they change existing behavior in pages that already have their own styles. The distinction isn't "safe vs dangerous" — it's "components only" vs "components + page."
+
+**Vocabulary consistency:** `css` matches the explicit endpoint (`/css`), so the word stays the same between the one-tag and multi-tag setups:
+
+```html
+<!-- one tag, tokens only -->
+<script src="https://cdn.semantic-ui.com/load" packages="core" css></script>
+
+<!-- one tag, full page -->
+<script src="https://cdn.semantic-ui.com/load" packages="core" css="all"></script>
+
+<!-- explicit, tokens only -->
+<link rel="stylesheet" href="https://cdn.semantic-ui.com/css@0.18.0/tokens">
+
+<!-- explicit, full page -->
+<link rel="stylesheet" href="https://cdn.semantic-ui.com/css">
+```
+
+**Middle tier (`css="reset"`) considered and deferred:** A third tier (tokens + reset, no base) is logically coherent but unlikely to be used. The person who wants that level of control is also the person who writes explicit `<link>` tags. The explicit endpoints (`/css/tokens`, `/css/reset`, `/css/base`) support à la carte selection; the loader attribute keeps it simple with two tiers.
+
+### Non-standard attributes: intentional spec deviation
+
+**Decision:** Use bare attributes (`css`, `packages`, `icons`, `fonts`) directly on the `<script>` tag, not `data-` prefixed.
+
+**Rationale:** The HTML parser doesn't care — non-standard attributes on `<script>` are parsed, stored on the element, and accessible via `getAttribute()`. The browser doesn't throw or warn. The only cost is HTML validator complaints.
+
+The benefit is readability and brand consistency. SUI already uses non-standard attribute syntax on its own components (`<ui-button large>` where `large` is a bare attribute resolved through the spec system). Using `data-packages` would be inconsistent with the framework's identity — it reads like a different framework wrote the first line. `packages="core"` reads like SUI.
+
+**Risks considered:**
+- *Future spec collision:* Could `packages` or `css` become real attributes on `<script>`? `css` has no precedent, `packages` is generic but not in any proposal. Low risk, and migratable if it ever happens.
+- *Framework interference:* Some frameworks strip non-standard attributes during SSR/hydration. But this is a classic script tag, not a component — frameworks don't process these.
+- *Linters:* HTML validators will flag it. Minor annoyance for users who run strict validation.
+
+**Precedent:** Google Analytics used `async` before it was specced. Cloudflare workers use non-standard attributes. The `data-` prefix exists because the web was full of custom attributes — "convention" isn't "requirement."
+
+### Import maps as the happy path
+
+**Decision:** The import map is the primary recommended approach, not the combo endpoint or direct URL imports.
+
+**Rationale:** Import maps have been baseline across all browsers since 2023. Teaching people a proprietary combo URL convention when there's a web standard that does the same job is backwards. The import map approach also produces portable code — if someone later moves to a bundler, their `import '@semantic-ui/core'` statements don't change.
+
+**The three approaches, in recommended order:**
+1. **Import map (happy path):** `/load` with `packages` — bare specifiers, standard imports, portable code.
+2. **Direct URL imports (no setup):** `<script type="module" src="https://cdn.semantic-ui.com/core@0.18.0">` — good for single-file experiments, CodePens. Tradeoff: CDN-coupled imports.
+3. **Combo endpoint (optimization):** `core@0.18.0/button,input,modal` — cherry-pick components in a single request. Performance tool, not a starting point.
+
+### The loader is a classic script (not a module)
+
+**Decision:** `/load` serves a classic (non-module) script.
+
+**Rationale:** Import maps must be present in the DOM before any ES module starts resolving. The browser spec enforces this — once any module has been imported, injecting an import map is an error. A classic synchronous script can inject `<script type="importmap">` into the DOM before any `<script type="module">` is processed by the parser.
+
+This means `/load` cannot be used as `<script type="module" src="...">` and cannot be dynamically `import()`ed from another module. This is an inherent constraint of import maps, not a design choice. The individual package files (e.g., `core@0.18.0/button.min.js`) remain normal ES modules.
+
+## Design Decisions (CSS Injection via `blocking="render"`)
+
+### The FOUC problem
+
+When the loader injects CSS via JavaScript, the injected `<link>` tags are *not* render-blocking by spec. The browser may paint before the CSS arrives, causing a flash of unstyled content. For a design system, this is a dealbreaker.
+
+### Why `blocking="render"` is the answer
+
+The `blocking="render"` attribute on `<link>` elements tells the browser to block rendering until the resource loads — exactly the behavior that parser-discovered `<link>` tags get automatically. This makes JS-injected stylesheets render-safe.
+
+**Browser support (as of April 2026, via caniuse.com/wf-blocking-render):**
+- Chrome/Edge: shipped since version 105 (September 2022)
+- Safari: shipped since 18.2, including iOS Safari
+- Firefox: **not yet supported** (not in 149–152). Mozilla's standards position is "positive." `blocking="render"` is included in the **Interop 2026** focus areas (under Cross-document View Transitions sub-features), meaning all three engine teams have committed to shipping it in 2026.
+- Global coverage: **91%** as of February 2026
+- SUI 1.0 target: end of 2026 — Firefox is the sole holdout. By 1.0 launch, `blocking="render"` should be fully baseline.
+
+### Alternatives considered and rejected
+
+**`document.write('<link ...')`** — Actually works (written content enters the parser stream and IS render-blocking). But Chrome actively throttles and warns about `document.write` on slow connections, and it breaks if the document has already finished parsing. Building flagship DX on a deprecated API is not viable.
+
+**Inline the CSS tokens into the loader script as a `<style>` block** — The token stylesheet is small (~4-5KB gzipped). Could be baked in at build time. No FOUC because it's synchronous. But CSS then lives inside JS, caching is coupled, version alignment gets fragile. And icons/fonts are still separate resources needing their own loading, so you haven't collapsed everything.
+
+**Rely on practical browser behavior (no explicit blocking)** — Most browsers won't paint if a stylesheet is added to `<head>` before first paint and is still loading. But "in practice" isn't "by spec," varies by browser/connection/document complexity. Shipping a quickstart that sometimes flashes is a bad first impression.
+
+**Explicit `<link>` tags only (no CSS injection)** — Works everywhere today, no FOUC. This is the fallback/explicit-control approach. The tradeoff is more tags, which is fine for production but worse for the golden quickstart snippet.
+
+### Fallback strategy
+
+The explicit multi-tag setup remains documented as the "full control" approach and works in all browsers today:
+
+```html
+<!-- Full page (equivalent to css="all") -->
+<link rel="stylesheet" href="https://cdn.semantic-ui.com/css">
+<link rel="stylesheet" href="https://cdn.semantic-ui.com/icons/lucide">
+<link rel="stylesheet" href="https://cdn.semantic-ui.com/fonts/lato">
+<script src="https://cdn.semantic-ui.com/load" packages="core"></script>
+
+<!-- Embedding (equivalent to bare css) -->
+<link rel="stylesheet" href="https://cdn.semantic-ui.com/css@0.18.0/tokens">
+<script src="https://cdn.semantic-ui.com/load" packages="core"></script>
+```
+
+If `blocking="render"` support is incomplete at 1.0 launch, the loader can detect support and warn in the console, or the docs can note the browser requirement for the single-tag CSS attributes.
+
+## Versioning Behavior
+
+Follows the same pattern as all other CDN endpoints:
+
+| URL | Behavior | Cache |
+|---|---|---|
+| `/load` | 302 → latest versioned | 5 min TTL on redirect |
+| `/load@latest` | 302 → exact version | 5 min TTL on redirect |
+| `/load@canary` | Served directly | 60s TTL |
+| `/load@0.18.0` | Served directly | Immutable (1 year) |
+
+The raw import map JSON remains available for manual use:
+
+| URL | Behavior |
+|---|---|
+| `/load@0.18.0.json` | Raw import map JSON |
+| `/load@0.18.0` | Classic script (the loader) |
+
+## Attribute Reference
+
+| Attribute | Type | Example | Behavior |
+|---|---|---|---|
+| `packages` | Comma-separated | `packages="core"`, `packages="core,query,reactivity"` | Injects import map, then dynamically imports the listed packages |
+| `css` | Boolean or keyword | `css` (bare) | Injects token stylesheet only (`/css/tokens@{version}`) with `blocking="render"` |
+| `css` | | `css="all"` | Injects tokens + reset + base (`/css@{version}`) with `blocking="render"` |
+| `icons` | Value | `icons="lucide"`, `icons="lucide,phosphor"` | Injects icon stylesheet(s) with `blocking="render"` |
+| `fonts` | Value | `fonts="lato"` | Injects font stylesheet(s) with `blocking="render"` |
+
+Without `packages`, the loader only injects the import map (resolution without loading). This is useful when the consumer's own `<script type="module">` handles imports.
+
+Without any CSS/icons/fonts attributes, the loader only handles JS — no stylesheets injected.
+
+### CSS sub-endpoints (explicit `<link>` usage)
+
+For fine-grained control, the CSS layers are available as individual endpoints:
+
+| URL | Content |
+|---|---|
+| `/css` | Everything (tokens + reset + base) — same as `css="all"` |
+| `/css@0.18.0/tokens` | Pure custom properties only — same as bare `css` |
+| `/css@0.18.0/reset` | Normalize (depends on tokens) |
+| `/css@0.18.0/base` | Page-level styling (depends on tokens + reset) |
+
+All follow standard versioning: `/css@0.18.0/tokens`, `/css@canary/tokens`, `/css/tokens` (302 → latest), etc. The version goes on the parent (`/css@version/layer`), consistent with icons (`/icons@version/lucide`) and fonts (`/fonts@version/lato`).
+
+## Implementation Sketch
+
+The loader script (served as a classic script):
+
+```js
+(function() {
+  var s = document.currentScript;
+
+  // 1. Inject import map (always)
+  if (!document.querySelector('script[type="importmap"]')) {
+    var map = document.createElement('script');
+    map.type = 'importmap';
+    map.textContent = JSON.stringify(/* baked in at build time */);
+    document.head.appendChild(map);
+  }
+
+  // 2. Inject CSS resources (if requested)
+  var base = 'https://cdn.semantic-ui.com';
+  var v = /* version, baked in at build time */;
+
+  if (s.hasAttribute('css')) {
+    var cssValue = s.getAttribute('css');
+    if (cssValue === 'all') {
+      // Full page: tokens + reset + base
+      injectCSS(base + '/css@' + v);
+    } else {
+      // Bare attribute or css="tokens": tokens only
+      injectCSS(base + '/css@' + v + '/tokens');
+    }
+  }
+
+  var icons = s.getAttribute('icons');
+  if (icons) {
+    icons.split(',').forEach(function(set) {
+      injectCSS(base + '/icons@' + v + '/' + set.trim());
+    });
+  }
+
+  var fonts = s.getAttribute('fonts');
+  if (fonts) {
+    fonts.split(',').forEach(function(set) {
+      injectCSS(base + '/fonts@' + v + '/' + set.trim());
+    });
+  }
+
+  // 3. Load packages (if requested)
+  var pkgs = s.getAttribute('packages');
+  if (pkgs) {
+    pkgs.split(',').forEach(function(pkg) {
+      import(base + '/' + pkg.trim() + '@' + v);
+    });
+  }
+
+  function injectCSS(href) {
+    var link = document.createElement('link');
+    link.rel = 'stylesheet';
+    link.href = href;
+    link.setAttribute('blocking', 'render');
+    document.head.appendChild(link);
+  }
+})();
+```
+
+### Build-time concerns
+
+- The import map JSON and version string are baked in at build time (same as current `importmap.js` in `upload.js:buildImportMap()`).
+- The loader is generated per-version, uploaded to R2 alongside other versioned assets.
+- The raw `.json` variant is the import map data without the loader wrapper.
+
+### Build system changes
+
+**New CSS entry points.** Currently `build-ui-framework.js` produces one CSS output (`semantic-ui.min.css`) from `all.css`. Three additional esbuild CSS builds are needed:
+
+| Entry file | Output | R2 key pattern |
+|---|---|---|
+| `src/definitions/tokens.css` | `tokens.min.css` + `.map` | `@semantic-ui/core/{version}/dist/tokens.min.css` |
+| `src/definitions/global/reset.css` | `reset.min.css` + `.map` | `@semantic-ui/core/{version}/dist/reset.min.css` |
+| `src/definitions/global/base.css` | `base.min.css` + `.map` | `@semantic-ui/core/{version}/dist/base.min.css` |
+
+Each uses esbuild's CSS loader (which follows `@import`). Tokens has ~30 sub-imports to resolve into one flat file. Reset and base are essentially flat already. This is adding entry points to the existing pipeline, not a structural change.
+
+**Loader script generation.** The `buildImportMap()` function in `upload.js` currently generates `importmap@{version}.js` and `importmap@{version}.json`. This needs to be extended to also generate `load@{version}.js` and `load@{version}.json`. The `.json` output is identical (raw import map). The `.js` output is the new loader IIFE (with import map JSON and version baked in).
+
+### Upload changes
+
+`upload.js` currently uploads CSS via a hardcoded list of four files (`semantic-ui.css`, `.css.map`, `.min.css`, `.min.css.map`). This list needs to expand to include the sub-layer files:
+
+```js
+const cssFiles = [
+  'semantic-ui.css', 'semantic-ui.css.map', 'semantic-ui.min.css', 'semantic-ui.min.css.map',
+  'tokens.css', 'tokens.css.map', 'tokens.min.css', 'tokens.min.css.map',
+  'reset.css', 'reset.css.map', 'reset.min.css', 'reset.min.css.map',
+  'base.css', 'base.css.map', 'base.min.css', 'base.min.css.map',
+];
+```
+
+The `uploadImportMaps()` function needs a parallel `uploadLoader()` that writes `_meta/load@{version}.js` and `_meta/load@{version}.json`. The `updateVersionPointer()` function needs to update `load@latest` and bare `load.js`/`load.json` in the same way it currently handles `importmap@latest`.
+
+### Worker routing changes
+
+The Worker (`worker/index.js`) needs three additions to `parseRoute()` and the fetch handler:
+
+**1. `/load` endpoint** — mirrors the import map pattern but with the new name:
+
+```js
+// In parseRoute():
+const loadMatch = pathname.match(/^\/load(?:@(.+))?\.(js|json)$/);
+if (loadMatch) {
+  return { type: 'load', version: loadMatch[1] || null, format: loadMatch[2] };
+}
+// Bare /load (no extension) → defaults to .js format
+if (pathname === '/load' || pathname.match(/^\/load@([^.]+)$/)) {
+  return { type: 'load', version: /* extract */, format: 'js' };
+}
+```
+
+The fetch handler mirrors the existing `importmap` case — serves from `_meta/load@{version}.js` or `.json`.
+
+**2. CSS sub-paths** — version on the parent, sub-path after (consistent with icons/fonts):
+
+```
+/css@0.18.0/tokens   → R2: @semantic-ui/core/0.18.0/dist/tokens.min.css
+/css@0.18.0/reset    → R2: @semantic-ui/core/0.18.0/dist/reset.min.css
+/css@0.18.0/base     → R2: @semantic-ui/core/0.18.0/dist/base.min.css
+/css@0.18.0          → R2: @semantic-ui/core/0.18.0/dist/semantic-ui.min.css (unchanged)
+```
+
+This follows the icons pattern (`/icons@0.18.0/lucide`) — version on the parent, layer name as sub-path. The existing `cssShortMatch` regex needs to be extended to capture an optional sub-path:
+
+```js
+const cssMatch = pathname.match(/^\/css(?:@([^/]+))?(?:\/(.+?))?$/);
+// cssMatch[1] = version, cssMatch[2] = sub-layer (tokens|reset|base) or undefined
+```
+
+The R2 key mapping in the fetch handler routes `sub-layer` → `{sub-layer}.min.css` and `undefined` → `semantic-ui.min.css`. Sourcemap handling (`.map` suffix, `SourceMap` header, inline rewrite) applies to all variants.
+
+**3. Backward compatibility** — the existing `/importmap.js` and `/importmap@{version}.json` endpoints continue to work unchanged. The `/load` endpoint is additive.
+
+### Test changes
+
+**Unit tests** (`test/unit/worker.test.js`): Add `parseRoute` tests for the new patterns:
+
+```js
+describe('parseRoute — load endpoint', () => {
+  it('/load → latest loader', ...);
+  it('/load@0.18.0 → versioned loader', ...);
+  it('/load@canary.json → canary raw JSON', ...);
+});
+
+describe('parseRoute — CSS sub-paths', () => {
+  it('/css@0.18.0/tokens → tokens only', ...);
+  it('/css@canary/reset → canary reset', ...);
+  it('/css/tokens → latest tokens', ...);
+});
+```
+
+**Browser tests** (`test/browser/cdn.test.js`): Add tests for the new CSS sub-endpoints and loader:
+
+```js
+describe('CDN CSS Sub-endpoints', () => {
+  it('/css@canary/tokens returns CSS', ...);
+  it('/css@canary/tokens does not include reset or base rules', ...);
+  it('/css@canary returns full CSS (tokens + reset + base)', ...);
+});
+
+describe('CDN Loader', () => {
+  it('/load serves classic script with import map', ...);
+  it('/load.json serves raw import map JSON', ...);
+});
+```
+
+## Open Questions
+
+1. **Should the import map include all SUI packages or only the ones listed in `packages`?** Currently the import map resolves all SUI packages. Unused mappings are inert (the browser ignores them), but it means loading `packages="reactivity"` also injects mappings for `core`, `query`, etc. This is probably fine — the import map data is small and having all mappings available means subsequent `<script type="module">` blocks can import any SUI package without additional setup. Confirm this is acceptable.
+
+2. **Should `packages` without a value (bare boolean) load a default set?** e.g., `<script src="/load" packages css>` could default to `packages="core"`. This is even more concise but might be too magical. Leaning toward requiring an explicit value.
+
+3. **Combo sub-selection syntax in `packages`.** Is `packages="core/button,modal"` supported? This would trigger the combo endpoint under the hood. Needs design for how this interacts with the import map (the import map resolves bare specifiers, but combo loads are URL-based).
+
+## Dependencies
+
+- [CDN Directory Pages](cdn-directory-pages.md) — the load endpoint's behavior and attributes need to be documented on the root dir page and package index pages. Content dependency, not a technical blocker.
+- `blocking="render"` browser support — the CSS injection feature depends on this reaching baseline. As of April 2026, 91% global coverage (Chrome, Edge, Safari). Firefox is the sole holdout, committed via Interop 2026. If it slips, the fallback is explicit `<link>` tags with the loader handling only JS.
+
+## Status
+
+Initial scope. Design decisions are settled from a pair session (2026-04-02). Implementation not started. Needs a follow-up session to resolve open questions and finalize the Worker routing changes.

--- a/ai/plans/cdn-load-endpoint.md
+++ b/ai/plans/cdn-load-endpoint.md
@@ -172,7 +172,8 @@ The raw import map JSON remains available for manual use:
 
 | Attribute | Type | Example | Behavior |
 |---|---|---|---|
-| `packages` | Comma-separated | `packages="core"`, `packages="core,query,reactivity"` | Injects import map, then dynamically imports the listed packages |
+| `packages` | Comma-separated or bare | `packages="core"`, `packages="core,query"`, `packages` | Injects import map, then dynamically imports listed packages. Bare attribute defaults to `core` with console warning. |
+| `components` | Comma-separated | `components="button,modal,tooltip"` | Cherry-picks specific components via combo endpoint. Use with `packages` for import map resolution. |
 | `css` | Boolean or keyword | `css` (bare) | Injects token stylesheet only (`/css/tokens@{version}`) with `blocking="render"` |
 | `css` | | `css="all"` | Injects tokens + reset + base (`/css@{version}`) with `blocking="render"` |
 | `icons` | Value | `icons="lucide"`, `icons="lucide,phosphor"` | Injects icon stylesheet(s) with `blocking="render"` |
@@ -366,19 +367,30 @@ describe('CDN Loader', () => {
 });
 ```
 
-## Open Questions
+## Resolved Questions
 
-1. **Should the import map include all SUI packages or only the ones listed in `packages`?** Currently the import map resolves all SUI packages. Unused mappings are inert (the browser ignores them), but it means loading `packages="reactivity"` also injects mappings for `core`, `query`, etc. This is probably fine — the import map data is small and having all mappings available means subsequent `<script type="module">` blocks can import any SUI package without additional setup. Confirm this is acceptable.
+1. **Import map scope:** Include all SUI packages, not just those listed in `packages`. Mappings are inert if unused, data is small, and having everything available means any subsequent `<script type="module">` just works.
 
-2. **Should `packages` without a value (bare boolean) load a default set?** e.g., `<script src="/load" packages css>` could default to `packages="core"`. This is even more concise but might be too magical. Leaning toward requiring an explicit value.
+2. **Bare `packages` (no value):** Defaults to `core` but logs a console warning: "Tip: use packages=\"core\" for clarity." Honors intent without being pedantic — but nudges toward explicit.
 
-3. **Combo sub-selection syntax in `packages`.** Is `packages="core/button,modal"` supported? This would trigger the combo endpoint under the hood. Needs design for how this interacts with the import map (the import map resolves bare specifiers, but combo loads are URL-based).
+3. **Component sub-selection:** Moved to a separate `components` attribute instead of overloading `packages` with slash syntax. `components="button,modal"` triggers the combo endpoint for cherry-picking. `packages` stays clean for package-level resolution.
+
+Updated attribute reference:
+
+| Attribute | Example | Behavior |
+|---|---|---|
+| `components` | `components="button,modal,tooltip"` | Loads specific components via combo endpoint |
+
+Full tag example:
+```html
+<script src="https://cdn.semantic-ui.com/load" packages="core" components="button,modal" css="all" icons="lucide" fonts="lato"></script>
+```
 
 ## Dependencies
 
-- [CDN Directory Pages](cdn-directory-pages.md) — the load endpoint's behavior and attributes need to be documented on the root dir page and package index pages. Content dependency, not a technical blocker.
+- [CDN Dir Pages](cdn-dir-pages.md) — the load endpoint's behavior and attributes need to be documented on the root dir page and package index pages. Content dependency, not a technical blocker.
 - `blocking="render"` browser support — the CSS injection feature depends on this reaching baseline. As of April 2026, 91% global coverage (Chrome, Edge, Safari). Firefox is the sole holdout, committed via Interop 2026. If it slips, the fallback is explicit `<link>` tags with the loader handling only JS.
 
 ## Status
 
-Initial scope. Design decisions are settled from a pair session (2026-04-02). Implementation not started. Needs a follow-up session to resolve open questions and finalize the Worker routing changes.
+Scoped. Design decisions settled, open questions resolved (2026-04-02). Implementation not started.

--- a/ai/plans/cdn-load-endpoint.md
+++ b/ai/plans/cdn-load-endpoint.md
@@ -2,20 +2,25 @@
 
 ## Goal
 
-Replace the current `importmap.js` / `importmap.json` endpoints with a unified `/load` endpoint that serves as the single entry point for using Semantic UI from the CDN. The loader injects an import map and optionally loads packages, CSS (tokens only or full page styles), icon sets, and fonts — collapsing up to four separate tags into one.
+Replace the current `importmap.js` / `importmap.json` endpoints with a unified `/load` endpoint that serves as the single entry point for using Semantic UI from the CDN. The loader injects an import map and handles component loading, CSS token injection, page-level styles, icon sets, and fonts — collapsing the entire setup into a single tag.
 
 The endpoint should embody SUI's natural language philosophy: every attribute reads as a declarative instruction, not a technical configuration.
 
 ## Target Snippet
 
 ```html
-<!-- Full page setup (own the page) -->
-<script src="https://cdn.semantic-ui.com/load" packages="core" css="all" icons="lucide" fonts="lato"></script>
-<ui-button primary>Click Me</ui-button>
+<!-- Most common: just works — tokens, Lato, Lucide all auto-injected -->
+<script src="https://cdn.semantic-ui.com/load" components="button,input,modal"></script>
+<ui-button primary><ui-icon home></ui-icon> Home</ui-button>
 
-<!-- Embedding into an existing page (tokens only, no global styles) -->
-<script src="https://cdn.semantic-ui.com/load" packages="core" css icons="lucide"></script>
-<ui-button primary>Click Me</ui-button>
+<!-- Full page ownership: add page-level styles (reset + base) -->
+<script src="https://cdn.semantic-ui.com/load" components="button,input,modal" css></script>
+
+<!-- Override defaults: different icon set, suppress font -->
+<script src="https://cdn.semantic-ui.com/load" components="button" icons="phosphor" fonts="none"></script>
+
+<!-- Embedding: suppress all auto-injection, manage CSS yourself -->
+<script src="https://cdn.semantic-ui.com/load" components="button" css="none" icons="none" fonts="none"></script>
 ```
 
 One line of setup. One line of markup.
@@ -26,54 +31,105 @@ One line of setup. One line of markup.
 
 **Decision:** The endpoint is `/load`.
 
-**Rationale:** Read the tag as a sentence — "script source: CDN load packages core, css, icons lucide, fonts lato." `load` is a verb that forms a grammatical sentence with the attributes that follow it. `loader` is a noun next to other nouns (`loader packages core` doesn't parse as English). `importmap` describes the mechanism, not the intent.
+**Rationale:** Read the tag as a sentence — "script source: CDN load components button, input, modal, icons, fonts." `load` is a verb that forms a grammatical sentence with the attributes that follow it. `loader` is a noun next to other nouns (`loader components button` doesn't parse as English). `importmap` describes the mechanism, not the intent.
 
 **Ecosystem context:** The term "loader" has deep lineage (SystemJS, RequireJS, the original ES Module Loader spec, Node's `--loader` flag). But the endpoint name should describe what the user is *doing*, not what the infrastructure *is*. The user is loading packages, not configuring a loader.
 
-### Attribute naming: `packages` not `load`
+### Attribute naming: bare attributes as capabilities
 
-**Decision:** The attribute for selecting JS packages is `packages="core"` (or `packages="core,query,reactivity"`).
+**Decision:** Every SUI package name is a valid bare attribute on the loader tag. Each reads as a single word describing what you need.
 
-**Rationale:** Originally considered `load="core"` but the endpoint is already named `/load` — `load` + `load` overloads the word. `packages` describes the *what*, not the *action*. It reads naturally: "load packages core." For combo sub-selection within a package: `packages="core/button,modal"`.
-
-### CSS attribute: `css` not `tokens`, with two tiers
-
-**Decision:** The attribute is `css` (not `tokens`). It supports two tiers:
+**`components`** — the primary path. Cherry-pick or use presets. Auto-injects tokens, Lato, Lucide.
 
 ```html
-css              → tokens only (pure custom properties, zero side effects)
-css="all"        → tokens + reset (normalize) + base (page-level styling)
+<!-- Cherry-pick -->
+<script src="https://cdn.semantic-ui.com/load" components="button,input,modal"></script>
+
+<!-- Named preset -->
+<script src="https://cdn.semantic-ui.com/load" components="standard"></script>
 ```
 
-**Why `css` not `tokens`:** `tokens` is technically more accurate (the bare attribute serves a stylesheet of pure CSS custom properties), but the person writing this tag doesn't know what tokens are yet. Their mental model is "I need CSS for this to look right." When they forget the attribute and components look broken, `css` leads to "oh, I forgot the CSS" while `tokens` leads to "what are tokens?" — a documentation detour.
+Presets (standard, extended, full) are sourced from the `bundle` field in each component's `.spec.js` and resolve through the existing combo endpoint. No new code needed.
 
-**Why bare `css` is safe to recommend unconditionally:** The token stylesheet (`tokens.css`) is pure custom property declarations. It doesn't style any elements. It can't conflict with anything. The variables sit inert until a component's Shadow DOM references them. Someone dropping a `<ui-button>` into an existing WordPress page or React app gets working components with zero visual side effects on their existing styles.
-
-**Why components don't need the reset or base:** Shadow DOM boundaries prevent external selectors from reaching inside components. The reset (normalize.css) targets specific elements (`h1`, `button`, `input`, etc.) — none of these selectors match elements inside a shadow root. The only things that cross the boundary are inherited properties on `html`/`body` (`line-height: 1.15`, `-webkit-text-size-adjust: 100%`), both of which SUI components override internally via their own scoped CSS and token references.
-
-**Why `css="all"` is opt-in:** The base stylesheet sets `body` background, font family, text color, heading sizes, link styles, scrollbar appearance, smooth scrolling, `text-wrap: pretty`, `field-sizing: content`, and `interpolate-size: allow-keywords`. These are modern best practices that designers would turn on by default in a fresh project, but they change existing behavior in pages that already have their own styles. The distinction isn't "safe vs dangerous" — it's "components only" vs "components + page."
-
-**Vocabulary consistency:** `css` matches the explicit endpoint (`/css`), so the word stays the same between the one-tag and multi-tag setups:
+**`authoring`** — for building custom components. Injects import map + tokens (custom component CSS needs them). No SUI components, fonts, or icons loaded.
 
 ```html
-<!-- one tag, tokens only -->
-<script src="https://cdn.semantic-ui.com/load" packages="core" css></script>
-
-<!-- one tag, full page -->
-<script src="https://cdn.semantic-ui.com/load" packages="core" css="all"></script>
-
-<!-- explicit, tokens only -->
-<link rel="stylesheet" href="https://cdn.semantic-ui.com/css@0.18.0/tokens">
-
-<!-- explicit, full page -->
-<link rel="stylesheet" href="https://cdn.semantic-ui.com/css">
+<script src="https://cdn.semantic-ui.com/load" authoring></script>
+<script type="module">
+  import { defineComponent } from '@semantic-ui/component';
+</script>
 ```
 
-**Middle tier (`css="reset"`) considered and deferred:** A third tier (tokens + reset, no base) is logically coherent but unlikely to be used. The person who wants that level of control is also the person who writes explicit `<link>` tags. The explicit endpoints (`/css/tokens`, `/css/reset`, `/css/base`) support à la carte selection; the loader attribute keeps it simple with two tiers.
+**`reactivity`, `query`, `utils`, `templating`, `renderer`, `compiler`, `specs`** — bare attributes that eagerly load the named package. Import map always injected. No CSS auto-injection.
+
+```html
+<script src="https://cdn.semantic-ui.com/load" reactivity></script>
+<script type="module">
+  import { Signal, Reaction } from '@semantic-ui/reactivity';
+</script>
+```
+
+```html
+<script src="https://cdn.semantic-ui.com/load" query></script>
+<script type="module">
+  import { $ } from '@semantic-ui/query';
+</script>
+```
+
+```html
+<script src="https://cdn.semantic-ui.com/load" utils></script>
+<script type="module">
+  import { capitalize, unique } from '@semantic-ui/utils';
+</script>
+```
+
+**Combining attributes:** Bare attributes compose naturally:
+
+```html
+<!-- Use SUI components + build custom ones -->
+<script src="https://cdn.semantic-ui.com/load" components="button" authoring></script>
+
+<!-- Reactivity + utils without UI -->
+<script src="https://cdn.semantic-ui.com/load" reactivity utils></script>
+
+<!-- Just the import map, nothing loaded -->
+<script src="https://cdn.semantic-ui.com/load"></script>
+```
+
+**Why bare attributes over `packages="reactivity"`:** The SUI pattern is bare attributes as words. `<ui-button primary>` not `<ui-button variant="primary">`. The loader follows the same philosophy — `<script load reactivity>` reads as English. `packages` as an attribute is retired.
+
+### CSS attribute: inferred tokens, opt-in page styles
+
+**Decision:** `components` auto-injects everything needed for a complete UI: tokens, default font (Lato), and default icon set (Lucide). The `css` attribute opts into page-level styles. `="none"` overrides any auto-injection.
+
+| Attribute | With `components` | With `packages` |
+|---|---|---|
+| *(none)* | Tokens + Lato + Lucide auto-injected | Nothing injected |
+| `css` | Above + reset + base (page styles) | Tokens + reset + base |
+| `css="none"` | Nothing CSS-related injected | Nothing injected |
+| `icons="none"` | Suppress icon auto-injection | — |
+| `fonts="none"` | Suppress font auto-injection | — |
+
+**Why everything is inferred with `components`:** The natural language context drives it. "Load components button" is a complete instruction — the user expects working components. Tokens, fonts, and icons are all component dependencies:
+- **Tokens:** Shadow DOM CSS references `var(--primary-color)`, `var(--text-color)`, etc. Without them, components have broken styling. No valid use case for components without tokens.
+- **Fonts:** Components reference `var(--page-font)` which resolves to `'Lato', ...`. Without Lato loaded, text renders in Arial — subtly wrong spacing and weight. An LLM generating UI can't diagnose this; the human sees "looks off" but can't identify why.
+- **Icons:** Button's most common pattern is `<ui-button><ui-icon home></ui-icon> Save</ui-button>`. Without icon CSS, the icon renders as an empty box. The icon CSS is ~6KB gzipped with lazy SVG loading — no wasted bandwidth for unused icons.
+
+This means `<script src="/load" components="button"></script>` just works. Zero failure modes. The minimum viable tag produces a complete, correct UI.
+
+**Why `="none"` overrides exist:** For users embedding into existing pages who have their own font, token layer, or icon system. These are power users making deliberate choices — the escape hatch is for them, not the common case.
+
+**Why `css` (bare) means page styles:** With tokens/fonts/icons inferred, `css` becomes explicitly about page-level styling — the reset (normalize) and base stylesheet (body font, heading sizes, link styles, scrollbar appearance, `text-wrap: pretty`, `field-sizing: content`, etc.). This is genuinely opt-in because it affects elements outside your components. The distinction is "components only" vs "components + page."
+
+**Why nothing is inferred with `packages`:** The `packages` path is for users who know what they're doing — loading standalone libraries like `reactivity` or `utils` that have no CSS dependency. Even `packages="core"` doesn't auto-inject because the user has explicitly chosen the lower-level API; they're responsible for their own setup.
+
+**Token safety:** The token stylesheet is pure custom property declarations. It doesn't style any elements. It can't conflict with anything. The variables sit inert until a component's Shadow DOM references them. Auto-injection is safe for any page — WordPress, React, an existing design system.
+
+**Shadow DOM isolation:** Components don't need the reset or base because Shadow DOM boundaries prevent external selectors from reaching inside. The reset (normalize.css) targets specific elements (`h1`, `button`, `input`, etc.) — none of these match inside a shadow root.
 
 ### Non-standard attributes: intentional spec deviation
 
-**Decision:** Use bare attributes (`css`, `packages`, `icons`, `fonts`) directly on the `<script>` tag, not `data-` prefixed.
+**Decision:** Use bare attributes (`css`, `packages`, `components`, `icons`, `fonts`) directly on the `<script>` tag, not `data-` prefixed.
 
 **Rationale:** The HTML parser doesn't care — non-standard attributes on `<script>` are parsed, stored on the element, and accessible via `getAttribute()`. The browser doesn't throw or warn. The only cost is HTML validator complaints.
 
@@ -93,9 +149,9 @@ The benefit is readability and brand consistency. SUI already uses non-standard 
 **Rationale:** Import maps have been baseline across all browsers since 2023. Teaching people a proprietary combo URL convention when there's a web standard that does the same job is backwards. The import map approach also produces portable code — if someone later moves to a bundler, their `import '@semantic-ui/core'` statements don't change.
 
 **The three approaches, in recommended order:**
-1. **Import map (happy path):** `/load` with `packages` — bare specifiers, standard imports, portable code.
-2. **Direct URL imports (no setup):** `<script type="module" src="https://cdn.semantic-ui.com/core@0.18.0">` — good for single-file experiments, CodePens. Tradeoff: CDN-coupled imports.
-3. **Combo endpoint (optimization):** `core@0.18.0/button,input,modal` — cherry-pick components in a single request. Performance tool, not a starting point.
+1. **Components (happy path):** `/load` with `components` — cherry-pick what you need, tokens auto-injected, import map available for subsequent imports.
+2. **Packages (full control):** `/load` with `packages` — load full package entry points, manage CSS yourself. For standalone libraries or advanced use.
+3. **Direct URL imports (no loader):** `<script type="module" src="https://cdn.semantic-ui.com/core@0.18.0">` — good for single-file experiments, CodePens. Tradeoff: CDN-coupled imports, manual CSS.
 
 ### The loader is a classic script (not a module)
 
@@ -137,15 +193,17 @@ The `blocking="render"` attribute on `<link>` elements tells the browser to bloc
 The explicit multi-tag setup remains documented as the "full control" approach and works in all browsers today:
 
 ```html
-<!-- Full page (equivalent to css="all") -->
+<!-- Full page (equivalent to components + css + icons + fonts) -->
 <link rel="stylesheet" href="https://cdn.semantic-ui.com/css">
 <link rel="stylesheet" href="https://cdn.semantic-ui.com/icons/lucide">
 <link rel="stylesheet" href="https://cdn.semantic-ui.com/fonts/lato">
-<script src="https://cdn.semantic-ui.com/load" packages="core"></script>
+<script src="https://cdn.semantic-ui.com/load" components="button,input,modal"></script>
 
-<!-- Embedding (equivalent to bare css) -->
+<!-- Embedding (equivalent to components + icons + fonts — tokens only) -->
 <link rel="stylesheet" href="https://cdn.semantic-ui.com/css@0.18.0/tokens">
-<script src="https://cdn.semantic-ui.com/load" packages="core"></script>
+<link rel="stylesheet" href="https://cdn.semantic-ui.com/icons/lucide">
+<link rel="stylesheet" href="https://cdn.semantic-ui.com/fonts/lato">
+<script src="https://cdn.semantic-ui.com/load" components="button,input,modal" css="none"></script>
 ```
 
 If `blocking="render"` support is incomplete at 1.0 launch, the loader can detect support and warn in the console, or the docs can note the browser requirement for the single-tag CSS attributes.
@@ -170,18 +228,46 @@ The raw import map JSON remains available for manual use:
 
 ## Attribute Reference
 
-| Attribute | Type | Example | Behavior |
-|---|---|---|---|
-| `packages` | Comma-separated or bare | `packages="core"`, `packages="core,query"`, `packages` | Injects import map, then dynamically imports listed packages. Bare attribute defaults to `core` with console warning. |
-| `components` | Comma-separated | `components="button,modal,tooltip"` | Cherry-picks specific components via combo endpoint. Use with `packages` for import map resolution. |
-| `css` | Boolean or keyword | `css` (bare) | Injects token stylesheet only (`/css/tokens@{version}`) with `blocking="render"` |
-| `css` | | `css="all"` | Injects tokens + reset + base (`/css@{version}`) with `blocking="render"` |
-| `icons` | Value | `icons="lucide"`, `icons="lucide,phosphor"` | Injects icon stylesheet(s) with `blocking="render"` |
-| `fonts` | Value | `fonts="lato"` | Injects font stylesheet(s) with `blocking="render"` |
+### JS loading (bare attributes)
 
-Without `packages`, the loader only injects the import map (resolution without loading). This is useful when the consumer's own `<script type="module">` handles imports.
+| Attribute | Behavior |
+|---|---|
+| `components="button,input"` | Cherry-pick components via combo endpoint. Auto-injects tokens, Lato, Lucide. |
+| `components="standard"` | Named preset (standard, extended, full). Same auto-injection. |
+| `authoring` | Loads `@semantic-ui/component`. Auto-injects tokens only. |
+| `reactivity` | Loads `@semantic-ui/reactivity`. No auto-injection. |
+| `query` | Loads `@semantic-ui/query`. No auto-injection. |
+| `utils` | Loads `@semantic-ui/utils`. No auto-injection. |
+| `templating` | Loads `@semantic-ui/templating`. No auto-injection. |
+| `renderer` | Loads `@semantic-ui/renderer`. No auto-injection. |
+| `compiler` | Loads `@semantic-ui/compiler`. No auto-injection. |
+| `specs` | Loads `@semantic-ui/specs`. No auto-injection. |
+| `tailwind` | Loads `@semantic-ui/tailwind`. No auto-injection. |
+| *(none)* | Import map only — resolution without loading. |
 
-Without any CSS/icons/fonts attributes, the loader only handles JS — no stylesheets injected.
+### CSS & assets (override defaults)
+
+| Attribute | Behavior |
+|---|---|
+| `css` | Injects full page styles: tokens + reset + base |
+| `css="none"` | Suppresses all CSS auto-injection |
+| `icons` (bare) | Lucide (same as default with `components`) |
+| `icons="phosphor"` | Override default icon set |
+| `icons="lucide,brands"` | Multiple sets |
+| `icons="none"` | Suppress icon auto-injection |
+| `fonts` (bare) | Lato (same as default with `components`) |
+| `fonts="lato"` | Explicit font set |
+| `fonts="none"` | Suppress font auto-injection |
+
+### Injection logic
+
+**With `components`:** Full component experience — tokens, Lato, Lucide auto-injected. `css` adds page styles. `="none"` suppresses any individual resource.
+
+**With `authoring`:** Tokens auto-injected (custom component CSS needs them). No fonts, icons, or SUI components.
+
+**With package attributes (`reactivity`, `query`, `utils`, etc.):** Nothing auto-injected. `css`, `icons`, `fonts` opt in explicitly.
+
+**Bare `/load`:** Import map only.
 
 ### CSS sub-endpoints (explicit `<link>` usage)
 
@@ -189,8 +275,8 @@ For fine-grained control, the CSS layers are available as individual endpoints:
 
 | URL | Content |
 |---|---|
-| `/css` | Everything (tokens + reset + base) — same as `css="all"` |
-| `/css@0.18.0/tokens` | Pure custom properties only — same as bare `css` |
+| `/css` | Everything (tokens + reset + base) — same as `css` attribute |
+| `/css@0.18.0/tokens` | Pure custom properties only — auto-injected by `components` |
 | `/css@0.18.0/reset` | Normalize (depends on tokens) |
 | `/css@0.18.0/base` | Page-level styling (depends on tokens + reset) |
 
@@ -212,42 +298,63 @@ The loader script (served as a classic script):
     document.head.appendChild(map);
   }
 
-  // 2. Inject CSS resources (if requested)
   var base = 'https://cdn.semantic-ui.com';
   var v = /* version, baked in at build time */;
+  var hasComponents = s.hasAttribute('components');
+  var hasAuthoring = s.hasAttribute('authoring');
+  var cssNone = s.getAttribute('css') === 'none';
 
-  if (s.hasAttribute('css')) {
-    var cssValue = s.getAttribute('css');
-    if (cssValue === 'all') {
-      // Full page: tokens + reset + base
+  // 2. Inject CSS resources
+  if (!cssNone) {
+    if (s.hasAttribute('css')) {
       injectCSS(base + '/css@' + v);
-    } else {
-      // Bare attribute or css="tokens": tokens only
+    } else if (hasComponents || hasAuthoring) {
       injectCSS(base + '/css@' + v + '/tokens');
     }
   }
 
-  var icons = s.getAttribute('icons');
-  if (icons) {
-    icons.split(',').forEach(function(set) {
-      injectCSS(base + '/icons@' + v + '/' + set.trim());
-    });
+  // 3. Icons — auto-inject lucide with components
+  var iconsAttr = s.getAttribute('icons');
+  if (iconsAttr !== 'none') {
+    var icons = iconsAttr || (hasComponents ? 'lucide' : null);
+    if (icons) {
+      icons.split(',').forEach(function(set) {
+        injectCSS(base + '/icons@' + v + '/' + set.trim());
+      });
+    }
   }
 
-  var fonts = s.getAttribute('fonts');
-  if (fonts) {
-    fonts.split(',').forEach(function(set) {
-      injectCSS(base + '/fonts@' + v + '/' + set.trim());
-    });
+  // 4. Fonts — auto-inject lato with components
+  var fontsAttr = s.getAttribute('fonts');
+  if (fontsAttr !== 'none') {
+    var fonts = fontsAttr || (hasComponents ? 'lato' : null);
+    if (fonts) {
+      fonts.split(',').forEach(function(set) {
+        injectCSS(base + '/fonts@' + v + '/' + set.trim());
+      });
+    }
   }
 
-  // 3. Load packages (if requested)
-  var pkgs = s.getAttribute('packages');
-  if (pkgs) {
-    pkgs.split(',').forEach(function(pkg) {
-      import(base + '/' + pkg.trim() + '@' + v);
-    });
+  // 5. Load components (via combo endpoint)
+  var components = s.getAttribute('components');
+  if (components) {
+    import(base + '/core@' + v + '/' + components);
   }
+
+  // 6. Load authoring lib
+  if (hasAuthoring) {
+    import(base + '/component@' + v);
+  }
+
+  // 7. Load bare package attributes
+  var pkgs = ['reactivity','query','utils','templating','renderer','compiler','specs','tailwind'];
+  // Note: 'component' is handled by 'authoring' above — not in this list
+  // because `<script load component>` reads ambiguously
+  pkgs.forEach(function(pkg) {
+    if (s.hasAttribute(pkg)) {
+      import(base + '/' + pkg + '@' + v);
+    }
+  });
 
   function injectCSS(href) {
     var link = document.createElement('link');
@@ -271,9 +378,9 @@ The loader script (served as a classic script):
 
 | Entry file | Output | R2 key pattern |
 |---|---|---|
-| `src/definitions/tokens.css` | `tokens.min.css` + `.map` | `@semantic-ui/core/{version}/dist/tokens.min.css` |
-| `src/definitions/global/reset.css` | `reset.min.css` + `.map` | `@semantic-ui/core/{version}/dist/reset.min.css` |
-| `src/definitions/global/base.css` | `base.min.css` + `.map` | `@semantic-ui/core/{version}/dist/base.min.css` |
+| `src/css/tokens.css` | `tokens.min.css` + `.map` | `@semantic-ui/core/{version}/dist/tokens.min.css` |
+| `src/css/global/reset.css` | `reset.min.css` + `.map` | `@semantic-ui/core/{version}/dist/reset.min.css` |
+| `src/css/global/base.css` | `base.min.css` + `.map` | `@semantic-ui/core/{version}/dist/base.min.css` |
 
 Each uses esbuild's CSS loader (which follows `@import`). Tokens has ~30 sub-imports to resolve into one flat file. Reset and base are essentially flat already. This is adding entry points to the existing pipeline, not a structural change.
 
@@ -369,28 +476,25 @@ describe('CDN Loader', () => {
 
 ## Resolved Questions
 
-1. **Import map scope:** Include all SUI packages, not just those listed in `packages`. Mappings are inert if unused, data is small, and having everything available means any subsequent `<script type="module">` just works.
+1. **Import map scope:** Include all SUI packages. Mappings are inert if unused, data is small, and having everything available means any subsequent `<script type="module">` just works.
 
-2. **Bare `packages` (no value):** Defaults to `core` but logs a console warning: "Tip: use packages=\"core\" for clarity." Honors intent without being pedantic — but nudges toward explicit.
+2. **`packages` attribute retired.** Replaced by bare package attributes (`reactivity`, `query`, `utils`, etc.) following SUI's bare-attribute pattern. `<script load reactivity>` reads as English.
 
-3. **Component sub-selection:** Moved to a separate `components` attribute instead of overloading `packages` with slash syntax. `components="button,modal"` triggers the combo endpoint for cherry-picking. `packages` stays clean for package-level resolution.
+3. **Component sub-selection:** Separate `components` attribute (not overloaded on `packages`). `components="button,modal"` triggers the combo endpoint. Named presets (`components="standard"`) also supported.
 
-Updated attribute reference:
+4. **Auto-injection with `components`:** Tokens, Lato font, and Lucide icons are all auto-injected — they are component dependencies, not separate resources. An LLM generating UI gets a complete, correct result from `components="button"` alone. `css="none"`, `icons="none"`, `fonts="none"` override individually.
 
-| Attribute | Example | Behavior |
-|---|---|---|
-| `components` | `components="button,modal,tooltip"` | Loads specific components via combo endpoint |
+5. **Auto-injection with `authoring`:** Tokens auto-injected (custom component CSS needs them). No fonts or icons — the authoring user manages their own. `tailwind` alongside `authoring` doesn't change this; Tailwind users who also want tokens get them via `authoring`. Those who don't add `css="none"`.
 
-Full tag example:
-```html
-<script src="https://cdn.semantic-ui.com/load" packages="core" components="button,modal" css="all" icons="lucide" fonts="lato"></script>
-```
+6. **`css` attribute semantics:** Bare `css` means full page styles (tokens + reset + base). `css="all"` eliminated — redundant. The default depends on context: `components` auto-injects tokens, `authoring` auto-injects tokens, bare package attributes inject nothing. `css` and `css="none"` are explicit overrides.
+
+7. **`tailwind` as bare attribute:** Loads `@semantic-ui/tailwind` (browser-native Oxide fork for shadow DOM). No auto-injection of its own — training data for LLMs using Tailwind doesn't know about SUI tokens, so mixing them by default would confuse generated code.
 
 ## Dependencies
 
-- [CDN Dir Pages](cdn-dir-pages.md) — the load endpoint's behavior and attributes need to be documented on the root dir page and package index pages. Content dependency, not a technical blocker.
+- [CDN Directory Pages](cdn-dir-pages.md) — the load endpoint's behavior and attributes need to be documented on the root dir page and package index pages. Content dependency, not a technical blocker.
 - `blocking="render"` browser support — the CSS injection feature depends on this reaching baseline. As of April 2026, 91% global coverage (Chrome, Edge, Safari). Firefox is the sole holdout, committed via Interop 2026. If it slips, the fallback is explicit `<link>` tags with the loader handling only JS.
 
 ## Status
 
-Scoped. Design decisions settled, open questions resolved (2026-04-02). Implementation not started.
+Scoped. Design decisions settled, open questions resolved from pair session (2026-04-02). Implementation not started.

--- a/internal-packages/scripts/src/build-ui-framework.js
+++ b/internal-packages/scripts/src/build-ui-framework.js
@@ -69,6 +69,13 @@ export const buildUIFramework = async ({
     entryNames: 'semantic-ui',
   };
 
+  // CSS sub-layers for /css/tokens, /css/reset, /css/base endpoints
+  const cssLayerConfigs = [
+    { entryPoints: ['src/css/tokens.css'], entryNames: 'tokens' },
+    { entryPoints: ['src/css/global/reset.css'], entryNames: 'reset' },
+    { entryPoints: ['src/css/global/base.css'], entryNames: 'base' },
+  ];
+
   if (includeESM) {
     tasks.push(
       buildESM({
@@ -76,6 +83,15 @@ export const buildUIFramework = async ({
         outdir: 'dist',
         log: { header: 'Framework CSS', text: 'Build ESM' },
       }),
+      ...cssLayerConfigs.map(layer =>
+        buildESM({
+          watch,
+          type: 'css',
+          ...layer,
+          outdir: 'dist',
+          log: { header: 'CSS Layer', text: `Build ${layer.entryNames}` },
+        })
+      ),
     );
   }
 
@@ -86,6 +102,15 @@ export const buildUIFramework = async ({
         outdir: 'dist/bundle',
         log: { header: 'Framework CSS', text: 'Build Bundle' },
       }),
+      ...cssLayerConfigs.map(layer =>
+        buildBundle({
+          watch,
+          type: 'css',
+          ...layer,
+          outdir: 'dist/bundle',
+          log: { header: 'CSS Layer', text: `Build ${layer.entryNames}` },
+        })
+      ),
     );
   }
 

--- a/tools/cdn/README.md
+++ b/tools/cdn/README.md
@@ -27,20 +27,60 @@ All JS and CSS responses include a `SourceMap` HTTP header pointing to the corre
 | `https://cdn.semantic-ui.com/semantic-ui@0.18.0.css` | Alias → same as `/css@0.18.0` |
 | `https://cdn.semantic-ui.com/semantic-ui@canary.css` | Alias → same as `/css@canary` |
 
-Serves `semantic-ui.min.css` by default (minified).
+Serves `semantic-ui.min.css` by default (minified). Individual CSS layers are available as sub-paths:
 
-### Import Map
+| URL | Content |
+|---|---|
+| `https://cdn.semantic-ui.com/css@0.18.0/tokens` | Pure custom properties only |
+| `https://cdn.semantic-ui.com/css@0.18.0/reset` | Normalize/reset stylesheet |
+| `https://cdn.semantic-ui.com/css@0.18.0/base` | Page-level styling (body, headings, links) |
+
+### Loader
+
+Single entry point for using Semantic UI from the CDN. Reads bare attributes from its `<script>` tag and injects import maps, CSS, icons, fonts, and loads components.
+
+```html
+<script src="https://cdn.semantic-ui.com/load" components="button,input,modal"></script>
+```
+
+The loader is version-agnostic — use the `version` attribute to pin:
+
+```html
+<script src="https://cdn.semantic-ui.com/load" version="0.18.0" components="standard"></script>
+```
+
+**Attributes:**
+
+| Attribute | Behavior |
+|---|---|
+| `components="button,input"` | Load specific components. Auto-injects tokens, Lato, Lucide. |
+| `components="standard"` | Load named preset (standard, extended, full). |
+| `components` (bare) | Defaults to `standard` preset. |
+| `authoring` | Load `@semantic-ui/component` for building custom components. Auto-injects tokens. |
+| `reactivity` | Load `@semantic-ui/reactivity`. |
+| `query` | Load `@semantic-ui/query`. |
+| `utils` | Load `@semantic-ui/utils`. |
+| `tailwind` | Load `@semantic-ui/tailwind`. |
+| `css` | Inject full page styles (tokens + reset + base). |
+| `css="tokens"` | Inject tokens only. |
+| `css="none"` | Suppress CSS auto-injection. |
+| `icons="phosphor"` | Override default icon set. |
+| `icons="none"` | Suppress icon auto-injection. |
+| `fonts="none"` | Suppress font auto-injection. |
+| `version="0.18.0"` | Pin all resources to a specific version. Default: `latest`. |
+
+The loader is a classic (non-module) synchronous script. Place it in `<head>` before any `<script type="module">` for import map resolution.
+
+### Import Map (legacy)
 
 | URL | Behavior |
 |---|---|
-| `https://cdn.semantic-ui.com/importmap.js` | Latest loader — synchronous, inline import map |
-| `https://cdn.semantic-ui.com/importmap@0.18.0.js` | Versioned loader, immutable |
-| `https://cdn.semantic-ui.com/importmap@canary.js` | Canary loader |
+| `https://cdn.semantic-ui.com/importmap.js` | Latest — synchronous, inline import map |
+| `https://cdn.semantic-ui.com/importmap@0.18.0.js` | Versioned, immutable |
+| `https://cdn.semantic-ui.com/importmap@canary.js` | Canary |
 | `https://cdn.semantic-ui.com/importmap.json` | Latest raw JSON |
-| `https://cdn.semantic-ui.com/importmap@0.18.0.json` | Versioned raw JSON |
-| `https://cdn.semantic-ui.com/importmap@canary.json` | Canary raw JSON |
 
-The `.js` loader is a synchronous script that injects a `<script type="importmap">` — no fetch, no race condition with `<script type="module">`.
+The import map endpoint is superseded by `/load` but continues to work for backward compatibility.
 
 ### SUI Packages
 
@@ -182,51 +222,29 @@ export * from "https://cdn.semantic-ui.com/core@0.18.0/modal.min.js";
 
 ## Usage Examples
 
-### Combo endpoint (simplest)
+### One-tag setup (recommended)
 
 ```html
-<link rel="stylesheet" href="https://cdn.semantic-ui.com/css">
-<link rel="stylesheet" href="https://cdn.semantic-ui.com/fonts/lato">
-<link rel="stylesheet" href="https://cdn.semantic-ui.com/icons/lucide">
-<script type="module" src="https://cdn.semantic-ui.com/core@canary/standard"></script>
-<ui-button primary>Click Me</ui-button>
-<ui-icon home></ui-icon>
+<script src="https://cdn.semantic-ui.com/load" components="button,input,icon"></script>
+<ui-button primary><ui-icon home></ui-icon> Home</ui-button>
 <ui-input placeholder="Type here"></ui-input>
 ```
 
-### Specific components + behavior
+Tokens, Lato font, and Lucide icons are auto-injected. One tag, everything works.
+
+### Full page ownership
 
 ```html
-<link rel="stylesheet" href="https://cdn.semantic-ui.com/css">
-<script type="module" src="https://cdn.semantic-ui.com/core@canary/button,tooltip"></script>
-<script type="module">
-  import { $ } from 'https://cdn.semantic-ui.com/query@canary';
-  $('ui-button').tooltip();
-</script>
-<ui-button data-text="Hello!">Hover me</ui-button>
-```
-
-### Import map (full control)
-
-```html
-<link rel="stylesheet" href="https://cdn.semantic-ui.com/css">
-<script src="https://cdn.semantic-ui.com/importmap.js"></script>
-<script type="module">
-  import '@semantic-ui/core';
-</script>
+<script src="https://cdn.semantic-ui.com/load" components="standard" css></script>
 <ui-button primary>Click Me</ui-button>
 ```
+
+`css` adds page-level styles (reset + base) on top of auto-injected tokens.
 
 ### Building custom components
 
 ```html
-<script type="importmap">
-{
-  "imports": {
-    "@semantic-ui/component": "https://cdn.semantic-ui.com/component@0.18.0"
-  }
-}
-</script>
+<script src="https://cdn.semantic-ui.com/load" authoring></script>
 <script type="module">
   import { defineComponent } from '@semantic-ui/component';
   defineComponent({
@@ -239,6 +257,33 @@ export * from "https://cdn.semantic-ui.com/core@0.18.0/modal.min.js";
   });
 </script>
 <my-counter></my-counter>
+```
+
+### Standalone packages
+
+```html
+<script src="https://cdn.semantic-ui.com/load" reactivity></script>
+<script type="module">
+  import { Signal, Reaction } from '@semantic-ui/reactivity';
+  const count = Signal(0);
+  Reaction(() => document.body.textContent = count.value);
+  setInterval(() => count.increment(), 1000);
+</script>
+```
+
+### Explicit setup (full control)
+
+```html
+<link rel="stylesheet" href="https://cdn.semantic-ui.com/css">
+<link rel="stylesheet" href="https://cdn.semantic-ui.com/fonts/lato">
+<link rel="stylesheet" href="https://cdn.semantic-ui.com/icons/lucide">
+<script src="https://cdn.semantic-ui.com/load" components="button,input"></script>
+```
+
+### Pinned version
+
+```html
+<script src="https://cdn.semantic-ui.com/load" version="0.18.0" components="standard"></script>
 ```
 
 ## Operations

--- a/tools/cdn/test/unit/worker.test.js
+++ b/tools/cdn/test/unit/worker.test.js
@@ -116,24 +116,12 @@ describe('parseRoute — vendor', () => {
 });
 
 describe('parseRoute — load endpoint', () => {
-  it('/load → latest loader', () => {
-    expect(parseRoute('/load')).toEqual({ type: 'load', version: null, format: 'js' });
+  it('/load → loader', () => {
+    expect(parseRoute('/load')).toEqual({ type: 'load' });
   });
 
-  it('/load@0.18.0 → versioned loader', () => {
-    expect(parseRoute('/load@0.18.0')).toEqual({ type: 'load', version: '0.18.0', format: 'js' });
-  });
-
-  it('/load@canary → canary loader', () => {
-    expect(parseRoute('/load@canary')).toEqual({ type: 'load', version: 'canary', format: 'js' });
-  });
-
-  it('/load@0.18.0.json → versioned raw JSON', () => {
-    expect(parseRoute('/load@0.18.0.json')).toEqual({ type: 'load', version: '0.18.0', format: 'json' });
-  });
-
-  it('/load.json → latest raw JSON', () => {
-    expect(parseRoute('/load.json')).toEqual({ type: 'load', version: null, format: 'json' });
+  it('/load.js → loader', () => {
+    expect(parseRoute('/load.js')).toEqual({ type: 'load' });
   });
 });
 
@@ -522,38 +510,8 @@ describe('asset set fetch', () => {
 ----------------------------------------------*/
 
 describe('load endpoint fetch', () => {
-  it('serves loader script', async () => {
+  it('serves loader script with short cache', async () => {
     const loaderJs = '(function(){ /* loader */ })();';
-    const env = {
-      CDN_BUCKET: mockR2Bucket({
-        '_meta/load@canary.js': loaderJs,
-      }),
-    };
-    const req = new Request('https://cdn.semantic-ui.com/load@canary');
-    const res = await worker.fetch(req, env);
-
-    expect(res.status).toBe(200);
-    expect(res.headers.get('Content-Type')).toBe('application/javascript');
-    expect(await res.text()).toBe(loaderJs);
-  });
-
-  it('serves raw JSON import map', async () => {
-    const mapJson = '{"imports":{}}';
-    const env = {
-      CDN_BUCKET: mockR2Bucket({
-        '_meta/load@canary.json': mapJson,
-      }),
-    };
-    const req = new Request('https://cdn.semantic-ui.com/load@canary.json');
-    const res = await worker.fetch(req, env);
-
-    expect(res.status).toBe(200);
-    expect(res.headers.get('Content-Type')).toBe('application/json');
-    expect(await res.text()).toBe(mapJson);
-  });
-
-  it('serves unversioned loader from latest', async () => {
-    const loaderJs = '(function(){ /* latest */ })();';
     const env = {
       CDN_BUCKET: mockR2Bucket({
         '_meta/load.js': loaderJs,
@@ -564,6 +522,8 @@ describe('load endpoint fetch', () => {
 
     expect(res.status).toBe(200);
     expect(res.headers.get('Content-Type')).toBe('application/javascript');
+    expect(res.headers.get('Cache-Control')).toBe('public, max-age=300');
+    expect(await res.text()).toBe(loaderJs);
   });
 });
 

--- a/tools/cdn/test/unit/worker.test.js
+++ b/tools/cdn/test/unit/worker.test.js
@@ -9,19 +9,40 @@ import worker from '../../worker/index.js';
 
 describe('parseRoute — CSS', () => {
   it('/css → latest', () => {
-    expect(parseRoute('/css')).toEqual({ type: 'css', version: 'latest', map: false });
+    expect(parseRoute('/css')).toEqual({ type: 'css', version: 'latest', layer: null, map: false });
   });
 
   it('/css@canary → canary', () => {
-    expect(parseRoute('/css@canary')).toEqual({ type: 'css', version: 'canary', map: false });
+    expect(parseRoute('/css@canary')).toEqual({ type: 'css', version: 'canary', layer: null, map: false });
   });
 
   it('/css@0.18.0 → versioned', () => {
-    expect(parseRoute('/css@0.18.0')).toEqual({ type: 'css', version: '0.18.0', map: false });
+    expect(parseRoute('/css@0.18.0')).toEqual({ type: 'css', version: '0.18.0', layer: null, map: false });
   });
 
   it('/css@canary.map → canary sourcemap', () => {
-    expect(parseRoute('/css@canary.map')).toEqual({ type: 'css', version: 'canary', map: true });
+    expect(parseRoute('/css@canary.map')).toEqual({ type: 'css', version: 'canary', layer: null, map: true });
+  });
+
+  it('/css@0.18.0/tokens → tokens layer', () => {
+    expect(parseRoute('/css@0.18.0/tokens')).toEqual({ type: 'css', version: '0.18.0', layer: 'tokens', map: false });
+  });
+
+  it('/css@canary/reset → reset layer', () => {
+    expect(parseRoute('/css@canary/reset')).toEqual({ type: 'css', version: 'canary', layer: 'reset', map: false });
+  });
+
+  it('/css/tokens → latest tokens', () => {
+    expect(parseRoute('/css/tokens')).toEqual({ type: 'css', version: 'latest', layer: 'tokens', map: false });
+  });
+
+  it('/css@0.18.0/tokens.map → tokens sourcemap', () => {
+    expect(parseRoute('/css@0.18.0/tokens.map')).toEqual({
+      type: 'css',
+      version: '0.18.0',
+      layer: 'tokens',
+      map: true,
+    });
   });
 
   it('/semantic-ui.css → latest', () => {
@@ -238,7 +259,7 @@ describe('CSS sourceMappingURL rewrite', () => {
 
     expect(res.status).toBe(200);
     const body = await res.text();
-    expect(body).toContain('sourceMappingURL=/semantic-ui@canary.css.map');
+    expect(body).toContain('sourceMappingURL=/css@canary.map');
     expect(body).not.toContain('sourceMappingURL=semantic-ui.min.css.map');
   });
 

--- a/tools/cdn/test/unit/worker.test.js
+++ b/tools/cdn/test/unit/worker.test.js
@@ -504,6 +504,8 @@ describe('asset set fetch', () => {
     expect(await res.text()).toBe(svg);
   });
 
+  // If 'icons' or 'fonts' were ever added to SUI_PACKAGES, the asset-set
+  // route must still match first — this is by design, not an accident
   it('asset-set routes take precedence over SUI packages with same name', () => {
     expect(parseRoute('/icons@0.18.0/lucide').type).toBe('asset-set');
     expect(parseRoute('/fonts@0.18.0/lato').type).toBe('asset-set');

--- a/tools/cdn/test/unit/worker.test.js
+++ b/tools/cdn/test/unit/worker.test.js
@@ -115,6 +115,28 @@ describe('parseRoute — vendor', () => {
   });
 });
 
+describe('parseRoute — load endpoint', () => {
+  it('/load → latest loader', () => {
+    expect(parseRoute('/load')).toEqual({ type: 'load', version: null, format: 'js' });
+  });
+
+  it('/load@0.18.0 → versioned loader', () => {
+    expect(parseRoute('/load@0.18.0')).toEqual({ type: 'load', version: '0.18.0', format: 'js' });
+  });
+
+  it('/load@canary → canary loader', () => {
+    expect(parseRoute('/load@canary')).toEqual({ type: 'load', version: 'canary', format: 'js' });
+  });
+
+  it('/load@0.18.0.json → versioned raw JSON', () => {
+    expect(parseRoute('/load@0.18.0.json')).toEqual({ type: 'load', version: '0.18.0', format: 'json' });
+  });
+
+  it('/load.json → latest raw JSON', () => {
+    expect(parseRoute('/load.json')).toEqual({ type: 'load', version: null, format: 'json' });
+  });
+});
+
 describe('parseRoute — SUI alias', () => {
   it('/@semantic-ui/core@0.18.0 → redirect', () => {
     expect(parseRoute('/@semantic-ui/core@0.18.0')).toEqual({
@@ -490,9 +512,105 @@ describe('asset set fetch', () => {
   });
 
   it('asset-set routes take precedence over SUI packages with same name', () => {
-    // If 'icons' or 'fonts' were ever added to SUI_PACKAGES, the asset-set
-    // route must still match first — this is by design, not an accident
     expect(parseRoute('/icons@0.18.0/lucide').type).toBe('asset-set');
     expect(parseRoute('/fonts@0.18.0/lato').type).toBe('asset-set');
+  });
+});
+
+/*----------------------------------------------
+  Worker fetch — Load endpoint
+----------------------------------------------*/
+
+describe('load endpoint fetch', () => {
+  it('serves loader script', async () => {
+    const loaderJs = '(function(){ /* loader */ })();';
+    const env = {
+      CDN_BUCKET: mockR2Bucket({
+        '_meta/load@canary.js': loaderJs,
+      }),
+    };
+    const req = new Request('https://cdn.semantic-ui.com/load@canary');
+    const res = await worker.fetch(req, env);
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Content-Type')).toBe('application/javascript');
+    expect(await res.text()).toBe(loaderJs);
+  });
+
+  it('serves raw JSON import map', async () => {
+    const mapJson = '{"imports":{}}';
+    const env = {
+      CDN_BUCKET: mockR2Bucket({
+        '_meta/load@canary.json': mapJson,
+      }),
+    };
+    const req = new Request('https://cdn.semantic-ui.com/load@canary.json');
+    const res = await worker.fetch(req, env);
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Content-Type')).toBe('application/json');
+    expect(await res.text()).toBe(mapJson);
+  });
+
+  it('serves unversioned loader from latest', async () => {
+    const loaderJs = '(function(){ /* latest */ })();';
+    const env = {
+      CDN_BUCKET: mockR2Bucket({
+        '_meta/load.js': loaderJs,
+      }),
+    };
+    const req = new Request('https://cdn.semantic-ui.com/load');
+    const res = await worker.fetch(req, env);
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Content-Type')).toBe('application/javascript');
+  });
+});
+
+/*----------------------------------------------
+  Worker fetch — CSS sub-layers
+----------------------------------------------*/
+
+describe('CSS sub-layer fetch', () => {
+  it('serves tokens CSS', async () => {
+    const tokens = ':root { --primary: blue; }';
+    const env = {
+      CDN_BUCKET: mockR2Bucket({
+        '@semantic-ui/core/canary/dist/tokens.min.css': tokens,
+      }),
+    };
+    const req = new Request('https://cdn.semantic-ui.com/css@canary/tokens');
+    const res = await worker.fetch(req, env);
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Content-Type')).toBe('text/css');
+    expect(res.headers.get('SourceMap')).toBe('/css@canary/tokens.map');
+  });
+
+  it('redirects latest CSS sub-layer to versioned', async () => {
+    const env = {
+      CDN_BUCKET: mockR2Bucket({
+        '_versions/latest': '0.19.0',
+      }),
+    };
+    const req = new Request('https://cdn.semantic-ui.com/css/tokens');
+    const res = await worker.fetch(req, env);
+
+    expect(res.status).toBe(302);
+    expect(res.headers.get('Location')).toBe('https://cdn.semantic-ui.com/css@0.19.0/tokens');
+  });
+
+  it('serves full CSS when no layer specified', async () => {
+    const fullCss = ':root {} body {}';
+    const env = {
+      CDN_BUCKET: mockR2Bucket({
+        '@semantic-ui/core/canary/dist/semantic-ui.min.css': fullCss,
+      }),
+    };
+    const req = new Request('https://cdn.semantic-ui.com/css@canary');
+    const res = await worker.fetch(req, env);
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('SourceMap')).toBe('/css@canary.map');
   });
 });

--- a/tools/cdn/test/unit/worker.test.js
+++ b/tools/cdn/test/unit/worker.test.js
@@ -574,3 +574,53 @@ describe('CSS sub-layer fetch', () => {
     expect(res.headers.get('SourceMap')).toBe('/css@canary.map');
   });
 });
+
+/*----------------------------------------------
+  Worker fetch — Combo endpoint
+----------------------------------------------*/
+
+describe('combo endpoint fetch', () => {
+  it('serves comma-separated components as re-exports', async () => {
+    const env = { CDN_BUCKET: mockR2Bucket({}) };
+    const req = new Request('https://cdn.semantic-ui.com/core@canary/button,input');
+    const res = await worker.fetch(req, env);
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Content-Type')).toBe('application/javascript');
+    const body = await res.text();
+    expect(body).toContain('export * from "https://cdn.semantic-ui.com/core@canary/button.min.js"');
+    expect(body).toContain('export * from "https://cdn.semantic-ui.com/core@canary/input.min.js"');
+  });
+
+  it('serves preset name as re-exports', async () => {
+    const env = {
+      CDN_BUCKET: mockR2Bucket({
+        '_meta/presets.json': JSON.stringify({
+          standard: ['button', 'input', 'icon'],
+        }),
+      }),
+    };
+    const req = new Request('https://cdn.semantic-ui.com/core@canary/standard');
+    const res = await worker.fetch(req, env);
+
+    expect(res.status).toBe(200);
+    const body = await res.text();
+    expect(body).toContain('button.min.js');
+    expect(body).toContain('input.min.js');
+    expect(body).toContain('icon.min.js');
+  });
+
+  it('falls through to file serving for non-combo paths', async () => {
+    const jsContent = 'export const Button = {};';
+    const env = {
+      CDN_BUCKET: mockR2Bucket({
+        '@semantic-ui/core/canary/dist/cdn/button.min.js': jsContent,
+      }),
+    };
+    const req = new Request('https://cdn.semantic-ui.com/core@canary/button.min.js');
+    const res = await worker.fetch(req, env);
+
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe(jsContent);
+  });
+});

--- a/tools/cdn/test/unit/worker.test.js
+++ b/tools/cdn/test/unit/worker.test.js
@@ -46,23 +46,28 @@ describe('parseRoute — CSS', () => {
   });
 
   it('/semantic-ui.css → latest', () => {
-    expect(parseRoute('/semantic-ui.css')).toEqual({ type: 'css', version: 'latest', map: false });
+    expect(parseRoute('/semantic-ui.css')).toEqual({ type: 'css', version: 'latest', layer: null, map: false });
   });
 
   it('/semantic-ui@canary.css → canary', () => {
-    expect(parseRoute('/semantic-ui@canary.css')).toEqual({ type: 'css', version: 'canary', map: false });
+    expect(parseRoute('/semantic-ui@canary.css')).toEqual({ type: 'css', version: 'canary', layer: null, map: false });
   });
 
   it('/semantic-ui@canary.css.map → canary sourcemap', () => {
-    expect(parseRoute('/semantic-ui@canary.css.map')).toEqual({ type: 'css', version: 'canary', map: true });
+    expect(parseRoute('/semantic-ui@canary.css.map')).toEqual({
+      type: 'css',
+      version: 'canary',
+      layer: null,
+      map: true,
+    });
   });
 
   it('/semantic-ui.min.css.map → latest sourcemap (inline URL)', () => {
-    expect(parseRoute('/semantic-ui.min.css.map')).toEqual({ type: 'css', version: 'latest', map: true });
+    expect(parseRoute('/semantic-ui.min.css.map')).toEqual({ type: 'css', version: 'latest', layer: null, map: true });
   });
 
   it('/semantic-ui.min.css → latest', () => {
-    expect(parseRoute('/semantic-ui.min.css')).toEqual({ type: 'css', version: 'latest', map: false });
+    expect(parseRoute('/semantic-ui.min.css')).toEqual({ type: 'css', version: 'latest', layer: null, map: false });
   });
 });
 

--- a/tools/cdn/upload.js
+++ b/tools/cdn/upload.js
@@ -311,7 +311,10 @@ function buildLoader() {
     }catch(e){}
   }else{
     if(document.querySelector('script[type="module"]')){
-      console.warn('SUI: Place <script src="/load"> before any <script type="module"> for import map resolution.');
+      console.warn('SUI: <script src="/load"> must appear before any <script type="module"> for import map resolution.');
+    }
+    if(s.parentElement&&s.parentElement!==document.head&&s.closest('body')){
+      console.warn('SUI: Place <script src="/load"> in <head> for reliable import map registration.');
     }
     var m=document.createElement('script');
     m.type='importmap';
@@ -346,16 +349,17 @@ function buildLoader() {
   // Components — bare = standard preset
   var co=s.getAttribute('components')||'';
   if(hc&&!co)co='standard';
-  if(co)import(b+'/core@'+v+'/'+co.split(',').map(function(x){return x.trim()}).join(','));
+  if(co)load(b+'/core@'+v+'/'+co.split(',').map(function(x){return x.trim()}).join(','));
 
   // Authoring lib
-  if(ha)import(b+'/component@'+v);
+  if(ha)load(b+'/component@'+v);
 
   // Bare package attributes
   ${bareAttrs}.forEach(function(p){
-    if(s.hasAttribute(p))import(b+'/'+p+'@'+v);
+    if(s.hasAttribute(p))load(b+'/'+p+'@'+v);
   });
 
+  function load(u){import(u).catch(function(e){console.error('SUI: Failed to load '+u,e)})}
   function inject(h){var l=document.createElement('link');l.rel='stylesheet';l.href=h;l.setAttribute('blocking','render');document.head.appendChild(l)}
 })();`;
 

--- a/tools/cdn/upload.js
+++ b/tools/cdn/upload.js
@@ -310,10 +310,9 @@ function buildLoader() {
     console.warn('SUI: Place <script src="/load"> in <head> for reliable import map registration.');
   }
   var m=document.createElement('script');
-    m.type='importmap';
-    m.textContent=mapJson;
-    document.head.appendChild(m);
-  }
+  m.type='importmap';
+  m.textContent=mapJson;
+  document.head.appendChild(m);
 
   var hc=s.hasAttribute('components'),ha=s.hasAttribute('authoring');
 
@@ -355,6 +354,14 @@ function buildLoader() {
   function load(u){import(u).catch(function(e){console.error('SUI: Failed to load '+u,e)})}
   function inject(h){var l=document.createElement('link');l.rel='stylesheet';l.href=h;l.setAttribute('blocking','render');document.head.appendChild(l)}
 })();`;
+
+  // Validate the generated script is syntactically valid
+  try {
+    new Function(js);
+  }
+  catch (e) {
+    throw new Error(`Generated loader has syntax error: ${e.message}`);
+  }
 
   return { js };
 }

--- a/tools/cdn/upload.js
+++ b/tools/cdn/upload.js
@@ -275,25 +275,38 @@ function buildImportMap(version) {
   return { json, js };
 }
 
-function buildLoader(version) {
+// Build the version-agnostic loader script.
+// The loader reads `version` from its own script tag attribute at runtime.
+// Package names are baked in from SUI_PACKAGES — the only build-time dependency.
+function buildLoader() {
   const cdnRoot = process.env.CDN_ROOT || 'https://cdn.semantic-ui.com';
-  const imports = {};
-  for (const name of SUI_PACKAGES) {
-    imports[`${SUI_SCOPE}${name}`] = `${cdnRoot}/${name}@${version}`;
-  }
-  const importMapJson = JSON.stringify({ imports });
 
-  // The loader IIFE — classic script that injects import map + resources
+  // Package names baked into the loader (derived from SUI_PACKAGES)
+  const pkgNames = JSON.stringify(SUI_PACKAGES);
+
+  // Bare package attributes the loader checks (everything except 'core' which is loaded via components)
+  const bareAttrs = JSON.stringify(
+    SUI_PACKAGES.filter(n => n !== 'core'),
+  );
+
   const js = `(function(){
   var s=document.currentScript;
-  var sui=${JSON.stringify(importMapJson)};
+  var b=${JSON.stringify(cdnRoot)};
+  var v=s.getAttribute('version')||'latest';
+  var scope='@semantic-ui/';
 
-  // Merge with existing import map or create new one
+  // Build import map from package list + version
+  var pkgs=${pkgNames};
+  var imports={};
+  pkgs.forEach(function(n){imports[scope+n]=b+'/'+n+'@'+v});
+  var mapJson=JSON.stringify({imports:imports});
+
+  // Merge with existing import map (user entries win) or create new one
   var existing=document.querySelector('script[type="importmap"]');
   if(existing){
     try{
       var prev=JSON.parse(existing.textContent);
-      var merged=Object.assign({},prev.imports,JSON.parse(sui).imports);
+      var merged=Object.assign({},imports,prev.imports);
       existing.textContent=JSON.stringify({imports:merged});
     }catch(e){}
   }else{
@@ -302,47 +315,58 @@ function buildLoader(version) {
     }
     var m=document.createElement('script');
     m.type='importmap';
-    m.textContent=sui;
+    m.textContent=mapJson;
     document.head.appendChild(m);
   }
 
-  var b=${JSON.stringify(cdnRoot)},v=${JSON.stringify(version)};
   var hc=s.hasAttribute('components'),ha=s.hasAttribute('authoring');
-  var cn=s.getAttribute('css')==='none';
-  if(!cn){
-    if(s.hasAttribute('css'))inject(b+'/css@'+v);
+
+  // CSS injection — css="none" suppresses, css="tokens"|"reset"|"base" selects layer, bare css = full page
+  var cv=s.getAttribute('css');
+  if(cv!=='none'){
+    if(cv==='tokens'||cv==='reset'||cv==='base')inject(b+'/css@'+v+'/'+cv);
+    else if(s.hasAttribute('css'))inject(b+'/css@'+v);
     else if(hc||ha)inject(b+'/css@'+v+'/tokens');
   }
+
+  // Icons — auto-inject lucide with components
   var ia=s.getAttribute('icons');
   if(ia!=='none'){
     var ic=ia||(hc?'lucide':null);
     if(ic)ic.split(',').forEach(function(x){inject(b+'/icons@'+v+'/'+x.trim())});
   }
+
+  // Fonts — auto-inject lato with components
   var fa=s.getAttribute('fonts');
   if(fa!=='none'){
     var fc=fa||(hc?'lato':null);
     if(fc)fc.split(',').forEach(function(x){inject(b+'/fonts@'+v+'/'+x.trim())});
   }
+
+  // Components — bare = standard preset
   var co=s.getAttribute('components')||'';
   if(hc&&!co)co='standard';
   if(co)import(b+'/core@'+v+'/'+co.split(',').map(function(x){return x.trim()}).join(','));
+
+  // Authoring lib
   if(ha)import(b+'/component@'+v);
-  ['reactivity','query','utils','templating','renderer','compiler','specs','tailwind'].forEach(function(p){
+
+  // Bare package attributes
+  ${bareAttrs}.forEach(function(p){
     if(s.hasAttribute(p))import(b+'/'+p+'@'+v);
   });
+
   function inject(h){var l=document.createElement('link');l.rel='stylesheet';l.href=h;l.setAttribute('blocking','render');document.head.appendChild(l)}
 })();`;
 
-  const json = JSON.stringify({ imports }, null, 2);
-  return { json, js };
+  return { js };
 }
 
-async function uploadLoader(s3, version) {
-  console.log(`\nGenerating loader @ ${version}`);
-  const { json, js } = buildLoader(version);
-  await uploadText(s3, `_meta/load@${version}.json`, json, 'application/json');
-  await uploadText(s3, `_meta/load@${version}.js`, js, 'application/javascript');
-  console.log(`  load@${version}.json + .js uploaded`);
+async function uploadLoader(s3) {
+  console.log('\nGenerating loader');
+  const { js } = buildLoader();
+  await uploadText(s3, '_meta/load.js', js, 'application/javascript');
+  console.log('  _meta/load.js uploaded');
 }
 
 async function uploadImportMaps(s3, version) {
@@ -374,19 +398,13 @@ async function updateVersionPointer(s3, alias, version) {
   await uploadText(s3, `_meta/importmap@${alias}.json`, mapJson, 'application/json');
   await uploadText(s3, `_meta/importmap@${alias}.js`, mapJs, 'application/javascript');
 
-  const { json: loadJson, js: loadJs } = buildLoader(version);
-  await uploadText(s3, `_meta/load@${alias}.json`, loadJson, 'application/json');
-  await uploadText(s3, `_meta/load@${alias}.js`, loadJs, 'application/javascript');
-
   // Unversioned endpoints always point to latest
   if (alias === 'latest') {
     await uploadText(s3, `_meta/importmap.js`, mapJs, 'application/javascript');
     await uploadText(s3, `_meta/importmap.json`, mapJson, 'application/json');
-    await uploadText(s3, `_meta/load.js`, loadJs, 'application/javascript');
-    await uploadText(s3, `_meta/load.json`, loadJson, 'application/json');
   }
 
-  console.log(`  importmap@${alias} + load@${alias} updated`);
+  console.log(`  importmap@${alias} updated`);
 }
 
 // Upload CDN asset sets (icons + fonts) — top-level R2 prefixes
@@ -449,7 +467,7 @@ async function main() {
   await uploadAssetSets(s3, suiVersion, { force: values['force-assets'] });
   await uploadVendorPackages(s3, { force: values['force-vendor'] });
   await uploadImportMaps(s3, suiVersion);
-  await uploadLoader(s3, suiVersion);
+  await uploadLoader(s3);
   await uploadPresets(s3);
 
   if (isCanary) {

--- a/tools/cdn/upload.js
+++ b/tools/cdn/upload.js
@@ -286,12 +286,26 @@ function buildLoader(version) {
   // The loader IIFE — classic script that injects import map + resources
   const js = `(function(){
   var s=document.currentScript;
-  if(!document.querySelector('script[type="importmap"]')){
+  var sui=${JSON.stringify(importMapJson)};
+
+  // Merge with existing import map or create new one
+  var existing=document.querySelector('script[type="importmap"]');
+  if(existing){
+    try{
+      var prev=JSON.parse(existing.textContent);
+      var merged=Object.assign({},prev.imports,JSON.parse(sui).imports);
+      existing.textContent=JSON.stringify({imports:merged});
+    }catch(e){}
+  }else{
+    if(document.querySelector('script[type="module"]')){
+      console.warn('SUI: Place <script src="/load"> before any <script type="module"> for import map resolution.');
+    }
     var m=document.createElement('script');
     m.type='importmap';
-    m.textContent=${JSON.stringify(importMapJson)};
+    m.textContent=sui;
     document.head.appendChild(m);
   }
+
   var b=${JSON.stringify(cdnRoot)},v=${JSON.stringify(version)};
   var hc=s.hasAttribute('components'),ha=s.hasAttribute('authoring');
   var cn=s.getAttribute('css')==='none';
@@ -309,8 +323,9 @@ function buildLoader(version) {
     var fc=fa||(hc?'lato':null);
     if(fc)fc.split(',').forEach(function(x){inject(b+'/fonts@'+v+'/'+x.trim())});
   }
-  var co=s.getAttribute('components');
-  if(co)import(b+'/core@'+v+'/'+co);
+  var co=s.getAttribute('components')||'';
+  if(hc&&!co)co='standard';
+  if(co)import(b+'/core@'+v+'/'+co.split(',').map(function(x){return x.trim()}).join(','));
   if(ha)import(b+'/component@'+v);
   ['reactivity','query','utils','templating','renderer','compiler','specs','tailwind'].forEach(function(p){
     if(s.hasAttribute(p))import(b+'/'+p+'@'+v);

--- a/tools/cdn/upload.js
+++ b/tools/cdn/upload.js
@@ -284,9 +284,10 @@ function buildLoader() {
   // Package names baked into the loader (derived from SUI_PACKAGES)
   const pkgNames = JSON.stringify(SUI_PACKAGES);
 
-  // Bare package attributes the loader checks (everything except 'core' which is loaded via components)
+  // Bare package attributes the loader checks
+  // 'core' is loaded via components, 'component' is loaded via authoring
   const bareAttrs = JSON.stringify(
-    SUI_PACKAGES.filter(n => n !== 'core'),
+    SUI_PACKAGES.filter(n => n !== 'core' && n !== 'component'),
   );
 
   const js = `(function(){
@@ -301,22 +302,14 @@ function buildLoader() {
   pkgs.forEach(function(n){imports[scope+n]=b+'/'+n+'@'+v});
   var mapJson=JSON.stringify({imports:imports});
 
-  // Merge with existing import map (user entries win) or create new one
-  var existing=document.querySelector('script[type="importmap"]');
-  if(existing){
-    try{
-      var prev=JSON.parse(existing.textContent);
-      var merged=Object.assign({},imports,prev.imports);
-      existing.textContent=JSON.stringify({imports:merged});
-    }catch(e){}
-  }else{
-    if(document.querySelector('script[type="module"]')){
-      console.warn('SUI: <script src="/load"> must appear before any <script type="module"> for import map resolution.');
-    }
-    if(s.parentElement&&s.parentElement!==document.head&&s.closest('body')){
-      console.warn('SUI: Place <script src="/load"> in <head> for reliable import map registration.');
-    }
-    var m=document.createElement('script');
+  // Inject import map (browsers support multiple, later entries win for collisions)
+  if(document.querySelector('script[type="module"]')){
+    console.warn('SUI: <script src="/load"> must appear before any <script type="module"> for import map resolution.');
+  }
+  if(s.parentElement&&s.parentElement!==document.head&&s.closest('body')){
+    console.warn('SUI: Place <script src="/load"> in <head> for reliable import map registration.');
+  }
+  var m=document.createElement('script');
     m.type='importmap';
     m.textContent=mapJson;
     document.head.appendChild(m);
@@ -332,17 +325,17 @@ function buildLoader() {
     else if(hc||ha)inject(b+'/css@'+v+'/tokens');
   }
 
-  // Icons — auto-inject lucide with components
+  // Icons — auto-inject lucide with components, bare icons attr defaults to lucide
   var ia=s.getAttribute('icons');
   if(ia!=='none'){
-    var ic=ia||(hc?'lucide':null);
+    var ic=ia||(s.hasAttribute('icons')||hc?'lucide':null);
     if(ic)ic.split(',').forEach(function(x){inject(b+'/icons@'+v+'/'+x.trim())});
   }
 
-  // Fonts — auto-inject lato with components
+  // Fonts — auto-inject lato with components, bare fonts attr defaults to lato
   var fa=s.getAttribute('fonts');
   if(fa!=='none'){
-    var fc=fa||(hc?'lato':null);
+    var fc=fa||(s.hasAttribute('fonts')||hc?'lato':null);
     if(fc)fc.split(',').forEach(function(x){inject(b+'/fonts@'+v+'/'+x.trim())});
   }
 

--- a/tools/cdn/upload.js
+++ b/tools/cdn/upload.js
@@ -161,8 +161,25 @@ async function uploadSuiPackages(s3, version, { force = false } = {}) {
     console.log(`  ${name}@${version} — ${files.length} files`);
   }
 
-  // Also upload core CSS
-  const cssFiles = ['semantic-ui.css', 'semantic-ui.css.map', 'semantic-ui.min.css', 'semantic-ui.min.css.map'];
+  // Also upload core CSS (full bundle + sub-layers)
+  const cssFiles = [
+    'semantic-ui.css',
+    'semantic-ui.css.map',
+    'semantic-ui.min.css',
+    'semantic-ui.min.css.map',
+    'tokens.css',
+    'tokens.css.map',
+    'tokens.min.css',
+    'tokens.min.css.map',
+    'reset.css',
+    'reset.css.map',
+    'reset.min.css',
+    'reset.min.css.map',
+    'base.css',
+    'base.css.map',
+    'base.min.css',
+    'base.min.css.map',
+  ];
   for (const cssFile of cssFiles) {
     const cssPath = join(ROOT, 'dist', cssFile);
     if (existsSync(cssPath)) {
@@ -258,6 +275,61 @@ function buildImportMap(version) {
   return { json, js };
 }
 
+function buildLoader(version) {
+  const cdnRoot = process.env.CDN_ROOT || 'https://cdn.semantic-ui.com';
+  const imports = {};
+  for (const name of SUI_PACKAGES) {
+    imports[`${SUI_SCOPE}${name}`] = `${cdnRoot}/${name}@${version}`;
+  }
+  const importMapJson = JSON.stringify({ imports });
+
+  // The loader IIFE — classic script that injects import map + resources
+  const js = `(function(){
+  var s=document.currentScript;
+  if(!document.querySelector('script[type="importmap"]')){
+    var m=document.createElement('script');
+    m.type='importmap';
+    m.textContent=${JSON.stringify(importMapJson)};
+    document.head.appendChild(m);
+  }
+  var b=${JSON.stringify(cdnRoot)},v=${JSON.stringify(version)};
+  var hc=s.hasAttribute('components'),ha=s.hasAttribute('authoring');
+  var cn=s.getAttribute('css')==='none';
+  if(!cn){
+    if(s.hasAttribute('css'))inject(b+'/css@'+v);
+    else if(hc||ha)inject(b+'/css@'+v+'/tokens');
+  }
+  var ia=s.getAttribute('icons');
+  if(ia!=='none'){
+    var ic=ia||(hc?'lucide':null);
+    if(ic)ic.split(',').forEach(function(x){inject(b+'/icons@'+v+'/'+x.trim())});
+  }
+  var fa=s.getAttribute('fonts');
+  if(fa!=='none'){
+    var fc=fa||(hc?'lato':null);
+    if(fc)fc.split(',').forEach(function(x){inject(b+'/fonts@'+v+'/'+x.trim())});
+  }
+  var co=s.getAttribute('components');
+  if(co)import(b+'/core@'+v+'/'+co);
+  if(ha)import(b+'/component@'+v);
+  ['reactivity','query','utils','templating','renderer','compiler','specs','tailwind'].forEach(function(p){
+    if(s.hasAttribute(p))import(b+'/'+p+'@'+v);
+  });
+  function inject(h){var l=document.createElement('link');l.rel='stylesheet';l.href=h;l.setAttribute('blocking','render');document.head.appendChild(l)}
+})();`;
+
+  const json = JSON.stringify({ imports }, null, 2);
+  return { json, js };
+}
+
+async function uploadLoader(s3, version) {
+  console.log(`\nGenerating loader @ ${version}`);
+  const { json, js } = buildLoader(version);
+  await uploadText(s3, `_meta/load@${version}.json`, json, 'application/json');
+  await uploadText(s3, `_meta/load@${version}.js`, js, 'application/javascript');
+  console.log(`  load@${version}.json + .js uploaded`);
+}
+
 async function uploadImportMaps(s3, version) {
   console.log(`\nGenerating import maps @ ${version}`);
   const { json, js } = buildImportMap(version);
@@ -283,17 +355,23 @@ async function updateVersionPointer(s3, alias, version) {
   await uploadText(s3, `_versions/${alias}`, version);
   console.log(`  _versions/${alias} → ${version}`);
 
-  const { json, js } = buildImportMap(version);
-  await uploadText(s3, `_meta/importmap@${alias}.json`, json, 'application/json');
-  await uploadText(s3, `_meta/importmap@${alias}.js`, js, 'application/javascript');
+  const { json: mapJson, js: mapJs } = buildImportMap(version);
+  await uploadText(s3, `_meta/importmap@${alias}.json`, mapJson, 'application/json');
+  await uploadText(s3, `_meta/importmap@${alias}.js`, mapJs, 'application/javascript');
 
-  // importmap.js (no version) always points to latest
+  const { json: loadJson, js: loadJs } = buildLoader(version);
+  await uploadText(s3, `_meta/load@${alias}.json`, loadJson, 'application/json');
+  await uploadText(s3, `_meta/load@${alias}.js`, loadJs, 'application/javascript');
+
+  // Unversioned endpoints always point to latest
   if (alias === 'latest') {
-    await uploadText(s3, `_meta/importmap.js`, js, 'application/javascript');
-    await uploadText(s3, `_meta/importmap.json`, json, 'application/json');
+    await uploadText(s3, `_meta/importmap.js`, mapJs, 'application/javascript');
+    await uploadText(s3, `_meta/importmap.json`, mapJson, 'application/json');
+    await uploadText(s3, `_meta/load.js`, loadJs, 'application/javascript');
+    await uploadText(s3, `_meta/load.json`, loadJson, 'application/json');
   }
 
-  console.log(`  importmap@${alias} updated`);
+  console.log(`  importmap@${alias} + load@${alias} updated`);
 }
 
 // Upload CDN asset sets (icons + fonts) — top-level R2 prefixes
@@ -356,6 +434,7 @@ async function main() {
   await uploadAssetSets(s3, suiVersion, { force: values['force-assets'] });
   await uploadVendorPackages(s3, { force: values['force-vendor'] });
   await uploadImportMaps(s3, suiVersion);
+  await uploadLoader(s3, suiVersion);
   await uploadPresets(s3);
 
   if (isCanary) {

--- a/tools/cdn/worker/index.js
+++ b/tools/cdn/worker/index.js
@@ -91,9 +91,7 @@ function getContentType(filepath) {
 //   /icons@0.18.0/lucide/house.svg          → icon asset
 //   /fonts@0.18.0/lato                      → font set CSS (extensionless)
 //   /fonts@0.18.0/lato/LatoLatin-Regular.woff2 → font asset
-//   /load                                   → loader script (latest)
-//   /load@0.18.0                            → versioned loader
-//   /load@0.18.0.json                       → raw import map JSON
+//   /load                                   → loader script (version-agnostic, reads version= attr)
 //   /css                                    → framework CSS (latest)
 //   /css@0.18.0                             → framework CSS (versioned)
 //   /css@0.18.0/tokens                      → tokens only

--- a/tools/cdn/worker/index.js
+++ b/tools/cdn/worker/index.js
@@ -74,12 +74,10 @@ const CONTENT_TYPES = {
 };
 
 function getContentType(filepath) {
-  for (const [ext, type] of Object.entries(CONTENT_TYPES)) {
-    if (filepath.endsWith(ext)) {
-      return type;
-    }
-  }
-  return 'application/octet-stream';
+  const lastDot = filepath.lastIndexOf('.');
+  if (lastDot === -1) { return 'application/octet-stream'; }
+  const ext = filepath.slice(lastDot);
+  return CONTENT_TYPES[ext] || 'application/octet-stream';
 }
 
 // Parse URL into route info
@@ -377,7 +375,7 @@ export default {
         if (!map) {
           const css = await object.text();
           body = css.replace(
-            /\/\*# sourceMappingURL=.+?\s*\*\/\s*$/,
+            /\/\*#\s*sourceMappingURL=\S+\s*\*\//,
             `/*# sourceMappingURL=${sourceMapUrl} */`,
           );
         }

--- a/tools/cdn/worker/index.js
+++ b/tools/cdn/worker/index.js
@@ -106,14 +106,9 @@ function getContentType(filepath) {
 //   /importmap.js                           → import map (legacy, use /load)
 //   /importmap@0.18.0.js                    → versioned import map (legacy)
 export function parseRoute(pathname) {
-  // Loader endpoint — /load, /load@0.18.0, /load@0.18.0.json
-  const loadMatch = pathname.match(/^\/load(?:@(.+))?\.(js|json)$/);
-  if (loadMatch) {
-    return { type: 'load', version: loadMatch[1] || null, format: loadMatch[2] };
-  }
-  const loadBareMatch = pathname.match(/^\/load(?:@(.+))?$/);
-  if (loadBareMatch) {
-    return { type: 'load', version: loadBareMatch[1] || null, format: 'js' };
+  // Loader endpoint — /load (version-agnostic, reads version from attribute at runtime)
+  if (pathname === '/load' || pathname === '/load.js') {
+    return { type: 'load' };
   }
 
   // Import map loader (legacy) — version can contain dots (semver)
@@ -422,22 +417,16 @@ export default {
       }
 
       case 'load': {
-        const { version, format } = route;
-        const r2Key = version
-          ? `_meta/load@${version}.${format}`
-          : `_meta/load.${format}`;
-        const object = await env.CDN_BUCKET.get(r2Key);
+        const object = await env.CDN_BUCKET.get('_meta/load.js');
         if (!object) {
-          return new Response(`Loader not found`, { status: 404 });
+          return new Response('Loader not found', { status: 404 });
         }
 
-        const contentType = format === 'js' ? 'application/javascript' : 'application/json';
-        const cache = version ? cacheHeaders(version) : { 'Cache-Control': 'public, max-age=300' };
         return new Response(object.body, {
           headers: {
-            'Content-Type': contentType,
+            'Content-Type': 'application/javascript',
             ...corsHeaders(),
-            ...cache,
+            'Cache-Control': 'public, max-age=300',
           },
         });
       }

--- a/tools/cdn/worker/index.js
+++ b/tools/cdn/worker/index.js
@@ -91,16 +91,32 @@ function getContentType(filepath) {
 //   /icons@0.18.0/lucide/house.svg          → icon asset
 //   /fonts@0.18.0/lato                      → font set CSS (extensionless)
 //   /fonts@0.18.0/lato/LatoLatin-Regular.woff2 → font asset
+//   /load                                   → loader script (latest)
+//   /load@0.18.0                            → versioned loader
+//   /load@0.18.0.json                       → raw import map JSON
 //   /css                                    → framework CSS (latest)
 //   /css@0.18.0                             → framework CSS (versioned)
+//   /css@0.18.0/tokens                      → tokens only
+//   /css@0.18.0/reset                       → reset only
+//   /css@0.18.0/base                        → base only
 //   /css@0.18.0.map                         → framework CSS sourcemap
 //   /semantic-ui@0.18.0.css                 → framework CSS (legacy alias)
 //   /semantic-ui@0.18.0.css.map             → framework CSS sourcemap (legacy alias)
 //   /semantic-ui.css                        → framework CSS (legacy alias)
-//   /importmap.js                           → import map loader (latest)
-//   /importmap@0.18.0.js                    → versioned import map loader
+//   /importmap.js                           → import map (legacy, use /load)
+//   /importmap@0.18.0.js                    → versioned import map (legacy)
 export function parseRoute(pathname) {
-  // Import map loader — version can contain dots (semver)
+  // Loader endpoint — /load, /load@0.18.0, /load@0.18.0.json
+  const loadMatch = pathname.match(/^\/load(?:@([^.]+))?\.(js|json)$/);
+  if (loadMatch) {
+    return { type: 'load', version: loadMatch[1] || null, format: loadMatch[2] };
+  }
+  const loadBareMatch = pathname.match(/^\/load(?:@([^.]+))?$/);
+  if (loadBareMatch) {
+    return { type: 'load', version: loadBareMatch[1] || null, format: 'js' };
+  }
+
+  // Import map loader (legacy) — version can contain dots (semver)
   const importmapMatch = pathname.match(/^\/importmap(?:@(.+))?\.(js|json)$/);
   if (importmapMatch) {
     return {
@@ -110,14 +126,16 @@ export function parseRoute(pathname) {
     };
   }
 
-  // Framework CSS — /css, /css@0.18.0, /semantic-ui.css, /semantic-ui@0.18.0.css
-  // Also matches .min and sourcemap variants: /semantic-ui.min.css.map, /css@0.18.0.map
-  const cssShortMatch = pathname.match(/^\/css(?:@(.+?))?(\.map)?$/);
+  // Framework CSS — /css, /css@0.18.0, /css@0.18.0/tokens, /semantic-ui.css
+  // Sub-layers: /css@0.18.0/tokens, /css@0.18.0/reset, /css@0.18.0/base
+  // Also matches sourcemap variants: /css@0.18.0.map, /css@0.18.0/tokens.map
+  const cssShortMatch = pathname.match(/^\/css(?:@([^/]+?))?(?:\/(tokens|reset|base))?(\.map)?$/);
   if (cssShortMatch) {
     return {
       type: 'css',
       version: cssShortMatch[1] || 'latest',
-      map: !!cssShortMatch[2],
+      layer: cssShortMatch[2] || null,
+      map: !!cssShortMatch[3],
     };
   }
   const cssMatch = pathname.match(/^\/semantic-ui(?:@(.+?))?(?:\.min)?\.css(\.map)?$/);
@@ -330,22 +348,24 @@ export default {
       }
 
       case 'css': {
-        const { version, map } = route;
+        const { version, layer, map } = route;
 
         if (version === 'latest') {
           const resolved = await resolveVersion(env, version);
           if (!resolved) {
             return new Response('Latest version not found', { status: 404 });
           }
-          const suffix = map ? '.css.map' : '.css';
+          const layerPath = layer ? `/${layer}` : '';
+          const suffix = map ? '.map' : '';
           return Response.redirect(
-            new URL(`/semantic-ui@${resolved}${suffix}`, url.origin).href,
+            new URL(`/css@${resolved}${layerPath}${suffix}`, url.origin).href,
             302,
           );
         }
 
-        // Serve minified CSS (or its sourcemap) from dist/
-        const filename = map ? 'semantic-ui.min.css.map' : 'semantic-ui.min.css';
+        // Map layer to filename: tokens → tokens.min.css, null → semantic-ui.min.css
+        const baseName = layer || 'semantic-ui';
+        const filename = map ? `${baseName}.min.css.map` : `${baseName}.min.css`;
         const r2Key = `@semantic-ui/core/${version}/dist/${filename}`;
         const object = await env.CDN_BUCKET.get(r2Key);
         if (!object) {
@@ -353,7 +373,8 @@ export default {
         }
 
         const contentType = map ? 'application/json' : 'text/css';
-        const sourceMapUrl = `/semantic-ui@${version}.css.map`;
+        const layerPath = layer ? `/${layer}` : '';
+        const sourceMapUrl = `/css@${version}${layerPath}.map`;
         const sourceMapHeader = map ? {} : { 'SourceMap': sourceMapUrl };
 
         // Rewrite the inline sourceMappingURL to an absolute versioned path
@@ -387,6 +408,27 @@ export default {
         const object = await env.CDN_BUCKET.get(r2Key);
         if (!object) {
           return new Response(`Import map not found`, { status: 404 });
+        }
+
+        const contentType = format === 'js' ? 'application/javascript' : 'application/json';
+        const cache = version ? cacheHeaders(version) : { 'Cache-Control': 'public, max-age=300' };
+        return new Response(object.body, {
+          headers: {
+            'Content-Type': contentType,
+            ...corsHeaders(),
+            ...cache,
+          },
+        });
+      }
+
+      case 'load': {
+        const { version, format } = route;
+        const r2Key = version
+          ? `_meta/load@${version}.${format}`
+          : `_meta/load.${format}`;
+        const object = await env.CDN_BUCKET.get(r2Key);
+        if (!object) {
+          return new Response(`Loader not found`, { status: 404 });
         }
 
         const contentType = format === 'js' ? 'application/javascript' : 'application/json';

--- a/tools/cdn/worker/index.js
+++ b/tools/cdn/worker/index.js
@@ -134,6 +134,7 @@ export function parseRoute(pathname) {
     return {
       type: 'css',
       version: cssMatch[1] || 'latest',
+      layer: null,
       map: !!cssMatch[2],
     };
   }

--- a/tools/cdn/worker/index.js
+++ b/tools/cdn/worker/index.js
@@ -107,11 +107,11 @@ function getContentType(filepath) {
 //   /importmap@0.18.0.js                    → versioned import map (legacy)
 export function parseRoute(pathname) {
   // Loader endpoint — /load, /load@0.18.0, /load@0.18.0.json
-  const loadMatch = pathname.match(/^\/load(?:@([^.]+))?\.(js|json)$/);
+  const loadMatch = pathname.match(/^\/load(?:@(.+))?\.(js|json)$/);
   if (loadMatch) {
     return { type: 'load', version: loadMatch[1] || null, format: loadMatch[2] };
   }
-  const loadBareMatch = pathname.match(/^\/load(?:@([^.]+))?$/);
+  const loadBareMatch = pathname.match(/^\/load(?:@(.+))?$/);
   if (loadBareMatch) {
     return { type: 'load', version: loadBareMatch[1] || null, format: 'js' };
   }


### PR DESCRIPTION
## Summary

- New `/load` endpoint — single `<script>` tag that reads bare attributes and handles everything
- `components="button,input"` loads components with auto-injected tokens, Lato, Lucide
- `authoring`, `reactivity`, `query`, `utils`, `tailwind` etc. as bare attributes
- `version="0.18.0"` pins all resources — loader is version-agnostic, reads at runtime
- CSS sub-layers: `/css@0.18.0/tokens`, `/css/reset`, `/css/base`
- Import map merge with existing maps (user entries win)
- `css="tokens"`, `css="none"`, `icons="none"`, `fonts="none"` overrides

Also fixed pre-existing issues found during red-team:
- `getContentType` suffix matching served `.js.map` as JS instead of JSON
- sourceMappingURL rewrite regex hardened
- Combo/preset endpoints now have unit test coverage

58 unit tests, all CI checks passing.

## Test plan
- [x] CDN worker unit tests (58/58)
- [x] Full monorepo tests pass in CI
- [ ] Post-merge: verify `/load` endpoint serves on canary