### PR TITLE
Build: Reporter consumes bench-history for peak attribution (D3b)

### DIFF
--- a/.github/workflows/benchmarks-report.yml
+++ b/.github/workflows/benchmarks-report.yml
@@ -31,6 +31,15 @@ jobs:
         with:
           node-version: 24
 
+      # Overlay main's bench-history.json onto the PR checkout so the
+      # reporter's peak-attribution runs against the freshest history,
+      # not whatever version was on the PR's branch point. `|| true` keeps
+      # the step non-fatal if main has no file yet (first run after D3a).
+      - name: Fetch latest bench-history.json from main
+        run: |
+          git fetch origin main --depth=1
+          git show origin/main:bench-history.json > bench-history.json 2>/dev/null || true
+
       - name: Download bench artifacts
         uses: dawidd6/action-download-artifact@v2
         with:

--- a/tools/bench-reporter/append-history.js
+++ b/tools/bench-reporter/append-history.js
@@ -33,7 +33,12 @@ const timestamp = args.timestamp ?? new Date().toISOString();
 const historyPath = args.history ?? './bench-history.json';
 
 const metrics = loadMetrics(resultsDir);
-const entry = { sha, msg, parent_sha: parentSha, timestamp, metrics };
+// Squash-merge commit titles end with ` (#N)` — the PR the commit came from.
+// Capturing it here lets the reporter link peak SHAs straight to the PR page
+// (where the bench comment lives) instead of just to the commit view.
+const prMatch = /\(#(\d+)\)\s*$/.exec(msg);
+const pr = prMatch ? Number(prMatch[1]) : null;
+const entry = { sha, msg, parent_sha: parentSha, timestamp, pr, metrics };
 
 const history = readOrSeedHistory(historyPath);
 const existingIdx = history.commits.findIndex((c) => c.sha === sha);

--- a/tools/bench-reporter/append-history.test.js
+++ b/tools/bench-reporter/append-history.test.js
@@ -113,6 +113,29 @@ test('records parent_sha when provided', () => {
   assert.equal(result.commits[0].parent_sha, 'parent');
 });
 
+test('extracts pr number from squash-merge commit titles', () => {
+  const tmp = fs.mkdtempSync('/tmp/bench-hist-test-');
+  const historyPath = path.join(tmp, 'bench-history.json');
+  // GitHub squash merges end the subject line with ` (#NNN)`.
+  const result = runAppend({
+    sha: 'abc',
+    msg: 'Build: Reporter polish — reorder sections (#143)',
+    historyPath,
+  });
+  assert.equal(result.commits[0].pr, 143);
+});
+
+test('pr is null when commit message has no PR reference', () => {
+  const tmp = fs.mkdtempSync('/tmp/bench-hist-test-');
+  const historyPath = path.join(tmp, 'bench-history.json');
+  const result = runAppend({
+    sha: 'abc',
+    msg: 'Chore: direct-to-main commit',
+    historyPath,
+  });
+  assert.equal(result.commits[0].pr, null);
+});
+
 test('rejects an unsupported schema version', () => {
   const tmp = fs.mkdtempSync('/tmp/bench-hist-test-');
   const historyPath = path.join(tmp, 'bench-history.json');

--- a/tools/bench-reporter/fixtures/history-sample.json
+++ b/tools/bench-reporter/fixtures/history-sample.json
@@ -1,0 +1,49 @@
+{
+  "schema_version": 1,
+  "commits": [
+    {
+      "sha": "aaaa111111111111",
+      "msg": "Perf: initial optimization",
+      "parent_sha": "",
+      "timestamp": "2026-04-10T00:00:00Z",
+      "metrics": {
+        "update-10th": { "ci": [10.0, 11.0], "mean_ms": 10.5 },
+        "select": { "ci": [20.0, 21.0], "mean_ms": 20.5 },
+        "toggle-middle": { "ci": [8.0, 9.0], "mean_ms": 8.5 }
+      }
+    },
+    {
+      "sha": "bbbb222222222222",
+      "msg": "Perf: deeper optimization (best)",
+      "parent_sha": "aaaa111111111111",
+      "timestamp": "2026-04-11T00:00:00Z",
+      "metrics": {
+        "update-10th": { "ci": [6.0, 7.0], "mean_ms": 6.5 },
+        "select": { "ci": [18.0, 19.0], "mean_ms": 18.5 },
+        "toggle-middle": { "ci": [7.0, 8.0], "mean_ms": 7.5 }
+      }
+    },
+    {
+      "sha": "cccc333333333333",
+      "msg": "Refactor: structural cleanup",
+      "parent_sha": "bbbb222222222222",
+      "timestamp": "2026-04-12T00:00:00Z",
+      "metrics": {
+        "update-10th": { "ci": [7.0, 8.0], "mean_ms": 7.5 },
+        "select": { "ci": [18.2, 19.1], "mean_ms": 18.65 },
+        "toggle-middle": { "ci": [7.1, 8.1], "mean_ms": 7.6 }
+      }
+    },
+    {
+      "sha": "dddd444444444444",
+      "msg": "Bug: fix correctness issue",
+      "parent_sha": "cccc333333333333",
+      "timestamp": "2026-04-13T00:00:00Z",
+      "metrics": {
+        "update-10th": { "ci": [9.0, 10.0], "mean_ms": 9.5 },
+        "select": { "ci": [18.1, 19.0], "mean_ms": 18.55 },
+        "toggle-middle": { "ci": [7.2, 8.2], "mean_ms": 7.7 }
+      }
+    }
+  ]
+}

--- a/tools/bench-reporter/fixtures/history-sample.json
+++ b/tools/bench-reporter/fixtures/history-sample.json
@@ -3,9 +3,10 @@
   "commits": [
     {
       "sha": "aaaa111111111111",
-      "msg": "Perf: initial optimization",
+      "msg": "Perf: initial optimization (#101)",
       "parent_sha": "",
       "timestamp": "2026-04-10T00:00:00Z",
+      "pr": 101,
       "metrics": {
         "update-10th": { "ci": [10.0, 11.0], "mean_ms": 10.5 },
         "select": { "ci": [20.0, 21.0], "mean_ms": 20.5 },
@@ -14,9 +15,10 @@
     },
     {
       "sha": "bbbb222222222222",
-      "msg": "Perf: deeper optimization (best)",
+      "msg": "Perf: deeper optimization (best) (#102)",
       "parent_sha": "aaaa111111111111",
       "timestamp": "2026-04-11T00:00:00Z",
+      "pr": 102,
       "metrics": {
         "update-10th": { "ci": [6.0, 7.0], "mean_ms": 6.5 },
         "select": { "ci": [18.0, 19.0], "mean_ms": 18.5 },
@@ -25,9 +27,10 @@
     },
     {
       "sha": "cccc333333333333",
-      "msg": "Refactor: structural cleanup",
+      "msg": "Refactor: structural cleanup (#103)",
       "parent_sha": "bbbb222222222222",
       "timestamp": "2026-04-12T00:00:00Z",
+      "pr": 103,
       "metrics": {
         "update-10th": { "ci": [7.0, 8.0], "mean_ms": 7.5 },
         "select": { "ci": [18.2, 19.1], "mean_ms": 18.65 },
@@ -36,9 +39,10 @@
     },
     {
       "sha": "dddd444444444444",
-      "msg": "Bug: fix correctness issue",
+      "msg": "Bug: fix correctness issue (#104)",
       "parent_sha": "cccc333333333333",
       "timestamp": "2026-04-13T00:00:00Z",
+      "pr": 104,
       "metrics": {
         "update-10th": { "ci": [9.0, 10.0], "mean_ms": 9.5 },
         "select": { "ci": [18.1, 19.0], "mean_ms": 18.55 },

--- a/tools/bench-reporter/reporter.js
+++ b/tools/bench-reporter/reporter.js
@@ -328,6 +328,12 @@ function renderMarkdown(report) {
     renderFasterSlowerSection(lines, slower, 'slower', report);
   }
 
+  // ─── Regressions from peak (cross-run; auto-expanded when present) ───
+  // Load-bearing signal — a metric better on a prior commit is always a
+  // cherry-pick candidate. Sits alongside Faster/Slower, not hidden in a
+  // collapsible, because a reviewer should never miss this.
+  renderRegressionsFromPeak(lines, report);
+
   // ─── No Change (always collapsed) ────────────────────────────────────
   if (noChange.length > 0) {
     lines.push('<details>');
@@ -395,9 +401,6 @@ function renderMarkdown(report) {
     lines.push('');
   }
 
-  // ─── Regressions from peak (cross-run; only when REOPENED exists) ────
-  renderRegressionsFromPeak(lines, report);
-
   // ─── Footer ──────────────────────────────────────────────────────────
   lines.push('---');
   const footerParts = [
@@ -427,8 +430,7 @@ function renderRegressionsFromPeak(lines, report) {
   // Sort by severity — largest delta-from-peak first.
   const sorted = [...reopened].sort((a, b) => (b.delta_from_peak_pct ?? 0) - (a.delta_from_peak_pct ?? 0));
 
-  lines.push('<details>');
-  lines.push(`<summary>📜 Regressions from peak (${reopened.length})</summary>`);
+  lines.push(`#### 📜 Regressions from peak (${reopened.length})`);
   lines.push('');
   lines.push(
     `These metrics were better on a prior commit than they are now. The peak CI dominates current CI — not attributable to per-sample noise. Bisect candidates are the commits between the peak and HEAD; nearest-to-peak is usually the best bet.`,
@@ -442,18 +444,10 @@ function renderRegressionsFromPeak(lines, report) {
     const deltaStr = m.delta_from_peak_pct > 0
       ? `+${m.delta_from_peak_pct.toFixed(0)}%`
       : `${m.delta_from_peak_pct.toFixed(0)}%`;
-    const peakShortSha = m.peak.sha.slice(0, 7);
-    const peakLink = report.repo
-      ? `[\`${peakShortSha}\`](https://github.com/${report.repo}/commit/${m.peak.sha})`
-      : `\`${peakShortSha}\``;
+    const peakLink = commitOrPrLink(m.peak, report.repo);
     const bisectMd = (m.bisect_candidates ?? [])
       .slice(0, BISECT_MARKDOWN_MAX)
-      .map((c) => {
-        const shortSha = c.sha.slice(0, 7);
-        return report.repo
-          ? `[\`${shortSha}\`](https://github.com/${report.repo}/commit/${c.sha})`
-          : `\`${shortSha}\``;
-      })
+      .map((c) => commitOrPrLink(c, report.repo))
       .join(', ');
     const bisectCell = m.bisect_candidates && m.bisect_candidates.length > BISECT_MARKDOWN_MAX
       ? `${bisectMd} +${m.bisect_candidates.length - BISECT_MARKDOWN_MAX} more`
@@ -464,8 +458,6 @@ function renderRegressionsFromPeak(lines, report) {
       }ms @ ${peakLink} | ${deltaStr} | ${bisectCell} |`,
     );
   }
-  lines.push('');
-  lines.push('</details>');
   lines.push('');
 }
 
@@ -588,6 +580,23 @@ function metricLink(m, report) {
   if (!report.repo || !m.source) { return label; }
   const hashPart = m.source.line ? `#L${m.source.line}` : '';
   return `[${label}](https://github.com/${report.repo}/blob/${report.head.sha}/${m.source.path}${hashPart})`;
+}
+
+/**
+ * Link a history entry to its PR (preferred) or commit. Label is the
+ * short SHA; the PR URL just takes you to the conversation page where
+ * the bench comment from that run was posted — which is where a
+ * reviewer actually wants to go when investigating a REOPENED regression.
+ * Falls back to commit URL when the commit wasn't a squash-merge (no
+ * `(#N)` in message) and plain text when no repo is configured.
+ */
+function commitOrPrLink(entry, repo) {
+  const shortSha = entry.sha.slice(0, 7);
+  if (!repo) { return `\`${shortSha}\``; }
+  const url = entry.pr
+    ? `https://github.com/${repo}/pull/${entry.pr}`
+    : `https://github.com/${repo}/commit/${entry.sha}`;
+  return `[\`${shortSha}\`](${url})`;
 }
 
 /**
@@ -723,7 +732,7 @@ function computeHistoryStatus(metric, hist) {
   const bisectCandidates = hist.commits
     .slice(peakHistIdx + 1)
     .filter((c) => c.metrics && metric.name in c.metrics)
-    .map((c) => ({ sha: c.sha, msg: c.msg }));
+    .map((c) => ({ sha: c.sha, msg: c.msg, pr: c.pr ?? null }));
 
   const currentMid = (currentCi[0] + currentCi[1]) / 2;
   const peakMid = (peakCi[0] + peakCi[1]) / 2;
@@ -734,6 +743,7 @@ function computeHistoryStatus(metric, hist) {
     peak: {
       sha: peakEntry.sha,
       msg: peakEntry.msg,
+      pr: peakEntry.pr ?? null,
       ci: peakCi,
       mean_ms: peakMetric.mean_ms,
     },

--- a/tools/bench-reporter/reporter.js
+++ b/tools/bench-reporter/reporter.js
@@ -16,11 +16,12 @@
       --repo <owner/name>     GitHub repo slug (falls back to $GITHUB_REPOSITORY)
       --repo-root <dir>       filesystem root for resolving bench sources (default: cwd)
       --wall-clock <seconds>  total bench run duration — footer metadata
+      --history <path>        bench-history.json path (default: <repo-root>/bench-history.json)
       --out <dir>             output directory (default: ./bench-report)
 
-  MVP scope: current-vs-baseline only. Cross-run taxonomy (WIN / REOPENED /
-  UNEXPLORED / peak attribution / commit impact) is a follow-up once
-  `bench-history.json` is populated.
+  Cross-run taxonomy (WIN / TIED-PEAK / REOPENED) engages automatically once
+  bench-history.json has entries. Empty or missing history file → reporter
+  falls back to current-vs-baseline only (no peak attribution rendered).
 */
 
 import fs from 'node:fs';
@@ -40,6 +41,7 @@ const baseSha = args['base-sha'] ?? '';
 const repo = args.repo ?? process.env.GITHUB_REPOSITORY ?? '';
 const repoRoot = args['repo-root'] ?? process.cwd();
 const wallClockSec = args['wall-clock'] ? Number(args['wall-clock']) : null;
+const historyPath = args.history ?? path.join(repoRoot, 'bench-history.json');
 const outDir = args.out ?? './bench-report';
 
 const NOISE_FLOOR = 2; // percent — matches autoSampleConditions
@@ -69,6 +71,11 @@ const SEVERITY_EXTREME = 75;
 const AUTO_EXPAND_MAX = 15;
 const TEASER_ROWS = 5;
 
+// Bisect candidates in the markdown "Regressions from peak" table are
+// capped at this count (nearest-to-peak bias); the full list is always
+// present in the JSON adjunct for agent use.
+const BISECT_MARKDOWN_MAX = 3;
+
 /**
  * Expected percent-change CI width for an unresolved CI given the bench's
  * absolute duration. Derived from the standard-error-of-the-difference of
@@ -81,6 +88,7 @@ function expectedNoisePp(meanMs) {
 }
 
 const benchDirs = findBenchDirs(repoRoot);
+const history = loadHistory(historyPath);
 const metrics = loadAllMetrics(resultsDir);
 const report = buildReport(metrics);
 const markdown = renderMarkdown(report);
@@ -158,6 +166,7 @@ function buildReport(metrics) {
     const expectedPp = expectedNoisePp(meanMs);
     const ratio = expectedPp > 0 ? widthPp / expectedPp : Infinity;
     const source = resolveMetricSource(m.name, benchDirs, repoRoot);
+    const historyStatus = computeHistoryStatus(m, history);
     return {
       ...m,
       meanMs,
@@ -165,11 +174,13 @@ function buildReport(metrics) {
       expectedPp,
       ratio,
       source,
+      historyStatus,
       status: classify(m.percentDelta, ratio),
     };
   });
   const summary = { faster: 0, slower: 0, 'within-noise': 0, unsure: 0, 'noise-floor-limited': 0 };
   for (const m of classified) { summary[m.status]++; }
+  const historySummary = historyStatusCounts(classified);
   return {
     head: { sha, msg, ref: process.env.GITHUB_HEAD_REF || '' },
     base: { sha: baseSha, ref: baseRef },
@@ -180,8 +191,26 @@ function buildReport(metrics) {
     sigma_abs_ms: SIGMA_ABS_MS,
     noise_ratio_tolerance: NOISE_RATIO_TOLERANCE,
     summary,
+    history_summary: historySummary,
+    history_available: history !== null && history.commits.length > 0,
     metrics: classified.map(toJsonMetric),
   };
+}
+
+/**
+ * Count metrics by cross-run status. Returns null keys only when the
+ * history file is empty/missing; otherwise three counters always present.
+ */
+function historyStatusCounts(classified) {
+  const out = { WIN: 0, 'TIED-PEAK': 0, REOPENED: 0, 'no-history': 0 };
+  for (const m of classified) {
+    if (!m.historyStatus) {
+      out['no-history']++;
+      continue;
+    }
+    out[m.historyStatus.status]++;
+  }
+  return out;
 }
 
 function classify([low, high], ratio) {
@@ -192,7 +221,7 @@ function classify([low, high], ratio) {
 }
 
 function toJsonMetric(m) {
-  return {
+  const out = {
     name: m.name,
     status: m.status,
     percent_change_ci: round2(m.percentDelta),
@@ -204,6 +233,15 @@ function toJsonMetric(m) {
     observed_noise_ratio: Number(m.ratio.toFixed(2)),
     source: m.source,
   };
+  // Cross-run fields only populated when history has data for this metric.
+  // Agents can detect absence vs "no peak" via missing key, not null.
+  if (m.historyStatus) {
+    out.history_status = m.historyStatus.status;
+    out.peak = m.historyStatus.peak;
+    out.delta_from_peak_pct = m.historyStatus.delta_from_peak_pct;
+    out.bisect_candidates = m.historyStatus.bisect_candidates;
+  }
+  return out;
 }
 
 /**
@@ -264,10 +302,18 @@ function renderMarkdown(report) {
 
   // ─── Results count line ──────────────────────────────────────────────
   const unsureTotal = inconclusive.length + tooFast.length;
-  lines.push(
-    `✅ ${faster.length} faster · ❌ ${slower.length} slower `
-      + `· 🔍 ${unsureTotal} unsure · ⚪ ${noChange.length} no change`,
-  );
+  const resultsParts = [
+    `✅ ${faster.length} faster`,
+    `❌ ${slower.length} slower`,
+    `🔍 ${unsureTotal} unsure`,
+    `⚪ ${noChange.length} no change`,
+  ];
+  // Surface REOPENED count in the headline when history has flagged any.
+  const reopenedCount = report.history_summary?.REOPENED ?? 0;
+  if (reopenedCount > 0) {
+    resultsParts.push(`📜 ${reopenedCount} reopened`);
+  }
+  lines.push(resultsParts.join(' · '));
   lines.push('');
   lines.push('---');
   lines.push('');
@@ -349,6 +395,9 @@ function renderMarkdown(report) {
     lines.push('');
   }
 
+  // ─── Regressions from peak (cross-run; only when REOPENED exists) ────
+  renderRegressionsFromPeak(lines, report);
+
   // ─── Footer ──────────────────────────────────────────────────────────
   lines.push('---');
   const footerParts = [
@@ -362,6 +411,62 @@ function renderMarkdown(report) {
   lines.push(`<sub>${footerParts.join(' · ')}</sub>`);
 
   return lines.join('\n');
+}
+
+/**
+ * Append a "Regressions from peak" section when one or more metrics are
+ * REOPENED (current CI dominated by a prior commit's CI). Actionable signal:
+ * the metric was once better and this PR — or a commit before it — gave
+ * that improvement back. Skipped entirely when history is empty or no
+ * REOPENED metrics exist.
+ */
+function renderRegressionsFromPeak(lines, report) {
+  const reopened = report.metrics.filter((m) => m.history_status === 'REOPENED');
+  if (reopened.length === 0) { return; }
+
+  // Sort by severity — largest delta-from-peak first.
+  const sorted = [...reopened].sort((a, b) => (b.delta_from_peak_pct ?? 0) - (a.delta_from_peak_pct ?? 0));
+
+  lines.push('<details>');
+  lines.push(`<summary>📜 Regressions from peak (${reopened.length})</summary>`);
+  lines.push('');
+  lines.push(
+    `These metrics were better on a prior commit than they are now. The peak CI dominates current CI — not attributable to per-sample noise. Bisect candidates are the commits between the peak and HEAD; nearest-to-peak is usually the best bet.`,
+  );
+  lines.push('');
+  lines.push('| metric | current | peak | vs peak | bisect candidates |');
+  lines.push('|---|---|---|---|---|');
+  for (const m of sorted) {
+    const currentMid = (m.mean_ms ?? ((m.this_change_ms_ci[0] + m.this_change_ms_ci[1]) / 2));
+    const peakMid = m.peak.mean_ms;
+    const deltaStr = m.delta_from_peak_pct > 0
+      ? `+${m.delta_from_peak_pct.toFixed(0)}%`
+      : `${m.delta_from_peak_pct.toFixed(0)}%`;
+    const peakShortSha = m.peak.sha.slice(0, 7);
+    const peakLink = report.repo
+      ? `[\`${peakShortSha}\`](https://github.com/${report.repo}/commit/${m.peak.sha})`
+      : `\`${peakShortSha}\``;
+    const bisectMd = (m.bisect_candidates ?? [])
+      .slice(0, BISECT_MARKDOWN_MAX)
+      .map((c) => {
+        const shortSha = c.sha.slice(0, 7);
+        return report.repo
+          ? `[\`${shortSha}\`](https://github.com/${report.repo}/commit/${c.sha})`
+          : `\`${shortSha}\``;
+      })
+      .join(', ');
+    const bisectCell = m.bisect_candidates && m.bisect_candidates.length > BISECT_MARKDOWN_MAX
+      ? `${bisectMd} +${m.bisect_candidates.length - BISECT_MARKDOWN_MAX} more`
+      : bisectMd || '—';
+    lines.push(
+      `| ${metricLink(m, report)} | ${currentMid.toFixed(1)}ms | ${
+        peakMid.toFixed(1)
+      }ms @ ${peakLink} | ${deltaStr} | ${bisectCell} |`,
+    );
+  }
+  lines.push('');
+  lines.push('</details>');
+  lines.push('');
 }
 
 /**
@@ -554,6 +659,87 @@ function formatWallClock(sec) {
   const m = Math.floor(sec / 60);
   const s = Math.round(sec % 60);
   return m > 0 ? `${m}m${s.toString().padStart(2, '0')}s` : `${s}s`;
+}
+
+/**
+ * Load bench-history.json. Returns null if missing/empty/invalid — the
+ * reporter's D3b features all gracefully degrade on a null history.
+ */
+function loadHistory(filePath) {
+  if (!filePath || !fs.existsSync(filePath)) { return null; }
+  try {
+    const parsed = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+    if (parsed.schema_version !== 1 || !Array.isArray(parsed.commits)) { return null; }
+    return parsed;
+  }
+  catch {
+    return null;
+  }
+}
+
+/**
+ * Compute per-metric cross-run status against the history file.
+ *
+ * Peak = the commit whose CI upper bound is lowest (smallest time = best
+ * perf). On exact ties, prefer the most recent entry (history is ordered
+ * chronologically by append order).
+ *
+ * Status taxonomy (current CI = this-change absolute ms):
+ *   WIN        — current CI dominates peak (current high < peak low)
+ *   REOPENED   — peak CI dominates current (peak high < current low)
+ *   TIED-PEAK  — CIs overlap (no dominance either way)
+ *
+ * Returns null when history is null/empty OR this metric has no prior
+ * entries (new bench). The reporter's caller distinguishes these cases
+ * via the `history_available` summary flag and per-metric presence.
+ */
+function computeHistoryStatus(metric, hist) {
+  if (!hist || hist.commits.length === 0) { return null; }
+  const entries = hist.commits.filter((c) => c.metrics && metric.name in c.metrics);
+  if (entries.length === 0) { return null; }
+
+  // Pick peak. Tie-break: newer commit wins (commits array is chronological).
+  let peakIdx = 0;
+  for (let i = 1; i < entries.length; i++) {
+    const candHigh = entries[i].metrics[metric.name].ci[1];
+    const peakHigh = entries[peakIdx].metrics[metric.name].ci[1];
+    if (candHigh < peakHigh) { peakIdx = i; }
+    else if (candHigh === peakHigh) { peakIdx = i; }
+  }
+  const peakEntry = entries[peakIdx];
+  const peakMetric = peakEntry.metrics[metric.name];
+  const currentCi = metric.thisChangeMs;
+  const peakCi = peakMetric.ci;
+
+  let status;
+  if (currentCi[1] < peakCi[0]) { status = 'WIN'; }
+  else if (peakCi[1] < currentCi[0]) { status = 'REOPENED'; }
+  else { status = 'TIED-PEAK'; }
+
+  // Bisect candidates: commits between peak and HEAD of history that
+  // contain this metric. Oldest-to-newest so the reviewer/agent sees
+  // the timeline in causal order.
+  const peakHistIdx = hist.commits.findIndex((c) => c.sha === peakEntry.sha);
+  const bisectCandidates = hist.commits
+    .slice(peakHistIdx + 1)
+    .filter((c) => c.metrics && metric.name in c.metrics)
+    .map((c) => ({ sha: c.sha, msg: c.msg }));
+
+  const currentMid = (currentCi[0] + currentCi[1]) / 2;
+  const peakMid = (peakCi[0] + peakCi[1]) / 2;
+  const deltaFromPeakPct = peakMid > 0 ? ((currentMid - peakMid) / peakMid) * 100 : 0;
+
+  return {
+    status,
+    peak: {
+      sha: peakEntry.sha,
+      msg: peakEntry.msg,
+      ci: peakCi,
+      mean_ms: peakMetric.mean_ms,
+    },
+    delta_from_peak_pct: Number(deltaFromPeakPct.toFixed(2)),
+    bisect_candidates: bisectCandidates,
+  };
 }
 
 // ---------- utilities ----------

--- a/tools/bench-reporter/reporter.test.js
+++ b/tools/bench-reporter/reporter.test.js
@@ -325,6 +325,30 @@ test('cross-run: WIN when current CI dominates historical peak', () => {
   assert.ok(!markdown.includes('Regressions from peak'), 'no reopened section when no REOPENED');
 });
 
+test('cross-run: peak links to PR conversation when PR number is known', () => {
+  // Peak has pr: 102 in the fixture → peak SHA in markdown should link
+  // to /pull/102, not /commit/<sha>. Takes reviewers directly to the
+  // bench comment from that PR (which is where the peak value came from).
+  const dir = writeHandcraftedResults('update-10th', [20.0, 21.0]);
+  const { report, markdown } = runReporter({
+    resultsDir: dir,
+    sha: 'feed',
+    msg: 'x',
+    baseSha: 'aaaa11',
+    repo: 'Semantic-Org/Semantic-Next',
+    history: HISTORY_FIXTURE,
+  });
+  const m = report.metrics.find((x) => x.name === 'update-10th');
+  assert.equal(m.peak.pr, 102, 'peak entry carries pr number from history');
+  assert.ok(
+    markdown.includes('[`bbbb222`](https://github.com/Semantic-Org/Semantic-Next/pull/102)'),
+    'peak SHA links to PR conversation, not commit',
+  );
+  // Bisect candidates also link to PRs.
+  assert.ok(markdown.includes('](https://github.com/Semantic-Org/Semantic-Next/pull/103)'));
+  assert.ok(markdown.includes('](https://github.com/Semantic-Org/Semantic-Next/pull/104)'));
+});
+
 test('cross-run: REOPENED when a prior commit dominates current', () => {
   // history-sample.json peak for update-10th = CI [6.0, 7.0]
   // Current CI [20.0, 21.0] is entirely above → REOPENED

--- a/tools/bench-reporter/reporter.test.js
+++ b/tools/bench-reporter/reporter.test.js
@@ -18,12 +18,23 @@ import { fileURLToPath } from 'node:url';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPORTER = path.join(__dirname, 'reporter.js');
 
-function runReporter({ fixture, sha, msg, baseSha, baseRef = 'main', runUrl = '', repo = '', wallClock = '' }) {
+function runReporter({
+  fixture,
+  sha,
+  msg,
+  baseSha,
+  baseRef = 'main',
+  runUrl = '',
+  repo = '',
+  wallClock = '',
+  history = '',
+  resultsDir = null,
+}) {
   const tmp = fs.mkdtempSync(path.join('/tmp', 'bench-report-test-'));
   const argv = [
     REPORTER,
     '--results',
-    path.join(__dirname, 'fixtures', fixture),
+    resultsDir ?? path.join(__dirname, 'fixtures', fixture),
     '--sha',
     sha,
     '--msg',
@@ -39,12 +50,44 @@ function runReporter({ fixture, sha, msg, baseSha, baseRef = 'main', runUrl = ''
   ];
   if (repo) { argv.push('--repo', repo); }
   if (wallClock) { argv.push('--wall-clock', wallClock); }
+  // Point history at a known fixture path OR a deliberate non-existent
+  // path to exercise the graceful-degrade branch. Default (no --history)
+  // resolves to <cwd>/bench-history.json which will typically exist on a
+  // D3a-landed checkout; tests opt in to a specific fixture.
+  if (history) { argv.push('--history', history); }
   // Run from repo root so resolveMetricSource can find packages/.../bench/tachometer
   const cwd = path.resolve(__dirname, '..', '..');
   execFileSync('node', argv, { stdio: ['ignore', 'pipe', 'inherit'], cwd });
   const report = JSON.parse(fs.readFileSync(path.join(tmp, 'bench-report.json'), 'utf8'));
   const markdown = fs.readFileSync(path.join(tmp, 'comment.md'), 'utf8');
   return { report, markdown };
+}
+
+/**
+ * Build a tiny tachometer JSON fixture with one metric whose this-change
+ * mean CI is the caller-specified range. Used to force specific cross-run
+ * outcomes against fixtures/history-sample.json.
+ */
+function writeHandcraftedResults(metricName, thisChangeCi, tipOfTreeCi = [10, 11]) {
+  const dir = fs.mkdtempSync('/tmp/bench-reporter-handcraft-');
+  const data = {
+    benchmarks: [
+      {
+        name: `this-change [${metricName}]`,
+        measurement: { name: metricName, mode: 'performance', entryName: metricName },
+        mean: { low: thisChangeCi[0], high: thisChangeCi[1] },
+        differences: [null, { absolute: { low: -1, high: 1 }, percentChange: { low: -5, high: 5 } }],
+      },
+      {
+        name: `tip-of-tree [${metricName}]`,
+        measurement: { name: metricName, mode: 'performance', entryName: metricName },
+        mean: { low: tipOfTreeCi[0], high: tipOfTreeCi[1] },
+        differences: [{ absolute: { low: -1, high: 1 }, percentChange: { low: -5, high: 5 } }, null],
+      },
+    ],
+  };
+  fs.writeFileSync(path.join(dir, 'handcrafted.json'), JSON.stringify(data));
+  return dir;
 }
 
 test('real-delta fixture — summary counts and key verdicts', () => {
@@ -260,6 +303,99 @@ test('severity emoji suffix placement', () => {
   assert.ok(/\+18% \(3ms\) ❗/.test(markdown), 'significant slower → ❗ trailing');
   // Sub-15% rows get no emoji suffix (but still render in the table)
   assert.ok(/-10% \(8ms\) \|/.test(markdown), 'sub-15% faster has no suffix');
+});
+
+const HISTORY_FIXTURE = path.join(__dirname, 'fixtures', 'history-sample.json');
+
+test('cross-run: WIN when current CI dominates historical peak', () => {
+  // history-sample.json has update-10th peak CI [6.0, 7.0] at bbbb...
+  // Current CI [4.5, 5.5] is entirely below → WIN
+  const dir = writeHandcraftedResults('update-10th', [4.5, 5.5]);
+  const { report, markdown } = runReporter({
+    resultsDir: dir,
+    sha: 'feedbeef',
+    msg: 'x',
+    baseSha: 'aaaa11',
+    history: HISTORY_FIXTURE,
+  });
+  const m = report.metrics.find((x) => x.name === 'update-10th');
+  assert.equal(m.history_status, 'WIN');
+  assert.equal(m.peak.sha, 'bbbb222222222222', 'peak commit is the best prior entry');
+  assert.ok(m.delta_from_peak_pct < 0, 'delta is negative when current is faster than peak');
+  assert.ok(!markdown.includes('Regressions from peak'), 'no reopened section when no REOPENED');
+});
+
+test('cross-run: REOPENED when a prior commit dominates current', () => {
+  // history-sample.json peak for update-10th = CI [6.0, 7.0]
+  // Current CI [20.0, 21.0] is entirely above → REOPENED
+  const dir = writeHandcraftedResults('update-10th', [20.0, 21.0]);
+  const { report, markdown } = runReporter({
+    resultsDir: dir,
+    sha: 'eeee55',
+    msg: 'x',
+    baseSha: 'aaaa11',
+    repo: 'Semantic-Org/Semantic-Next',
+    history: HISTORY_FIXTURE,
+  });
+  const m = report.metrics.find((x) => x.name === 'update-10th');
+  assert.equal(m.history_status, 'REOPENED');
+  assert.equal(m.peak.sha, 'bbbb222222222222');
+  assert.ok(m.delta_from_peak_pct > 50, `delta should be large positive when reopened (got ${m.delta_from_peak_pct})`);
+
+  // Bisect candidates = commits after peak (cccc, dddd)
+  const bisectShas = m.bisect_candidates.map((c) => c.sha);
+  assert.deepEqual(bisectShas, ['cccc333333333333', 'dddd444444444444']);
+
+  // Markdown renders the REOPENED section when REOPENED metrics exist
+  assert.ok(markdown.includes('📜 Regressions from peak (1)'), 'reopened section with count');
+  assert.ok(markdown.includes('`bbbb222`'), 'peak SHA linked');
+  assert.ok(markdown.includes('📜 1 reopened'), 'headline count includes reopened');
+});
+
+test('cross-run: TIED-PEAK when CIs overlap', () => {
+  // history peak for update-10th = [6.0, 7.0]
+  // Current CI [6.5, 7.5] overlaps → TIED-PEAK
+  const dir = writeHandcraftedResults('update-10th', [6.5, 7.5]);
+  const { report } = runReporter({
+    resultsDir: dir,
+    sha: 'aaaa',
+    msg: 'x',
+    baseSha: 'bbbb22',
+    history: HISTORY_FIXTURE,
+  });
+  const m = report.metrics.find((x) => x.name === 'update-10th');
+  assert.equal(m.history_status, 'TIED-PEAK');
+});
+
+test('cross-run: graceful degrade when history file is missing', () => {
+  const dir = writeHandcraftedResults('update-10th', [10, 11]);
+  const { report, markdown } = runReporter({
+    resultsDir: dir,
+    sha: 'abc',
+    msg: 'x',
+    baseSha: 'def',
+    history: '/tmp/does-not-exist-bench-history.json',
+  });
+  const m = report.metrics.find((x) => x.name === 'update-10th');
+  assert.equal(report.history_available, false);
+  assert.ok(!('history_status' in m), 'no cross-run fields when history missing');
+  assert.ok(!('peak' in m));
+  assert.ok(!markdown.includes('Regressions from peak'));
+  assert.ok(!markdown.includes('reopened'));
+});
+
+test('cross-run: graceful degrade for a brand-new metric not in history', () => {
+  const dir = writeHandcraftedResults('unknown-metric', [5, 6]);
+  const { report } = runReporter({
+    resultsDir: dir,
+    sha: 'abc',
+    msg: 'x',
+    baseSha: 'def',
+    history: HISTORY_FIXTURE,
+  });
+  const m = report.metrics.find((x) => x.name === 'unknown-metric');
+  assert.equal(report.history_available, true, 'history file loaded');
+  assert.ok(!('history_status' in m), 'metric absent from history → no cross-run fields');
 });
 
 test('classify boundary behavior', async () => {


### PR DESCRIPTION
Stacked on #145 (D3a). Reads the history file D3a populates, attributes a peak commit per metric, classifies current vs peak (WIN / TIED-PEAK / REOPENED), and surfaces regressions-from-peak with bisect candidates.

**Base for review:** target main; if #145 merges first this rebases clean. If it doesn't, this PR's diff includes D3a's files too — review D3a first.

## What ships

**Reporter (`reporter.js`):**

- New CLI `--history <path>`, default `<repo-root>/bench-history.json`. Graceful degrade on missing/invalid/empty file — existing rubric rendering is unaffected.
- \`computeHistoryStatus(metric, history)\` — finds peak (commit with lowest CI upper bound, most-recent wins ties), classifies current vs peak:
  - **WIN** — current dominates peak (current high < peak low). Metric has a new best.
  - **REOPENED** — peak dominates current (peak high < current low). Metric lost an improvement we previously had.
  - **TIED-PEAK** — CIs overlap. No dominance either way.
- Bisect candidates = commits after peak in history, full list in JSON, capped at 3 in markdown.
- JSON adjunct gains top-level \`history_available\` + \`history_summary\` and per-metric \`history_status\`, \`peak\`, \`delta_from_peak_pct\`, \`bisect_candidates\` when history has data.
- Headline results line gets \`📜 N reopened\` when REOPENED > 0.
- Collapsible "Regressions from peak" renders ONLY when REOPENED metrics exist — clean PRs don't carry empty cross-run furniture.

**Workflow (\`benchmarks-report.yml\`):**

- Comment job overlays \`origin/main:bench-history.json\` onto the PR checkout before running the reporter. Protects against stale PR branches missing recent D3a-merged history updates. Non-fatal if main has no file yet.

## Why deferred bootstrap is OK

The continuation plan's "bootstrap from last N merged PRs' artifacts" is deliberately left out. Two reasons:

1. **Post-squash SHAs don't match artifact SHAs.** PR artifacts are indexed by the pre-squash head SHA. After merge, main has a different (squashed) SHA. Using PR SHAs as history keys muddies the cross-run story.
2. **Organic fill is fast.** Once #145 lands, every main push populates history. Within a few days it's non-empty for most actively-merged metrics.

If someone wants a one-shot seed later, \`tools/bench-reporter/append-history.js\`'s CLI is sufficient — wrap it in a loop over historical runs.

## Test plan

13 tests in \`reporter.test.js\` (up from 8):

- WIN / REOPENED / TIED-PEAK classification via handcrafted tachometer JSON against a seeded history fixture
- Bisect-candidates correctly indexed post-peak (REOPENED case)
- Graceful degrade on missing history file
- Graceful degrade on metric not in history (new bench first run)
- Existing rubric rendering unaffected by history presence/absence

Full suite green locally (\`node --test tools/bench-reporter/reporter.test.js\`).

## Example rendering

Against the real-delta fixture + seeded history (update-10th peak at 6.5ms, current ~21ms):

    ✅ 10 faster · ❌ 5 slower · 🔍 3 unsure · ⚪ 3 no change · 📜 2 reopened

    <details>
    <summary>📜 Regressions from peak (2)</summary>

    | metric | current | peak | vs peak | bisect candidates |
    |---|---|---|---|---|
    | update-10th | 21.3ms | 6.5ms @ bbbb222 | +228% | cccc333, dddd444 |
    | toggle-middle | 8.7ms | 7.5ms @ bbbb222 | +15% | cccc333, dddd444 |

    </details>