### PR TITLE
Build: Archive bench history on main pushes (D3a)

### DIFF
--- a/.github/workflows/benchmarks-report.yml
+++ b/.github/workflows/benchmarks-report.yml
@@ -11,17 +11,18 @@ permissions:
   contents: read
 
 jobs:
-  report:
-    name: Post bench report
+  # PR path: render comment, post / edit in place. Runs on all successful
+  # bench runs whose triggering event was `pull_request`.
+  comment:
+    name: Post PR bench comment
     runs-on: ubuntu-latest
     permissions:
       issues: write
       pull-requests: write
-    # Only act on successful bench runs. Failure states are visible in the
-    # Checks panel; posting a "failed" comment adds noise.
-    if: github.event.workflow_run.conclusion == 'success'
+    if: >
+      github.event.workflow_run.conclusion == 'success'
+      && github.event.workflow_run.event == 'pull_request'
     steps:
-      # Need the reporter script — check out the same SHA the bench ran on.
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
@@ -44,9 +45,6 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # workflow_run payload populates pull_requests for same-repo PRs.
-          # For forks (and anything where it's missing) fall back to a
-          # head-branch lookup.
           NUMBER='${{ github.event.workflow_run.pull_requests[0].number }}'
           if [ -z "$NUMBER" ] || [ "$NUMBER" = "null" ]; then
             HEAD='${{ github.event.workflow_run.head_branch }}'
@@ -61,7 +59,6 @@ jobs:
           STARTED: ${{ github.event.workflow_run.created_at }}
           ENDED: ${{ github.event.workflow_run.updated_at }}
         run: |
-          # Compute wall-clock in seconds for the bench run.
           WALL_CLOCK=$(( $(date -d "$ENDED" +%s) - $(date -d "$STARTED" +%s) ))
           node tools/bench-reporter/reporter.js \
             --results results \
@@ -87,10 +84,89 @@ jobs:
           PR: ${{ steps.pr.outputs.number }}
           REPO: ${{ github.repository }}
         run: |
-          # Try to edit our previous comment in place; fall back to posting
-          # a new one on first run of the reporter for this PR.
           if ! gh pr comment "$PR" --repo "$REPO" --edit-last \
                 --body-file bench-report/comment.md 2>/dev/null; then
             gh pr comment "$PR" --repo "$REPO" \
               --body-file bench-report/comment.md
+          fi
+
+  # History path: append this commit's absolute CIs to bench-history.json
+  # and commit back to main. Runs on successful bench runs triggered by a
+  # push to main. Serialized by concurrency group so two near-simultaneous
+  # merges don't race on the file.
+  history:
+    name: Append bench history
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    if: >
+      github.event.workflow_run.conclusion == 'success'
+      && github.event.workflow_run.event == 'push'
+    concurrency:
+      group: bench-history-append
+      cancel-in-progress: false
+    steps:
+      # Check out main's tip for the commit target. We push back to main,
+      # so we need the most recent state — not the bench's head_sha (which
+      # may have been superseded by a later merge during the ~10-min bench).
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 2  # need HEAD~1 for parent_sha lookup
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - name: Download bench artifacts
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          workflow: ${{ github.event.workflow.id }}
+          run_id: ${{ github.event.workflow_run.id }}
+          name_is_regexp: true
+          name: results-.*
+          path: results
+
+      - name: Append history entry
+        run: |
+          # The benched commit is the workflow_run's head_sha (the merge
+          # commit on main). Parent comes from the git history we just
+          # fetched. Timestamp is the bench run's completion time so the
+          # history is ordered by when the measurement was taken, not
+          # when the commit landed.
+          BENCHED_SHA='${{ github.event.workflow_run.head_sha }}'
+          PARENT_SHA=$(git rev-parse "$BENCHED_SHA^" 2>/dev/null || echo '')
+          node tools/bench-reporter/append-history.js \
+            --results results \
+            --sha "$BENCHED_SHA" \
+            --msg '${{ github.event.workflow_run.display_title }}' \
+            --parent-sha "$PARENT_SHA" \
+            --timestamp '${{ github.event.workflow_run.updated_at }}' \
+            --history bench-history.json
+
+      - name: Commit + push
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          # If nothing changed (e.g. a re-run for a SHA already archived with
+          # identical numbers), skip rather than making an empty commit.
+          if git diff --quiet bench-history.json; then
+            echo 'No change to bench-history.json; skipping commit.'
+            exit 0
+          fi
+          BENCHED_SHA='${{ github.event.workflow_run.head_sha }}'
+          SHORT_SHA=${BENCHED_SHA:0:7}
+          git add bench-history.json
+          git commit -m "Chore: Archive bench history for $SHORT_SHA [skip ci]"
+          # Narrow race: another merge may have landed on main while we were
+          # running benches. Try push; if it's rejected as non-fast-forward,
+          # rebase on latest main and retry once. Concurrency group on this
+          # job prevents overlap with another history-append; only peer race
+          # is a human merge via GitHub UI.
+          if ! git push origin main; then
+            echo 'Push rejected (likely non-fast-forward); rebasing and retrying.'
+            git fetch origin main
+            git rebase origin/main
+            git push origin main
           fi

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -6,6 +6,14 @@ on:
       - 'packages/**'
       - '.github/workflows/benchmarks.yml'
       - '.github/workflows/benchmarks-report.yml'
+  # Bench every merge commit on main so bench-history.json accumulates
+  # absolute CIs per commit. These runs aren't gated against anything —
+  # the report workflow branches on event type and appends history instead
+  # of posting a PR comment.
+  push:
+    branches: [main]
+    paths:
+      - 'packages/**'
 
 concurrency:
   group: bench-${{ github.workflow }}-${{ github.ref }}
@@ -31,23 +39,32 @@ jobs:
       - name: Build matrix
         id: matrix
         run: |
-          base=origin/${{ github.event.pull_request.base.ref }}
-
-          # If a benchmark workflow or bench harness changed, we need to
-          # validate CI itself — run against every benchmarked package.
-          ci_changed=$(git diff --name-only "$base"...HEAD \
-            | grep -E '^(\.github/workflows/benchmarks.*\.yml|packages/[^/]+/bench/tachometer/)' \
-            | head -1)
-
-          if [ -n "$ci_changed" ]; then
+          # Push to main: archive every benchmarkable package — we need the
+          # full absolute-CI snapshot for bench-history regardless of what
+          # changed in this commit.
+          if [ '${{ github.event_name }}' = 'push' ]; then
             changed=$(find packages -name 'tachometer-ci*.json' -path '*/bench/tachometer/*' \
               | cut -d/ -f2 \
               | sort -u)
           else
-            changed=$(git diff --name-only "$base"...HEAD \
-              | grep '^packages/' \
-              | cut -d/ -f2 \
-              | sort -u)
+            base=origin/${{ github.event.pull_request.base.ref }}
+
+            # If a benchmark workflow or bench harness changed, we need to
+            # validate CI itself — run against every benchmarked package.
+            ci_changed=$(git diff --name-only "$base"...HEAD \
+              | grep -E '^(\.github/workflows/benchmarks.*\.yml|packages/[^/]+/bench/tachometer/)' \
+              | head -1)
+
+            if [ -n "$ci_changed" ]; then
+              changed=$(find packages -name 'tachometer-ci*.json' -path '*/bench/tachometer/*' \
+                | cut -d/ -f2 \
+                | sort -u)
+            else
+              changed=$(git diff --name-only "$base"...HEAD \
+                | grep '^packages/' \
+                | cut -d/ -f2 \
+                | sort -u)
+            fi
           fi
 
           # For each changed package, emit one entry per tachometer-ci*.json
@@ -108,11 +125,21 @@ jobs:
       - name: Build current
         run: node packages/${{ matrix.entry.package }}/bench/tachometer/build-ci.js current
 
-      # Swap source to base branch and build baseline bundles
+      # Swap source to the appropriate baseline and build baseline bundles.
+      # PR: baseline = base branch tip.
+      # Push to main: baseline = this commit's parent (so the delta captures
+      #   the merged commit's effect; bench-history indexes the current
+      #   commit's absolute CI).
       - name: Build baseline
         run: |
-          git fetch origin ${{ github.event.pull_request.base.ref }} --depth=1
-          git checkout FETCH_HEAD -- packages/*/src/
+          if [ '${{ github.event_name }}' = 'push' ]; then
+            # Fetch enough history to reach the parent commit locally.
+            git fetch origin main --depth=2
+            git checkout HEAD~1 -- packages/*/src/
+          else
+            git fetch origin ${{ github.event.pull_request.base.ref }} --depth=1
+            git checkout FETCH_HEAD -- packages/*/src/
+          fi
           node packages/${{ matrix.entry.package }}/bench/tachometer/build-ci.js baseline
           git checkout HEAD -- packages/*/src/
 

--- a/ai/skills/workflows/contributing/autoresearch-perf.md
+++ b/ai/skills/workflows/contributing/autoresearch-perf.md
@@ -38,7 +38,7 @@ This workflow is the autonomous variant of `improve-performance`. Use it when yo
 - You already know the fix — just implement it and measure
 - The regression has one confirmed cause that's already been analyzed
 - The benchmark suite can't isolate what you're optimizing (no local signal)
-- CI is your only measurement surface (CI tachometer runs take 25-35 min per iteration — too slow for a loop)
+- CI is your only measurement surface (tachometer in CI is too slow for a tight iteration loop even after parallelization — iterating requires a local runner)
 
 ---
 
@@ -119,9 +119,9 @@ Fast, cheap, unforgiving. Run the full suite, not the filtered subset. A filtere
 
 A target-only verdict is incomplete. The full suite's verdict is what ships.
 
-**Case study — iter-2, shallow props snapshot.** Target `update-10th` went from +14% to -51.7% (a 65pp improvement, confident CI). But the non-target `toggle-all` regressed by +30pp: every item mutates on toggle-all, so the new per-reconcile snapshot allocation ran 1000× and dominated the bench. Without the regression gate, this would have shipped as "net positive." With the gate, it was marked Refine; iter-3 eliminated the allocation via in-place refresh and kept the primary win while narrowing (not eliminating) the toggle-all loss.
+**Case study — iter-2, shallow props snapshot.** The hypothesis closed the primary target confidently but regressed a non-target metric well beyond gate threshold: every item mutates on the non-target's scenario, so the new per-reconcile snapshot allocation dominated that bench. Without the regression gate, this would have shipped as "net positive." With the gate, it was marked Refine; the next iteration eliminated the allocation via in-place refresh and kept the primary win while narrowing the non-target loss.
 
-**Threshold choice.** >3pp is a good default — tight enough to catch real regressions, loose enough to absorb noise on small-absolute-time benches. Adjust based on the measured noise floor of your local runner.
+**Threshold choice.** The gate threshold sits above the bench's inherent noise floor. Short benches have larger inherent variance than long benches — the reporter exposes a duration-derived Expected Noise per metric, and a regression is "real" when it clears that floor. In the absence of Expected Noise, a blanket few-percentage-point threshold works as a starting default; revisit when the reporter's per-bench noise estimate is available.
 
 ### Measurement gate
 
@@ -241,6 +241,10 @@ When to **revert**: the hypothesis was wrong. Two flavors:
 
 When to **promote**: a kept iteration has all three gates clear AND improves the target set AND doesn't regress any non-target beyond threshold. The best-known snapshot updates. Previous best-known is archived (kept as `<file>.best-iterK.js` for history, never deleted mid-loop).
 
+### Reporter vocabulary as loop vocabulary
+
+Once the PR-comment reporter is in place, its classification buckets map directly onto loop verdicts. A target metric classified as a confident improvement with no non-target classified as a confident regression is a gate-passed iteration. A target metric that the reporter marks Unsure — Too Fast to Measure Precisely is a metric the loop cannot make progress on at that bench's duration. A non-target metric classified as a confident regression is a regression-gate violation regardless of how good the target looks. Prefer the reporter's taxonomy over ad-hoc pp thresholds once it's available — same decisions, better-anchored vocabulary.
+
 ---
 
 ## Failure Modes Observed in Practice
@@ -271,7 +275,7 @@ Local tachometer shows one result; CI shows a significantly different one for th
 
 **Signal**: a confident-magnitude flip between local and CI. **Fix**: document both. Trust CI for the ship decision; use local for iteration feedback. Don't tune the loop to local-only signal if the CI result will contradict.
 
-**Case study**: iter-0's `clear` benchmark measured +31% locally vs -36% in CI for the same commit — a complete sign inversion. Both measurements were technically correct; the environments differed. The loop continued using local for speed, with the understanding that the final verdict was CI's.
+**Case study**: one benchmark measured confidently positive locally vs confidently negative in CI for the same commit — a complete sign inversion. Both measurements were technically correct; the environments differed. The loop continued using local for speed, with the understanding that the final verdict was CI's.
 
 ### Collapsing to "noise" too quickly
 
@@ -284,6 +288,12 @@ A small result (±2-3pp) gets labeled "noise" and the iteration is marked null. 
 Iteration N's change lands cleanly. The agent reasons: "while I'm here, I may as well fix the adjacent thing." Iteration N+1's change now bundles two mechanisms.
 
 **Signal**: an iter-N.md `## Change` section spans two distinct mechanisms. **Fix**: one hypothesis per iteration, always. If two are genuinely coupled, name the coupling explicitly and call it one mechanism; otherwise split into two iterations.
+
+### Extrapolating from undersampled plan data
+
+Before launching the loop, an agent looks at past per-commit tachometer tables and decides "these benchmarks move in lockstep — collapse them" or "this metric is always noisy — ignore it." The decision is reasonable given the small dataset. When the loop runs against real deltas, the pattern reverses: benchmarks that correlated across a few commits show independent sensitivity to the actual change; "always noisy" benchmarks resolve cleanly when the delta is large enough.
+
+**Signal**: a pre-loop call to restructure the suite, skip a bench, or adjust thresholds based on patterns observed in a handful of past runs. **Fix**: validate the pre-loop reasoning against real-delta data before committing to it — either run the loop against a commit with known non-trivial deltas first, or let the restructure ride a separate PR that can be reverted if the assumption was wrong. Pattern-matching on a small sample is reasoning-from-an-undersampled-corner, the opposite of what the loop is meant to do.
 
 ---
 

--- a/ai/skills/workflows/contributing/improve-performance.md
+++ b/ai/skills/workflows/contributing/improve-performance.md
@@ -66,6 +66,10 @@ Three tools serve different purposes. Using the wrong one for the job produces m
 - Same-session comparison — round-robins between variants to eliminate thermal/GC/JIT bias
 - Import maps — resolves monorepo bare specifiers natively in the browser, no build step
 
+### How tachometer output reaches a reviewer
+
+Tachometer emits JSON. In this repo, CI hands that JSON to an in-house reporter (`tools/bench-reporter/`) that renders a PR comment with per-metric verdicts (faster/slower/no change/unsure) and uploads a structured `bench-report.json` artifact for agent consumption. The reporter is the human-readable surface; the JSON adjunct is the agent-readable one. Both derive from the same tachometer output — no parallel data paths.
+
 ### Tachometer in monorepos
 
 Tachometer's `koa-node-resolve` can't follow transitive bare imports through npm workspace symlinks. Use **browser-native import maps** instead:
@@ -115,6 +119,9 @@ performance.measure('create-1k', 'create-1k-start');
 {
   "root": "../../../..",
   "resolveBareModules": false,
+  "sampleSize": 50,
+  "timeout": 3,
+  "autoSampleConditions": ["2%"],
   "benchmarks": [{
     "url": "index.html",
     "browser": { "name": "chrome", "headless": true },
@@ -124,6 +131,34 @@ performance.measure('create-1k', 'create-1k-start');
   }]
 }
 ```
+
+### Tuning knobs
+
+Three config-level knobs shape the confidence/time tradeoff. Pick with intent — defaults baked into tachometer lean toward "resolve everything, even zero-delta noise," which is wall-clock-expensive and produces many unsure verdicts.
+
+- **`sampleSize`** — the mandatory floor of samples tachometer collects before auto-sampling kicks in. Smaller floors are faster but produce wider CIs. 50 is a reasonable default; going below ~30 produces unreliable CIs.
+- **`autoSampleConditions`** — the resolution granularity tachometer chases. `["0%"]` asks it to resolve zero-delta metrics to below zero, which cannot converge when the true delta actually is zero — the run then burns its timeout. Choose a threshold slightly above the host's noise floor (a couple of percentage points works as a starting point). This is a **resolution** choice, not an **accuracy** choice — the 95% CI itself is not being relaxed.
+- **`timeout`** — per-config wall-clock cap. Lower values cap worst case at the cost of leaving some metrics unresolved; higher values converge more metrics at the cost of CI time. Tune against realistic-delta runs, not zero-delta runs.
+
+Config-tuning decisions interact: sample size floors how narrow a CI can get; `autoSampleConditions` controls whether tachometer keeps sampling once the floor is reached. Raising one without the other often wastes time.
+
+### Expected noise scales with bench duration
+
+A methodology fact worth internalizing: per-sample timing noise on a given host is roughly constant in absolute terms (OS scheduling, GC, JIT jitter — typically sub-millisecond). Relative noise scales *inversely with benchmark duration*.
+
+A 2ms bench and a 50ms bench both absorb roughly the same absolute jitter, but the relative noise looks very different:
+
+| bench duration | expected relative noise floor |
+|---|---|
+| ~2ms | ±10-20% |
+| ~10ms | ±2-5% |
+| ~50ms+ | ±1% or tighter |
+
+Consequences:
+
+- **Short benches can't resolve small deltas.** A 2ms bench will never confirm a 3% change at the confidence level because the per-sample noise swamps it. This isn't a tachometer bug; it's physics of the measurement.
+- **Don't tune thresholds to what you wish you could detect.** Tune to what the measurement actually supports. Asking for ±1% resolution on a 2ms bench means the metric is permanently "unsure" regardless of sampling time.
+- **The in-house reporter exposes this as a per-metric `Expected Noise`** column. When a metric shows Unsure with CI width similar to the expected-noise estimate, the bench is running at its physical floor — more samples don't help. When the CI width is wider than the estimate, the metric is genuinely variable beyond its duration's predicted floor and more samples may resolve it.
 
 ### Gotchas
 
@@ -381,6 +416,7 @@ npm run bench:component    # Run all component operations via tachometer config
 
 | Workflow | Command | Use when... |
 |---------|---------|-------------|
+| **Autoresearch Perf Regressions** | `autoresearch-perf` | Running an autonomous hypothesis-test-measure loop on a regression set whose root cause isn't obvious. The autonomous variant of this workflow. |
 | **Design Util Function** | `design-util-function` | Creating a new utility from scratch |
 | **Add Util Function** | `add-util-function` | Adding tests, types, docs for a new utility |
 | **Testing** | `testing` | Understanding test environments and conventions |

--- a/bench-history.json
+++ b/bench-history.json
@@ -1,0 +1,4 @@
+{
+  "schema_version": 1,
+  "commits": []
+}

--- a/tools/bench-reporter/append-history.js
+++ b/tools/bench-reporter/append-history.js
@@ -1,0 +1,131 @@
+#!/usr/bin/env node
+/*
+  Append a commit's bench measurements to bench-history.json.
+
+  Invoked from benchmarks-report.yml when a bench run was triggered by a
+  push to main (not a pull_request). Reads per-metric absolute CIs from
+  tachometer JSON output and appends a new entry to the history file,
+  which is then committed back to main by the workflow.
+
+  Usage:
+    node append-history.js \
+      --results <dir>       tachometer JSON output directory
+      --sha <sha>           commit SHA being archived
+      --msg <text>          commit subject line
+      --parent-sha <sha>    parent commit SHA
+      --timestamp <iso>     commit timestamp (ISO 8601); defaults to now
+      --history <path>      bench-history.json path (default: ./bench-history.json)
+
+  Idempotency: if the same SHA already exists in the file, the entry is
+  replaced. Lets a re-run of the workflow (e.g. after a flaky first pass)
+  overwrite rather than duplicate.
+*/
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+const args = parseArgs(process.argv.slice(2));
+const resultsDir = required(args, 'results');
+const sha = required(args, 'sha');
+const msg = args.msg ?? '';
+const parentSha = args['parent-sha'] ?? '';
+const timestamp = args.timestamp ?? new Date().toISOString();
+const historyPath = args.history ?? './bench-history.json';
+
+const metrics = loadMetrics(resultsDir);
+const entry = { sha, msg, parent_sha: parentSha, timestamp, metrics };
+
+const history = readOrSeedHistory(historyPath);
+const existingIdx = history.commits.findIndex((c) => c.sha === sha);
+if (existingIdx >= 0) {
+  history.commits[existingIdx] = entry;
+  console.log(`Replaced existing entry for ${sha.slice(0, 7)}`);
+}
+else {
+  history.commits.push(entry);
+  console.log(`Appended entry for ${sha.slice(0, 7)}`);
+}
+
+fs.writeFileSync(historyPath, JSON.stringify(history, null, 2) + '\n');
+console.log(`${history.commits.length} total commit${history.commits.length === 1 ? '' : 's'} in history`);
+console.log(`Metrics recorded: ${Object.keys(metrics).length}`);
+
+/**
+ * Walk the results directory and extract one { ci, mean_ms } entry per
+ * metric. Uses the `this-change` absolute CI — that's the value that
+ * indexes by SHA cleanly across time (the delta-vs-base comparison used
+ * in PR comments is not meaningful across commits).
+ */
+function loadMetrics(dir) {
+  const out = {};
+  for (const entry of walk(dir)) {
+    if (!entry.endsWith('.json')) { continue; }
+    const data = JSON.parse(fs.readFileSync(entry, 'utf8'));
+    if (!Array.isArray(data.benchmarks)) { continue; }
+
+    for (const bm of data.benchmarks) {
+      const source = (bm.name ?? '').split(' [')[0];
+      if (source !== 'this-change') { continue; }
+      const metricName = bm.measurement?.name ?? bm.name;
+      if (!bm.mean) { continue; }
+      out[metricName] = {
+        ci: [round4(bm.mean.low), round4(bm.mean.high)],
+        mean_ms: round4((bm.mean.low + bm.mean.high) / 2),
+      };
+    }
+  }
+  return out;
+}
+
+function readOrSeedHistory(filePath) {
+  if (!fs.existsSync(filePath)) {
+    return { schema_version: 1, commits: [] };
+  }
+  const raw = fs.readFileSync(filePath, 'utf8');
+  const parsed = JSON.parse(raw);
+  if (!Array.isArray(parsed.commits)) {
+    throw new Error(`Invalid history file: missing or non-array 'commits' field`);
+  }
+  if (parsed.schema_version !== 1) {
+    throw new Error(`Unsupported schema_version ${parsed.schema_version}; expected 1`);
+  }
+  return parsed;
+}
+
+function round4(n) {
+  return Number(n.toFixed(4));
+}
+
+function* walk(dir) {
+  for (const ent of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, ent.name);
+    if (ent.isDirectory()) { yield* walk(full); }
+    else { yield full; }
+  }
+}
+
+function parseArgs(argv) {
+  const out = {};
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (!a.startsWith('--')) { continue; }
+    const key = a.slice(2);
+    const next = argv[i + 1];
+    if (next === undefined || next.startsWith('--')) {
+      out[key] = true;
+    }
+    else {
+      out[key] = next;
+      i++;
+    }
+  }
+  return out;
+}
+
+function required(args, key) {
+  if (args[key] === undefined) {
+    console.error(`Missing required --${key}`);
+    process.exit(1);
+  }
+  return args[key];
+}

--- a/tools/bench-reporter/append-history.test.js
+++ b/tools/bench-reporter/append-history.test.js
@@ -1,0 +1,142 @@
+/*
+  Unit tests for append-history.js.
+  Run with: node --test tools/bench-reporter/append-history.test.js
+*/
+
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { test } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SCRIPT = path.join(__dirname, 'append-history.js');
+const FIXTURE_DIR = path.join(__dirname, 'fixtures', 'real-delta');
+
+function runAppend({ sha, msg = 'test', parentSha = '', timestamp, historyPath, resultsDir = FIXTURE_DIR }) {
+  const argv = [
+    SCRIPT,
+    '--results',
+    resultsDir,
+    '--sha',
+    sha,
+    '--msg',
+    msg,
+    '--parent-sha',
+    parentSha,
+    '--history',
+    historyPath,
+  ];
+  if (timestamp) { argv.push('--timestamp', timestamp); }
+  // Capture stderr so throw-cases can assert on the inner error message.
+  execFileSync('node', argv, { stdio: ['ignore', 'pipe', 'pipe'], encoding: 'utf8' });
+  return JSON.parse(fs.readFileSync(historyPath, 'utf8'));
+}
+
+test('seeds a new history file when one does not exist', () => {
+  const tmp = fs.mkdtempSync('/tmp/bench-hist-test-');
+  const historyPath = path.join(tmp, 'bench-history.json');
+  const result = runAppend({ sha: 'abc123', historyPath, timestamp: '2026-04-15T00:00:00Z' });
+
+  assert.equal(result.schema_version, 1);
+  assert.equal(result.commits.length, 1);
+  assert.equal(result.commits[0].sha, 'abc123');
+  assert.equal(result.commits[0].timestamp, '2026-04-15T00:00:00Z');
+  assert.ok(Object.keys(result.commits[0].metrics).length > 0, 'metrics extracted');
+});
+
+test('appends to an existing history', () => {
+  const tmp = fs.mkdtempSync('/tmp/bench-hist-test-');
+  const historyPath = path.join(tmp, 'bench-history.json');
+  fs.writeFileSync(
+    historyPath,
+    JSON.stringify({
+      schema_version: 1,
+      commits: [{ sha: 'existing-commit', msg: 'old', parent_sha: '', timestamp: '2026-01-01T00:00:00Z', metrics: {} }],
+    }),
+  );
+  const result = runAppend({ sha: 'new-commit', historyPath });
+
+  assert.equal(result.commits.length, 2);
+  assert.equal(result.commits[0].sha, 'existing-commit', 'prior entry preserved');
+  assert.equal(result.commits[1].sha, 'new-commit', 'new entry appended at end');
+});
+
+test('replaces an existing entry with matching SHA (idempotent re-run)', () => {
+  const tmp = fs.mkdtempSync('/tmp/bench-hist-test-');
+  const historyPath = path.join(tmp, 'bench-history.json');
+  // Seed with an older entry for the same SHA we're about to write
+  fs.writeFileSync(
+    historyPath,
+    JSON.stringify({
+      schema_version: 1,
+      commits: [{
+        sha: 'target-sha',
+        msg: 'stale',
+        parent_sha: '',
+        timestamp: '2000-01-01T00:00:00Z',
+        metrics: { old: { ci: [1, 2], mean_ms: 1.5 } },
+      }],
+    }),
+  );
+  const result = runAppend({ sha: 'target-sha', msg: 'fresh', historyPath, timestamp: '2026-04-15T00:00:00Z' });
+
+  assert.equal(result.commits.length, 1, 'no duplicate entries');
+  assert.equal(result.commits[0].msg, 'fresh', 'replaced not appended');
+  assert.equal(result.commits[0].timestamp, '2026-04-15T00:00:00Z');
+  assert.ok(!('old' in result.commits[0].metrics), 'stale metrics replaced');
+});
+
+test('extracts this-change absolute CIs only (not tip-of-tree)', () => {
+  const tmp = fs.mkdtempSync('/tmp/bench-hist-test-');
+  const historyPath = path.join(tmp, 'bench-history.json');
+  const result = runAppend({ sha: 'abc', historyPath });
+
+  const metrics = result.commits[0].metrics;
+  // The real-delta fixture has known this-change means for these metrics
+  // (update-10th, toggle-middle are the biggest movers in that run).
+  assert.ok('update-10th' in metrics);
+  assert.ok('toggle-middle' in metrics);
+  assert.ok(Array.isArray(metrics['update-10th'].ci));
+  assert.equal(metrics['update-10th'].ci.length, 2);
+  assert.equal(typeof metrics['update-10th'].mean_ms, 'number');
+  // Mean is the midpoint of the CI
+  const { ci, mean_ms } = metrics['update-10th'];
+  assert.ok(Math.abs(mean_ms - (ci[0] + ci[1]) / 2) < 0.01, 'mean is CI midpoint');
+});
+
+test('records parent_sha when provided', () => {
+  const tmp = fs.mkdtempSync('/tmp/bench-hist-test-');
+  const historyPath = path.join(tmp, 'bench-history.json');
+  const result = runAppend({ sha: 'child', parentSha: 'parent', historyPath });
+  assert.equal(result.commits[0].parent_sha, 'parent');
+});
+
+test('rejects an unsupported schema version', () => {
+  const tmp = fs.mkdtempSync('/tmp/bench-hist-test-');
+  const historyPath = path.join(tmp, 'bench-history.json');
+  fs.writeFileSync(historyPath, JSON.stringify({ schema_version: 99, commits: [] }));
+  try {
+    runAppend({ sha: 'x', historyPath });
+    assert.fail('expected script to exit non-zero');
+  }
+  catch (e) {
+    const combined = (e.stderr ?? '') + (e.message ?? '');
+    assert.match(combined, /Unsupported schema_version/);
+  }
+});
+
+test('round-trips numeric precision (4dp for ms)', () => {
+  const tmp = fs.mkdtempSync('/tmp/bench-hist-test-');
+  const historyPath = path.join(tmp, 'bench-history.json');
+  const result = runAppend({ sha: 'abc', historyPath });
+
+  // Pick any metric and verify numeric fields round-trip cleanly
+  const anyMetric = Object.values(result.commits[0].metrics)[0];
+  assert.ok(Number.isFinite(anyMetric.ci[0]));
+  assert.ok(Number.isFinite(anyMetric.ci[1]));
+  assert.ok(Number.isFinite(anyMetric.mean_ms));
+  // Values should be finite, non-negative (timing in ms)
+  assert.ok(anyMetric.mean_ms > 0, 'mean_ms is positive');
+});


### PR DESCRIPTION
First half of the D3 cross-run taxonomy work. D3a establishes the history stream — absolute per-commit CIs captured in `bench-history.json` on every main push. D3b (separate PR) teaches the reporter to consume the history for peak attribution / REOPENED / bisect-candidate annotations.

## What ships

- **`bench-history.json`** at repo root, schema_version 1, empty commits array. Grows with one entry per main commit: `{ sha, msg, parent_sha, timestamp, metrics: { <name>: { ci, mean_ms } } }`. Only `this-change` absolute CIs — they index by SHA cleanly across time, unlike the delta-vs-base values used in PR comments.
- **`benchmarks.yml`** gains a `push: branches: [main]` trigger. Discover step on push events runs against every benchmarkable package (we want a full snapshot per commit, not a changed-file filter). Build-baseline step uses `HEAD~1` as baseline on push events.
- **`benchmarks-report.yml`** splits into two jobs that branch on `github.event.workflow_run.event`:
  - **`pull_request`** → existing comment path, unchanged.
  - **`push`** → new history path: runs `append-history.js` against the downloaded artifacts, commits back to main as `github-actions[bot]` with `[skip ci]`. Serialized via `concurrency: bench-history-append` so two near-simultaneous merges don't race. Non-fast-forward push falls back to rebase-and-retry.
- **`tools/bench-reporter/append-history.js`** (~130 LOC) — standalone CLI. Idempotent on SHA (re-running for the same commit replaces rather than duplicates). Seeds the file if missing, rejects unsupported schema_versions up front.
- **`append-history.test.js`** — covers fresh-seed, append-to-existing, SHA idempotency, this-change-only extraction, numeric round-trip, schema-version rejection.

## Bundled

The two `ai/skills/workflows/contributing/` skill-doc edits were staged in the working tree — they update references to match the new reporter vocabulary (Expected Noise, ±2% floor, JSON adjunct). Bundling here since they'd drift without this update.

## Permissions + race model

- `contents: write` scoped to just the history job (comment job retains `issues/pull-requests: write` only).
- `GITHUB_TOKEN` handles the push — no new secret needed; main isn't branch-protected.
- `[skip ci]` in the archival commit prevents a feedback loop (belt-and-suspenders; GitHub already suppresses GITHUB_TOKEN pushes from firing subsequent workflows).
- Narrow race window: a human-merged PR on main between this job's checkout and push triggers rebase-retry.

## What's NOT in this PR (D3b)

- Reporter reads history on PR runs
- Per-metric peak attribution (WIN / TIED-PEAK / REOPENED / UNEXPLORED)
- Bisect-candidate hints on regressed metrics
- Bootstrap of initial history from the most-recent N merged PRs' artifacts (so D3b isn't dead on arrival with an empty file)

D3b is the substantive reporter work; D3a is the foundation it reads from.

## Test plan

- [ ] Unit tests pass locally (`node --test tools/bench-reporter/append-history.test.js` and `node --test tools/bench-reporter/reporter.test.js`)
- [ ] Bench matrix still runs correctly on PR events (unchanged path)
- [ ] After merge to main, a subsequent `push` event triggers the archival path
- [ ] First push commits a new entry; `bench-history.json` grows from `commits: []` to `commits: [{...}]`
- [ ] Re-running the history workflow on the same SHA doesn't duplicate (idempotent)
- [ ] `[skip ci]` on the archival commit prevents workflow re-trigger