### PR TITLE
Docs: Renderer README (acceptance test for new reporter)

### DIFF
--- a/packages/renderer/README.md
+++ b/packages/renderer/README.md
@@ -1,0 +1,3 @@
+# @semantic-ui/renderer
+
+Native and Lit rendering engines, the shared expression evaluator, and the SSR pipeline for Semantic UI Next. See the main monorepo [`README.md`](../../README.md) for framework-level docs.


### PR DESCRIPTION
Trivial PR to trigger the benchmarks workflow — first live exercise of the new in-house bench reporter (PR C / #141).

Adds a three-line README under `packages/renderer/`. No bundle impact (README isn't imported anywhere). The run's resulting comment is the actual acceptance test.

Criteria:
- [x] Comment is posted (new reporter is alive)
- [x] Header shows short SHA + commit msg + base + run link
- [x] No "Significant changes" section (this PR has no code change)
- [x] All 21 metrics appear in Unsure or Within-noise (boundary behavior at ±2% on zero-delta)
- [x] `bench-report.json` artifact uploaded

If anything reads wrong, revert of `c73791db0` on main is a one-commit rollback to the upstream tachometer-reporter-action.