### PR TITLE
Docs: Add extend-bench-suite + read-bench-report skills

### DIFF
--- a/ai/skills/contributing/extend-bench-suite.md
+++ b/ai/skills/contributing/extend-bench-suite.md
@@ -1,0 +1,240 @@
+---
+title: Extending the Benchmark Suite
+description: How to add a new tachometer benchmark to the renderer bench suite — pattern, naming, duration considerations, and where it lands in CI.
+keywords: [tachometer, benchmark, performance, CI, bench, perf, sampleSize, autoSampleConditions, noise floor]
+audience: contributing
+skill: extend-bench-suite
+type: skill
+---
+
+# Extending the Benchmark Suite
+
+> **Skill:** `extend-bench-suite`
+> **Purpose:** Add a new tachometer benchmark that runs in CI and reports cleanly through the in-house bench reporter.
+
+**Golden rule: estimate the bench's absolute duration on GHA before writing it.** Per-sample timing noise on the shared runners is roughly constant at σ≈2ms, which means relative noise scales inversely with duration. A 2ms bench and a 50ms bench eat the same ~2ms of irreducible jitter but show it as ±30% vs ±1%. **Benches under ~5ms will land in "Too Fast to Measure Precisely" on zero-delta runs regardless of how clean the code is** — they still work for detecting real perf changes that clear the noise, but reviewers see them flagged as unresolved most of the time.
+
+---
+
+## When to Add a Bench
+
+Add one only if at least one of these holds:
+
+- **A current or near-future perf initiative needs to gate on it.** The bench proves the feature does what it claims and catches regressions later. Ship it with the feature PR, not speculatively.
+- **A hot path has no coverage.** The existing suite covers rendering throughput, reactivity, and list-structural ops. Before adding, check `packages/renderer/bench/tachometer/tachometer-ci*.json` to see if something close already exists.
+
+**Do not add a bench just because a workload seems interesting.** Every bench costs ~1 min of CI time (initial samples at N=50 + some auto-sample tail) and more comment surface area for reviewers. Benches without a failure mode they actually gate against are noise.
+
+---
+
+## Anatomy
+
+A CI-gated bench is three files working together:
+
+| File | Role |
+|------|------|
+| `bench-<name>.js` under `packages/<pkg>/bench/tachometer/` | Defines the workload and emits `performance.mark`/`performance.measure` for each metric |
+| `ci-current-<name>.html` + `ci-baseline-<name>.html` | Loads the built bundle; tachometer navigates here |
+| `tachometer-ci-<suite>.json` | Lists which measurements to collect; configures sampleSize, timeout, autoSampleConditions |
+
+The `build-ci.js` script bundles the bench JS files with esbuild into `dist/current/` and `dist/baseline/` (baseline uses the PR's base-branch `packages/*/src/`). The CI workflow at `.github/workflows/benchmarks.yml` spawns one parallel matrix cell per `tachometer-ci*.json` config discovered in changed packages.
+
+---
+
+## The Authoring Pattern
+
+### Measurement: `performance.mark` + `performance.measure`
+
+Each metric wraps its workload with a paired mark/measure. The convention uses a `startMark` helper so the start-mark name is derivable from the metric name:
+
+```js
+const startMark = (name) => `${name}-start`;
+
+performance.mark(startMark('toggle-middle'));
+await toggleMiddleItem();
+performance.measure('toggle-middle', startMark('toggle-middle'));
+```
+
+The **first argument to `performance.measure`** is the metric name. Tachometer extracts it via `measurement.entryName` — these must match exactly.
+
+### ❌ Wrong — end-mark convention diverges
+
+```js
+// Inconsistent with existing benches; the reporter's source-link resolver
+// matches the first quoted occurrence of the metric name, so stray unrelated
+// literals can misdirect the link.
+performance.mark('toggle-middle-begin');
+performance.measure('toggleMiddle', 'toggle-middle-begin');
+```
+
+### ✅ Right — same name everywhere
+
+```js
+performance.mark(startMark('toggle-middle'));
+performance.measure('toggle-middle', startMark('toggle-middle'));
+```
+
+### Tachometer config entry
+
+```json
+{
+  "$schema": "...",
+  "root": "../../../..",
+  "sampleSize": 50,
+  "timeout": 3,
+  "autoSampleConditions": ["2%"],
+  "benchmarks": [
+    {
+      "name": "this-change",
+      "url": "ci-current-<suite>.html",
+      "browser": { "name": "chrome", "headless": true },
+      "measurement": [
+        { "mode": "performance", "entryName": "toggle-middle" }
+      ]
+    },
+    {
+      "name": "tip-of-tree",
+      "url": "ci-baseline-<suite>.html",
+      "browser": { "name": "chrome", "headless": true },
+      "measurement": [
+        { "mode": "performance", "entryName": "toggle-middle" }
+      ]
+    }
+  ]
+}
+```
+
+**Always list the same measurements in both the `this-change` and `tip-of-tree` entries** — tachometer compares pairwise, so the sets must match.
+
+**Don't change these knob values without a reason:**
+
+| Knob | Value | Why |
+|------|-------|-----|
+| `sampleSize` | `50` | Floor calibrated against GHA runner noise; smaller → wider CIs, more unsure verdicts |
+| `autoSampleConditions` | `["2%"]` | Resolution floor below runner's per-sample noise; tighter → metrics can't converge on zero-delta |
+| `timeout` | `3` | 3-minute auto-sample cap per config; larger adds CI wall-clock without resolving stubborn metrics |
+
+---
+
+## Decision: Extend an Existing Bench File or Create a New One?
+
+**Extend existing if the workload fits an existing bench's fixture.** Most new metrics add to `bench-todo.js` (TodoMVC-style list operations) or `bench.js` (krausest table workload). Add the `mark`/`measure` pair to the JS file, add the `entryName` to the appropriate `tachometer-ci*.json`. Done in 5 minutes.
+
+**Create a new bench file if the workload is orthogonal.** E.g., a hydration bench needs its own fixture setup; a signal micro-bench has a different harness shape. Then you need:
+
+1. `bench-<name>.js` with the workload
+2. `ci-current-<name>.html` and `ci-baseline-<name>.html` that load `./dist/current/bench-<name>.js` and `./dist/baseline/bench-<name>.js`
+3. A new `tachometer-ci-<name>.json` config
+4. Update `build-ci.js` to include the new bench file in its `benchFiles` array
+
+The matrix workflow auto-discovers `tachometer-ci*.json` globs, so the new config gets picked up without editing `benchmarks.yml`.
+
+---
+
+## Duration Check Before Writing
+
+Before you write the workload, estimate how long a single iteration will take on CI. The duration determines what the reporter will do with your bench on zero-delta PRs:
+
+| Mean duration | Expected relative noise (σ≈2ms) | How the reporter classifies on zero-delta |
+|---|---|---|
+| < 5ms | ±30% or wider | "Too Fast to Measure Precisely" — always unresolved |
+| 5–20ms | ±5% to ±15% | Usually noise-floor-limited on zero-delta; resolves cleanly under >10% real delta |
+| 20–100ms | ±1% to ±5% | Fits the ["2%"] floor — resolves cleanly when CI is narrow |
+| > 100ms | < ±1% | Tight CIs; surfaces real regressions at the ~2% threshold |
+
+**If your workload is naturally under 5ms**, scale it up. Loop the operation enough times to get into the 20ms+ range. For example: `toggle-10` loops the toggle operation 10× to amplify a per-toggle delta that would be lost in noise at 1×.
+
+### ❌ Tiny single-iteration workload
+
+```js
+performance.mark(startMark('signal-set'));
+signal.set(42);
+performance.measure('signal-set', startMark('signal-set'));
+// mean ≈ 0.01ms — can't measure
+```
+
+### ✅ Amplified to a measurable scale
+
+```js
+performance.mark(startMark('signal-set-1k'));
+for (let i = 0; i < 1000; i++) { signal.set(i); }
+performance.measure('signal-set-1k', startMark('signal-set-1k'));
+// mean ≈ 15ms — resolvable under real perf deltas
+```
+
+Naming convention for amplified workloads: suffix with the iteration count (`signal-set-1k`, `create-1k`, `bulk-add-50`).
+
+---
+
+## Naming Conventions
+
+| Rule | Example |
+|------|---------|
+| `kebab-case` | `toggle-middle`, `remove-5-front` |
+| Suffix iteration count when amplified | `create-1k`, `update-10th`, `bulk-add-50` |
+| No framework prefix | `create-1k` — not `sui-create-1k` (the suite is already SUI-scoped) |
+| Unique across the whole suite | Tachometer's `entryName` is global per matrix cell, but the reporter indexes by name across all configs — collisions break cross-referencing |
+
+### ❌ Name collision across configs
+
+`tachometer-ci.json` has `clear` (table-clear workload).
+`tachometer-ci-todo.json` also wants `clear` (todo-list clear). **Don't** — rename one to `clear-completed` or `clear-table`.
+
+### ✅ Disambiguated names
+
+`clear` (krausest table clear) and `clear-completed` (TodoMVC clear-completed button).
+
+---
+
+## Before You Push
+
+Run the bench locally to confirm it works:
+
+```sh
+cd packages/renderer/bench/tachometer
+node build-ci.js current
+node build-ci.js baseline  # same source both sides for a dry-run; zero-delta
+npx tachometer --config tachometer-ci-<suite>.json
+```
+
+**Check for:**
+
+- Tachometer reports the expected number of measurements (`N for this-change, N for tip-of-tree`).
+- Each measurement name matches what you defined.
+- Mean duration is in the range you estimated — if it's 10× shorter than expected, something's wrong with the workload (early return? optimiser elision?).
+- No `ReferenceError` or `undefined is not a function` in the Chrome console. Open `ci-current-<suite>.html` in a browser to debug interactively.
+
+If the local run works, push. CI will run the same config in matrix form and the in-house reporter will render the comment per the rubric in `ai/workspace/tmp/bench-reporter-rubric.md`.
+
+---
+
+## Quick Reference
+
+**Files to touch for an extension to an existing suite:**
+
+1. `packages/renderer/bench/tachometer/bench-<existing>.js` — add `mark`/`measure` pair
+2. `packages/renderer/bench/tachometer/tachometer-ci-<suite>.json` — add `{ mode: 'performance', entryName: '<metric>' }` to BOTH `this-change` and `tip-of-tree` measurement arrays
+
+**Files to touch for a new bench file:**
+
+1. `bench-<name>.js` — workload + marks
+2. `ci-current-<name>.html` / `ci-baseline-<name>.html` — fixtures (copy an existing pair)
+3. `tachometer-ci-<name>.json` — config
+4. `build-ci.js` — add `'bench-<name>.js'` to `benchFiles` array
+
+**Knobs to leave alone unless you have data:**
+
+```json
+{ "sampleSize": 50, "timeout": 3, "autoSampleConditions": ["2%"] }
+```
+
+**Duration target:** 20–100ms mean. Scale up short workloads via iteration count.
+
+---
+
+## Related Skills
+
+| Skill | Command | Use when... |
+|-------|---------|-------------|
+| **Reading Bench Reports** | `/read-bench-report` | Reviewing a bench comment on a PR |
+| **Internals** | `/internals` | Understanding the renderer's hot paths when picking what to benchmark |

--- a/ai/skills/contributing/read-bench-report.md
+++ b/ai/skills/contributing/read-bench-report.md
@@ -1,0 +1,287 @@
+---
+title: Reading Bench Reports on PRs
+description: How to interpret the in-house bench reporter's PR comment — state banner, severity emoji, the two Unsure subsections, and the JSON adjunct for agent consumption.
+keywords: [benchmark, tachometer, PR comment, bench report, noise floor, unsure, autoresearch, confidence interval]
+audience: contributing
+skill: read-bench-report
+type: skill
+---
+
+# Reading Bench Reports on PRs
+
+> **Skill:** `read-bench-report`
+> **Purpose:** Correctly interpret the bench reporter comment on a PR — what each section means, what to chase, what to ignore.
+
+**Golden rule: confident signals live in the Faster and Slower sections.** `🔍 Unsure` means "the measurement did not resolve," *not* "regression to investigate." A metric in "Too Fast to Measure Precisely" will stay unsure on zero-delta PRs by physics — chasing it wastes time. A metric in "Inconclusive" might resolve with more samples but isn't an actionable signal today.
+
+---
+
+## Comment Anatomy
+
+Every bench comment follows the same shape. Top to bottom:
+
+```
+### <state-emoji> <State phrase> for <sha-link> on Benchmark Suite 📊
+
+**Base:** [main](commit) · **Action:** [run ↗] · **Raw:** [bench-report.json]
+
+<sup>Commit message</sup>
+
+> [!<alert>]
+> Verdict sentence.
+
+✅ N faster · ❌ N slower · 🔍 N unsure · ⚪ N no change
+
+---
+
+#### ✅ Faster (N)       ← expanded when ≤ 15 rows
+#### ❌ Slower (N)       ← same
+<details>⚪ No Change</details>  ← always collapsed
+<details>🔍 Unsure</details>     ← always collapsed, two subsections inside
+
+<sub>Sample size · Resolution floor · Timeout · Wall-clock</sub>
+```
+
+---
+
+## Top Header State — What the Headline Says
+
+Six possible states based on the count of faster and slower metrics. The emoji and the GitHub alert color both encode the state; use either as your entry point.
+
+| State | Emoji | Alert | Meaning |
+|-------|:---:|:---:|---------|
+| Improvement | ✅ | `[!TIP]` green | At least one faster, zero slower. Clean win. |
+| Regression | ❌ | `[!CAUTION]` red | At least one slower, zero faster. Investigate. |
+| Mixed — Net Positive | 🟡 | `[!WARNING]` yellow | More faster than slower. Look at the slower table first. |
+| Mixed — Net Negative | 🟡 | `[!WARNING]` yellow | More slower than faster. Investigate which regressions outweigh the wins. |
+| Mixed — Balanced | 🟡 | `[!WARNING]` yellow | Equal count. Magnitude matters more than count here. |
+| No Meaningful Change | ⚪ | `[!NOTE]` blue | Zero faster, zero slower. Docs/CI-only PRs; refactor PRs that preserve perf. |
+
+Net modifier uses **count**, not magnitude-weighted score. 9 wins × 5% improvement outweighs 1 regression × 30% regression in user-observable impact, but the count-based label still says "Net Positive." The individual tables show magnitudes — trust those for the real tradeoff judgment.
+
+---
+
+## Faster / Slower — The Headline Verdicts
+
+Metrics land in Faster or Slower only when their 95% CI is entirely above or below ±2%. This is the confident-signal bucket. If a metric is here, **there's a real perf change to discuss.**
+
+### Reading a row
+
+```
+| `update-10th` | -62% (34ms) 🌟 |
+```
+
+- **`update-10th`** — metric name, links to its `performance.measure(...)` line in the bench source at the run's SHA. Click to see what's actually being benchmarked.
+- **`-62%`** — midpoint of the 95% CI for percent change. Sign carries direction (negative = faster; positive = slower). The CI itself is in `bench-report.json`.
+- **`(34ms)`** — midpoint absolute-ms delta, unsigned (sign inferred from the section — Faster means time *saved*, Slower means time *added*).
+- **`🌟`** — severity emoji. Appears *after* the values so number columns align vertically; lets you scan magnitudes at a glance.
+
+### Severity emoji by |midpoint%|
+
+| Threshold | Faster | Slower | Category |
+|---|:---:|:---:|---|
+| ≥ 75% | 🏆 | 🚨 | Extreme |
+| 35–75% | 🌟 | ‼️ | Very significant |
+| 15–35% | ⭐ | ❗ | Significant |
+| < 15% | *(none)* | *(none)* | Below threshold — still a real signal, just lower magnitude |
+
+Rows sorted by `|midpoint|` descending, so the biggest effects are at the top.
+
+### Teaser pattern for big PRs
+
+If Faster or Slower has more than 15 rows, the section shows a top-5 teaser above a collapsible with the full list:
+
+```markdown
+#### ✅ Faster (18) — top 5 shown
+<5-row table>
+<details>
+<summary>Show all 18 faster metrics</summary>
+<full 18-row table>
+</details>
+```
+
+The teaser prevents the comment from blowing up while keeping the headline-worthy wins visible.
+
+---
+
+## No Change — Confirmed Unchanged
+
+Metrics with CI entirely inside ±2%. These are the *positive* signal for a refactor or cleanup PR — proof you didn't regress anything. Always collapsed so the list doesn't dominate mixed-outcome comments, but expand when:
+
+- You're reviewing a refactor and want confirmation nothing moved.
+- You want to double-check that a metric you expected to improve didn't actually shift.
+
+Don't expand reflexively on a mixed PR — the Faster/Slower tables have the story.
+
+---
+
+## Unsure — The Two Subsections
+
+Unsure metrics have CIs that straddle the ±2% threshold. The reporter splits them into two buckets by **duration-derived noise analysis**, because they need different responses.
+
+### Inconclusive — boundary cases, more samples might help
+
+```
+| `bulk-add-50` | +0.2% – +3.8% | ±4% |
+```
+
+- **Change**: CI range straddling ±2%.
+- **Expected Noise**: the CI width predicted by the bench's absolute duration and the GHA σ≈2ms jitter floor. The `±4%` here says "at this bench's duration, we'd expect the CI to narrow to about ±4% wide."
+
+A metric lands in Inconclusive when its observed CI width is **more than 2× the expected width** for its duration. That's the "we tried to resolve and couldn't" signal — either more sampling time would settle it, or the bench is genuinely noisier than its duration predicts (worth a second look at the bench itself).
+
+### ✅ When to investigate an Inconclusive row
+
+`create-1k` (~130ms mean) shows CI width ~3.5% while expected is ~1.3%. **2.7× expected** — long benches shouldn't have wide CIs. That's a "this bench has unusual per-sample variance" signal worth tracing to a setup issue or a legitimate GC/allocation pattern.
+
+### ❌ When NOT to investigate
+
+`bulk-add-50` shows CI `+0.2% to +3.8%` with expected `±4%`. **Roughly 1× expected** — this is the boundary CI narrowing right up against the expected noise floor. More samples won't narrow it materially. Treat as no-signal.
+
+### Too Fast to Measure Precisely — physics-limited, ignore
+
+```
+| `clear` | -10.2% – +10.7% | ~13ms | ±12% |
+```
+
+- **Change**: CI range; often wide on short benches.
+- **Test Time**: mean absolute duration.
+- **Expected Noise**: at 13ms, GHA's ~2ms absolute jitter becomes ±12% relative. The observed CI width is right at that floor.
+
+These are benches whose duration is short enough that per-sample OS/GC/JIT jitter dominates sub-5% changes. Tachometer literally cannot resolve the signal on zero-delta runs — not a tuning issue, a physical limit of the hardware.
+
+**These benches still work under real perf deltas.** A genuine 30% improvement on `clear` will clear the ±12% noise floor and show up in the Faster section. What they *won't* do is confirm "no change" — they'll default to unsure whenever the true delta is smaller than the noise floor.
+
+### ❌ Common mistake
+
+> "`remove-last` is marked unsure — we regressed it!"
+
+Check if it's in the Too Fast subsection. If the Expected Noise is comparable to the observed CI width, the bench is noise-floor-limited and the verdict is neither regression nor improvement. **Not a regression signal.**
+
+### ✅ Correct reading
+
+> "`remove-last` is in Too Fast to Measure Precisely — mean ~8ms, expected noise ±20%. Zero-delta PRs will always show this as unsure. Move on unless there's a substantive change in the PR that should have affected this code path."
+
+---
+
+## Footer Metadata
+
+```
+<sub>Sample size: 50 · Resolution floor: ±2% · Timeout: 3min · Wall-clock: 10m42s</sub>
+```
+
+Useful when something looks off — tells you the parameters the run used without opening the raw JSON. If a bench comment is missing metrics, check Wall-clock — if the cell hit the 10-min job cap, some metrics may have timed out before finishing initial samples.
+
+---
+
+## JSON Adjunct — for Agents
+
+The `bench-report.json` artifact (linked from the **Raw:** line in the metadata header) contains the full structured output:
+
+```json
+{
+  "head": { "sha": "...", "msg": "...", "ref": "..." },
+  "base": { "sha": "...", "ref": "main" },
+  "run":  { "url": "..." },
+  "repo": "Semantic-Org/Semantic-Next",
+  "wall_clock_seconds": 642,
+  "noise_floor_percent": 2,
+  "sigma_abs_ms": 2,
+  "noise_ratio_tolerance": 2,
+  "summary": { "faster": 10, "slower": 5, "within-noise": 3, "unsure": 0, "noise-floor-limited": 3 },
+  "metrics": [
+    {
+      "name": "update-10th",
+      "status": "faster",
+      "percent_change_ci": [-63.1, -60.4],
+      "absolute_ms_ci":    [-35.7, -33.17],
+      "this_change_ms_ci": [8.2, 8.5],
+      "tip_of_tree_ms_ci": [22.5, 22.8],
+      "mean_ms": 8.35,
+      "expected_noise_pp": 0.94,
+      "observed_noise_ratio": 2.87,
+      "source": { "path": "packages/renderer/bench/tachometer/bench.js", "line": 180 }
+    }
+  ]
+}
+```
+
+### Fields agents care about
+
+| Field | Agent use |
+|-------|-----------|
+| `summary` | One-shot verdict counts; drives decision trees |
+| `metrics[].status` | Classification without re-parsing CIs |
+| `metrics[].percent_change_ci` | Exact CI bounds for cross-run comparison |
+| `metrics[].mean_ms` | Duration for noise-floor reasoning |
+| `metrics[].expected_noise_pp` | Floor this run would be limited by |
+| `metrics[].observed_noise_ratio` | Ratio ≤ 2 → expected; > 2 → investigate |
+| `metrics[].source` | Jump to bench source at this SHA |
+
+### ✅ Good agent query
+
+"For any metric with `status: slower` and `observed_noise_ratio < 1.5`, the regression is real and the CI is tight — worth surfacing to the reviewer."
+
+### ❌ Bad agent query
+
+"Count all `unsure` entries and flag regression." Unsure ≠ regression; the category is defined by "CI straddles ±2% boundary," not direction. Count `slower` instead.
+
+---
+
+## Reading Decision Tree
+
+```
+Headline state says Improvement or No Meaningful Change
+  └─ Default trust. Spot-check Slower (empty) and Unsure (curiosity only).
+
+Headline state says Regression or Mixed Net Negative
+  └─ Go straight to the Slower table. The sort order puts the biggest
+     regressions at top. Click the metric name to see what the bench does.
+
+A specific metric reads wrong (e.g. expected a win, didn't get one)
+  └─ Check Unsure first. It might be in Too Fast — physics-limited,
+     not a failure. If it's in Inconclusive at ratio > 2, real investigation.
+
+Reviewing a refactor / cleanup PR
+  └─ Expand No Change. Confirm the expected metrics are there, not
+     surprise-Slower.
+
+An agent needs the data
+  └─ bench-report.json from the metadata Raw link. Parse, act.
+```
+
+---
+
+## Quick Reference
+
+**What each section's inclusion threshold means:**
+
+- `✅ Faster` — CI entirely below -2% (confident improvement)
+- `❌ Slower` — CI entirely above +2% (confident regression)
+- `⚪ No Change` — CI entirely inside ±2% (confident unchanged)
+- `🔍 Unsure > Inconclusive` — CI straddles ±2% AND observed/expected ratio > 2× (could resolve with more samples or bench is unusually noisy)
+- `🔍 Unsure > Too Fast to Measure Precisely` — CI straddles ±2% AND observed ≤ 2× expected (noise floor limited by duration; won't resolve)
+
+**Severity emoji cheat sheet:**
+
+| Emoji | Faster / Slower | |midpoint%| |
+|:---:|---|---|
+| 🏆 / 🚨 | Extreme | ≥ 75% |
+| 🌟 / ‼️ | Very significant | 35 – 75% |
+| ⭐ / ❗ | Significant | 15 – 35% |
+| (none) | Below threshold | < 15% |
+
+**What to ignore:**
+
+- Unsure rows in "Too Fast to Measure Precisely" on zero-delta PRs — physics.
+- Noise in the No Change section — that's the *absence* of signal, which is the signal for a refactor.
+- Count modifiers in Mixed states (Net Positive/Negative/Balanced) — magnitude in the tables matters more than count.
+
+---
+
+## Related Skills
+
+| Skill | Command | Use when... |
+|-------|---------|-------------|
+| **Extend Bench Suite** | `/extend-bench-suite` | Adding a new benchmark to the suite |
+| **Agent Lessons** | `/agent-lessons` | Understanding how past perf work went |


### PR DESCRIPTION
Two contributing skills documenting the shipping bench infrastructure. Doc-only, no code changes.

## extend-bench-suite

Procedural skill for adding a new tachometer benchmark:

- Three-file pattern (bench JS + HTML fixture + tachometer config)
- \`startMark\` → \`performance.mark\` / \`performance.measure\` convention (name matches \`entryName\` in the config)
- **Duration-before-code guidance**: σ≈2ms on GHA means <5ms benches land in "Too Fast to Measure Precisely" on zero-delta regardless of code quality. Amplify short workloads via iteration count (pattern: \`signal-set-1k\`, \`create-1k\`, \`bulk-add-50\`).
- Knobs to leave alone (\`sampleSize: 50\`, \`timeout: 3\`, \`autoSampleConditions: ["2%"]\`) with the reason why.
- Local dry-run recipe using \`build-ci.js\` + \`npx tachometer\`.

## read-bench-report

Procedural skill for interpreting the reporter's PR comment:

- State mapping (✅ Improvement / ❌ Regression / 🟡 Mixed Net-*/ ⚪ No Meaningful Change) and which alert block each carries.
- Severity emoji thresholds (⭐ 🌟 🏆 / ❗ ‼️ 🚨) at 15/35/75% midpoint.
- Teaser pattern for >15-row Faster/Slower sections.
- The two-bucket Unsure split (Inconclusive vs Too Fast to Measure Precisely) — crucially, when each is worth investigating vs ignoring. Short benches are noise-floor-limited by physics and will stay unsure on zero-delta PRs; that's not a regression.
- JSON adjunct (\`bench-report.json\`) schema for agent autoresearch.
- A reviewer decision tree at the end.

## Authoring conventions

Both follow \`ai/skills/contributing/ai-author-context.md\`:

- YAML frontmatter with \`audience: contributing\`, \`skill:\` kebab-case name, \`type: skill\`
- Golden rule up top
- ✅/❌ paired examples throughout
- Quick Reference block before the Related table

Served via the Semantic UI MCP server (\`list_skills\` / \`use_skill\`) and \`llms.txt\`. Downstream users consuming these get a self-contained guide — neither skill requires reading other files to act on it.

## Coordination with PR #143 (D1 reporter polish)

These skills describe behavior landed in PRs A-C plus the D1 rubric in #143. If #143 merges first, the skills accurately describe what's live. If these merge first, the skills describe what the reporter WILL do once #143 ships — accurate post-merge; mildly premature for any day-of reviewers looking at current main. No functional dependency either way.

## Test plan

- [ ] Authored per \`ai-author-context.md\` — frontmatter present, headings match the section-API convention, golden rules up top, ✅/❌ pairs, Quick Reference + Related at end.
- [ ] Both under 500 lines (procedural skill budget).
- [ ] No claims about unshipped behavior — everything described exists on \`origin/main\` or PR #143.