### PR TITLE
[NOT FOR MERGE] Knob validation — baseline pinned to 087308428

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -116,8 +116,9 @@ jobs:
       - name: Build baseline
         run: |
           BASELINE_REF=087308428
-          git fetch origin "$BASELINE_REF" --depth=1
-          git checkout FETCH_HEAD -- packages/*/src/
+          # Deepen main's history so the pinned SHA is reachable locally.
+          git fetch origin main --depth=50
+          git checkout $BASELINE_REF -- packages/*/src/
           node packages/${{ matrix.entry.package }}/bench/tachometer/build-ci.js baseline
           git checkout HEAD -- packages/*/src/
 

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -109,9 +109,14 @@ jobs:
         run: node packages/${{ matrix.entry.package }}/bench/tachometer/build-ci.js current
 
       # Swap source to base branch and build baseline bundles
+      # VALIDATION RUN: baseline pinned to 087308428 (pre-perf/native merge)
+      # so we measure against a real multi-magnitude delta (true-zero deltas
+      # can't validate ["2%"] + timeout:3 meaningfully). REVERT this block
+      # before merging — this is a throwaway PR for knob tuning evidence.
       - name: Build baseline
         run: |
-          git fetch origin ${{ github.event.pull_request.base.ref }} --depth=1
+          BASELINE_REF=087308428
+          git fetch origin "$BASELINE_REF" --depth=1
           git checkout FETCH_HEAD -- packages/*/src/
           node packages/${{ matrix.entry.package }}/bench/tachometer/build-ci.js baseline
           git checkout HEAD -- packages/*/src/

--- a/packages/renderer/bench/tachometer/tachometer-ci-todo-micro.json
+++ b/packages/renderer/bench/tachometer/tachometer-ci-todo-micro.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/nicolo-ribaudo/nicolo-ribaudo.github.io/HEAD/nicolo-ribaudo.github.io/src/assets/tachometer.schema.json",
   "root": "../../../..",
   "sampleSize": 50,
-  "timeout": 2,
+  "timeout": 3,
   "autoSampleConditions": ["2%"],
   "benchmarks": [
     {

--- a/packages/renderer/bench/tachometer/tachometer-ci-todo-micro.json
+++ b/packages/renderer/bench/tachometer/tachometer-ci-todo-micro.json
@@ -2,23 +2,19 @@
   "$schema": "https://raw.githubusercontent.com/nicolo-ribaudo/nicolo-ribaudo.github.io/HEAD/nicolo-ribaudo.github.io/src/assets/tachometer.schema.json",
   "root": "../../../..",
   "sampleSize": 50,
-  "timeout": 3,
-  "autoSampleConditions": ["0%"],
+  "timeout": 2,
+  "autoSampleConditions": ["2%"],
   "benchmarks": [
     {
       "name": "this-change",
       "url": "ci-current-todo.html",
       "browser": { "name": "chrome", "headless": true },
       "measurement": [
-        { "mode": "performance", "entryName": "toggle-first" },
-        { "mode": "performance", "entryName": "toggle-last" },
         { "mode": "performance", "entryName": "toggle-middle" },
         { "mode": "performance", "entryName": "remove-first" },
         { "mode": "performance", "entryName": "remove-middle" },
         { "mode": "performance", "entryName": "remove-last" },
-        { "mode": "performance", "entryName": "filter-active" },
         { "mode": "performance", "entryName": "filter-completed" },
-        { "mode": "performance", "entryName": "filter-all" },
         { "mode": "performance", "entryName": "edit-start" },
         { "mode": "performance", "entryName": "edit-save" }
       ]
@@ -28,15 +24,11 @@
       "url": "ci-baseline-todo.html",
       "browser": { "name": "chrome", "headless": true },
       "measurement": [
-        { "mode": "performance", "entryName": "toggle-first" },
-        { "mode": "performance", "entryName": "toggle-last" },
         { "mode": "performance", "entryName": "toggle-middle" },
         { "mode": "performance", "entryName": "remove-first" },
         { "mode": "performance", "entryName": "remove-middle" },
         { "mode": "performance", "entryName": "remove-last" },
-        { "mode": "performance", "entryName": "filter-active" },
         { "mode": "performance", "entryName": "filter-completed" },
-        { "mode": "performance", "entryName": "filter-all" },
         { "mode": "performance", "entryName": "edit-start" },
         { "mode": "performance", "entryName": "edit-save" }
       ]

--- a/packages/renderer/bench/tachometer/tachometer-ci-todo.json
+++ b/packages/renderer/bench/tachometer/tachometer-ci-todo.json
@@ -2,8 +2,8 @@
   "$schema": "https://raw.githubusercontent.com/nicolo-ribaudo/nicolo-ribaudo.github.io/HEAD/nicolo-ribaudo.github.io/src/assets/tachometer.schema.json",
   "root": "../../../..",
   "sampleSize": 50,
-  "timeout": 5,
-  "autoSampleConditions": ["0%", "10%"],
+  "timeout": 2,
+  "autoSampleConditions": ["2%"],
   "benchmarks": [
     {
       "name": "this-change",
@@ -11,7 +11,6 @@
       "browser": { "name": "chrome", "headless": true },
       "measurement": [
         { "mode": "performance", "entryName": "bulk-add-50" },
-        { "mode": "performance", "entryName": "bulk-add-200" },
         { "mode": "performance", "entryName": "add-20" },
         { "mode": "performance", "entryName": "toggle-10" },
         { "mode": "performance", "entryName": "toggle-all" },
@@ -27,7 +26,6 @@
       "browser": { "name": "chrome", "headless": true },
       "measurement": [
         { "mode": "performance", "entryName": "bulk-add-50" },
-        { "mode": "performance", "entryName": "bulk-add-200" },
         { "mode": "performance", "entryName": "add-20" },
         { "mode": "performance", "entryName": "toggle-10" },
         { "mode": "performance", "entryName": "toggle-all" },

--- a/packages/renderer/bench/tachometer/tachometer-ci-todo.json
+++ b/packages/renderer/bench/tachometer/tachometer-ci-todo.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/nicolo-ribaudo/nicolo-ribaudo.github.io/HEAD/nicolo-ribaudo.github.io/src/assets/tachometer.schema.json",
   "root": "../../../..",
   "sampleSize": 50,
-  "timeout": 2,
+  "timeout": 3,
   "autoSampleConditions": ["2%"],
   "benchmarks": [
     {

--- a/packages/renderer/bench/tachometer/tachometer-ci.json
+++ b/packages/renderer/bench/tachometer/tachometer-ci.json
@@ -2,8 +2,8 @@
   "$schema": "https://raw.githubusercontent.com/nicolo-ribaudo/nicolo-ribaudo.github.io/HEAD/nicolo-ribaudo.github.io/src/assets/tachometer.schema.json",
   "root": "../../../..",
   "sampleSize": 50,
-  "timeout": 5,
-  "autoSampleConditions": ["0%", "10%"],
+  "timeout": 2,
+  "autoSampleConditions": ["2%"],
   "benchmarks": [
     {
       "name": "this-change",
@@ -11,7 +11,6 @@
       "browser": { "name": "chrome", "headless": true },
       "measurement": [
         { "mode": "performance", "entryName": "create-1k" },
-        { "mode": "performance", "entryName": "create-10k" },
         { "mode": "performance", "entryName": "append-1k" },
         { "mode": "performance", "entryName": "update-10th" },
         { "mode": "performance", "entryName": "select" },
@@ -25,7 +24,6 @@
       "browser": { "name": "chrome", "headless": true },
       "measurement": [
         { "mode": "performance", "entryName": "create-1k" },
-        { "mode": "performance", "entryName": "create-10k" },
         { "mode": "performance", "entryName": "append-1k" },
         { "mode": "performance", "entryName": "update-10th" },
         { "mode": "performance", "entryName": "select" },

--- a/packages/renderer/bench/tachometer/tachometer-ci.json
+++ b/packages/renderer/bench/tachometer/tachometer-ci.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/nicolo-ribaudo/nicolo-ribaudo.github.io/HEAD/nicolo-ribaudo.github.io/src/assets/tachometer.schema.json",
   "root": "../../../..",
   "sampleSize": 50,
-  "timeout": 2,
+  "timeout": 3,
   "autoSampleConditions": ["2%"],
   "benchmarks": [
     {


### PR DESCRIPTION
**Throwaway PR.** Validates PR B's `["2%"]` + `timeout: 3` knob choices against real multi-magnitude deltas.

Baseline pinned to commit \`087308428\` (the revert state on perf/native, pre-merge). Current = main post-merge. Produces the same delta surface that perf/native shipped yesterday, which was already catalogued under the OLD knob settings — so any resolution *difference* here is attributable to the knobs, not noise.

## Expected deltas (from yesterday's run under old settings)

| delta tier | metrics |
|---|---|
| ~70% | toggle-middle (toggle-first/last cut in PR B) |
| ~50% | update-10th, edit-save |
| ~20% | bulk-add-50, append-1k, create-1k |
| ~5-15% | toggle-10, filter-completed |
| known-unsure | clear |
| known-regressed | toggle-all, edit-start, remove-5-front |

## Acceptance criteria

- [ ] Every metric with known \`|delta| > 2%\` resolves confidently (no unsure verdicts on the catalogued `faster`/`slower` set)
- [ ] `clear` and near-boundary metrics may legitimately be unsure — that's the threshold doing its job
- [ ] Wall-clock stays ~11 min

## Outcome branching

- **Validation passes** → close this PR, merge PR B
- **Validation fails on resolvable metrics** → tune further (timeout or sampleSize) in PR B, close this PR

**DO NOT MERGE.** This ships a workflow with a hardcoded baseline that would break all future PRs.