### PR TITLE
Build(hooks): Block agent commits to main and enforce subject vocab

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "@semantic-ui/core",
       "version": "0.18.0",
+      "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [
         "internal-packages/*",
@@ -25,8 +26,6 @@
         "@semantic-ui/specs": "^0.18.0"
       },
       "devDependencies": {
-        "@commitlint/cli": "^20.5.0",
-        "@commitlint/config-conventional": "^20.5.0",
         "@types/node": "^25.6.0",
         "@typescript-eslint/eslint-plugin": "^8.58.1",
         "@typescript-eslint/parser": "^8.58.1",
@@ -1908,289 +1907,6 @@
       ],
       "engines": {
         "node": ">=16"
-      }
-    },
-    "node_modules/@commitlint/cli": {
-      "version": "20.5.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-20.5.0.tgz",
-      "integrity": "sha512-yNkyN/tuKTJS3wdVfsZ2tXDM4G4Gi7z+jW54Cki8N8tZqwKBltbIvUUrSbT4hz1bhW/h0CdR+5sCSpXD+wMKaQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@commitlint/format": "^20.5.0",
-        "@commitlint/lint": "^20.5.0",
-        "@commitlint/load": "^20.5.0",
-        "@commitlint/read": "^20.5.0",
-        "@commitlint/types": "^20.5.0",
-        "tinyexec": "^1.0.0",
-        "yargs": "^17.0.0"
-      },
-      "bin": {
-        "commitlint": "cli.js"
-      },
-      "engines": {
-        "node": ">=v18"
-      }
-    },
-    "node_modules/@commitlint/config-conventional": {
-      "version": "20.5.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-20.5.0.tgz",
-      "integrity": "sha512-t3Ni88rFw1XMa4nZHgOKJ8fIAT9M2j5TnKyTqJzsxea7FUetlNdYFus9dz+MhIRZmc16P0PPyEfh6X2d/qw8SA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@commitlint/types": "^20.5.0",
-        "conventional-changelog-conventionalcommits": "^9.2.0"
-      },
-      "engines": {
-        "node": ">=v18"
-      }
-    },
-    "node_modules/@commitlint/config-validator": {
-      "version": "20.5.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/config-validator/-/config-validator-20.5.0.tgz",
-      "integrity": "sha512-T/Uh6iJUzyx7j35GmHWdIiGRQB+ouZDk0pwAaYq4SXgB54KZhFdJ0vYmxiW6AMYICTIWuyMxDBl1jK74oFp/Gw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@commitlint/types": "^20.5.0",
-        "ajv": "^8.11.0"
-      },
-      "engines": {
-        "node": ">=v18"
-      }
-    },
-    "node_modules/@commitlint/ensure": {
-      "version": "20.5.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-20.5.0.tgz",
-      "integrity": "sha512-IpHqAUesBeW1EDDdjzJeaOxU9tnogLAyXLRBn03SHlj1SGENn2JGZqSWGkFvBJkJzfXAuCNtsoYzax+ZPS+puw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@commitlint/types": "^20.5.0",
-        "lodash.camelcase": "^4.3.0",
-        "lodash.kebabcase": "^4.1.1",
-        "lodash.snakecase": "^4.1.1",
-        "lodash.startcase": "^4.4.0",
-        "lodash.upperfirst": "^4.3.1"
-      },
-      "engines": {
-        "node": ">=v18"
-      }
-    },
-    "node_modules/@commitlint/execute-rule": {
-      "version": "20.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/execute-rule/-/execute-rule-20.0.0.tgz",
-      "integrity": "sha512-xyCoOShoPuPL44gVa+5EdZsBVao/pNzpQhkzq3RdtlFdKZtjWcLlUFQHSWBuhk5utKYykeJPSz2i8ABHQA+ZZw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=v18"
-      }
-    },
-    "node_modules/@commitlint/format": {
-      "version": "20.5.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/format/-/format-20.5.0.tgz",
-      "integrity": "sha512-TI9EwFU/qZWSK7a5qyXMpKPPv3qta7FO4tKW+Wt2al7sgMbLWTsAcDpX1cU8k16TRdsiiet9aOw0zpvRXNJu7Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@commitlint/types": "^20.5.0",
-        "picocolors": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=v18"
-      }
-    },
-    "node_modules/@commitlint/is-ignored": {
-      "version": "20.5.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-20.5.0.tgz",
-      "integrity": "sha512-JWLarAsurHJhPozbuAH6GbP4p/hdOCoqS9zJMfqwswne+/GPs5V0+rrsfOkP68Y8PSLphwtFXV0EzJ+GTXTTGg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@commitlint/types": "^20.5.0",
-        "semver": "^7.6.0"
-      },
-      "engines": {
-        "node": ">=v18"
-      }
-    },
-    "node_modules/@commitlint/lint": {
-      "version": "20.5.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-20.5.0.tgz",
-      "integrity": "sha512-jiM3hNUdu04jFBf1VgPdjtIPvbuVfDTBAc6L98AWcoLjF5sYqkulBHBzlVWll4rMF1T5zeQFB6r//a+s+BBKlA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@commitlint/is-ignored": "^20.5.0",
-        "@commitlint/parse": "^20.5.0",
-        "@commitlint/rules": "^20.5.0",
-        "@commitlint/types": "^20.5.0"
-      },
-      "engines": {
-        "node": ">=v18"
-      }
-    },
-    "node_modules/@commitlint/load": {
-      "version": "20.5.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-20.5.0.tgz",
-      "integrity": "sha512-sLhhYTL/KxeOTZjjabKDhwidGZan84XKK1+XFkwDYL/4883kIajcz/dZFAhBJmZPtL8+nBx6bnkzA95YxPeDPw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@commitlint/config-validator": "^20.5.0",
-        "@commitlint/execute-rule": "^20.0.0",
-        "@commitlint/resolve-extends": "^20.5.0",
-        "@commitlint/types": "^20.5.0",
-        "cosmiconfig": "^9.0.1",
-        "cosmiconfig-typescript-loader": "^6.1.0",
-        "is-plain-obj": "^4.1.0",
-        "lodash.mergewith": "^4.6.2",
-        "picocolors": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=v18"
-      }
-    },
-    "node_modules/@commitlint/message": {
-      "version": "20.4.3",
-      "resolved": "https://registry.npmjs.org/@commitlint/message/-/message-20.4.3.tgz",
-      "integrity": "sha512-6akwCYrzcrFcTYz9GyUaWlhisY4lmQ3KvrnabmhoeAV8nRH4dXJAh4+EUQ3uArtxxKQkvxJS78hNX2EU3USgxQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=v18"
-      }
-    },
-    "node_modules/@commitlint/parse": {
-      "version": "20.5.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/parse/-/parse-20.5.0.tgz",
-      "integrity": "sha512-SeKWHBMk7YOTnnEWUhx+d1a9vHsjjuo6Uo1xRfPNfeY4bdYFasCH1dDpAv13Lyn+dDPOels+jP6D2GRZqzc5fA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@commitlint/types": "^20.5.0",
-        "conventional-changelog-angular": "^8.2.0",
-        "conventional-commits-parser": "^6.3.0"
-      },
-      "engines": {
-        "node": ">=v18"
-      }
-    },
-    "node_modules/@commitlint/read": {
-      "version": "20.5.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/read/-/read-20.5.0.tgz",
-      "integrity": "sha512-JDEIJ2+GnWpK8QqwfmW7O42h0aycJEWNqcdkJnyzLD11nf9dW2dWLTVEa8Wtlo4IZFGLPATjR5neA5QlOvIH1w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@commitlint/top-level": "^20.4.3",
-        "@commitlint/types": "^20.5.0",
-        "git-raw-commits": "^5.0.0",
-        "minimist": "^1.2.8",
-        "tinyexec": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=v18"
-      }
-    },
-    "node_modules/@commitlint/resolve-extends": {
-      "version": "20.5.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-20.5.0.tgz",
-      "integrity": "sha512-3SHPWUW2v0tyspCTcfSsYml0gses92l6TlogwzvM2cbxDgmhSRc+fldDjvGkCXJrjSM87BBaWYTPWwwyASZRrg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@commitlint/config-validator": "^20.5.0",
-        "@commitlint/types": "^20.5.0",
-        "global-directory": "^4.0.1",
-        "import-meta-resolve": "^4.0.0",
-        "lodash.mergewith": "^4.6.2",
-        "resolve-from": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=v18"
-      }
-    },
-    "node_modules/@commitlint/rules": {
-      "version": "20.5.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-20.5.0.tgz",
-      "integrity": "sha512-5NdQXQEdnDPT5pK8O39ZA7HohzPRHEsDGU23cyVCNPQy4WegAbAwrQk3nIu7p2sl3dutPk8RZd91yKTrMTnRkQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@commitlint/ensure": "^20.5.0",
-        "@commitlint/message": "^20.4.3",
-        "@commitlint/to-lines": "^20.0.0",
-        "@commitlint/types": "^20.5.0"
-      },
-      "engines": {
-        "node": ">=v18"
-      }
-    },
-    "node_modules/@commitlint/to-lines": {
-      "version": "20.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/to-lines/-/to-lines-20.0.0.tgz",
-      "integrity": "sha512-2l9gmwiCRqZNWgV+pX1X7z4yP0b3ex/86UmUFgoRt672Ez6cAM2lOQeHFRUTuE6sPpi8XBCGnd8Kh3bMoyHwJw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=v18"
-      }
-    },
-    "node_modules/@commitlint/top-level": {
-      "version": "20.4.3",
-      "resolved": "https://registry.npmjs.org/@commitlint/top-level/-/top-level-20.4.3.tgz",
-      "integrity": "sha512-qD9xfP6dFg5jQ3NMrOhG0/w5y3bBUsVGyJvXxdWEwBm8hyx4WOk3kKXw28T5czBYvyeCVJgJJ6aoJZUWDpaacQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "escalade": "^3.2.0"
-      },
-      "engines": {
-        "node": ">=v18"
-      }
-    },
-    "node_modules/@commitlint/types": {
-      "version": "20.5.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-20.5.0.tgz",
-      "integrity": "sha512-ZJoS8oSq2CAZEpc/YI9SulLrdiIyXeHb/OGqGrkUP6Q7YV+0ouNAa7GjqRdXeQPncHQIDz/jbCTlHScvYvO/gA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "conventional-commits-parser": "^6.3.0",
-        "picocolors": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=v18"
-      }
-    },
-    "node_modules/@conventional-changelog/git-client": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@conventional-changelog/git-client/-/git-client-2.7.0.tgz",
-      "integrity": "sha512-j7A8/LBEQ+3rugMzPXoKYzyUPpw/0CBQCyvtTR7Lmu4olG4yRC/Tfkq79Mr3yuPs0SUitlO2HwGP3gitMJnRFw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@simple-libs/child-process-utils": "^1.0.0",
-        "@simple-libs/stream-utils": "^1.2.0",
-        "semver": "^7.5.2"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "conventional-commits-filter": "^5.0.0",
-        "conventional-commits-parser": "^6.4.0"
-      },
-      "peerDependenciesMeta": {
-        "conventional-commits-filter": {
-          "optional": true
-        },
-        "conventional-commits-parser": {
-          "optional": true
-        }
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -4636,35 +4352,6 @@
       "resolved": "packages/utils",
       "link": true
     },
-    "node_modules/@simple-libs/child-process-utils": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@simple-libs/child-process-utils/-/child-process-utils-1.0.2.tgz",
-      "integrity": "sha512-/4R8QKnd/8agJynkNdJmNw2MBxuFTRcNFnE5Sg/G+jkSsV8/UBgULMzhizWWW42p8L5H7flImV2ATi79Ove2Tw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@simple-libs/stream-utils": "^1.2.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://ko-fi.com/dangreen"
-      }
-    },
-    "node_modules/@simple-libs/stream-utils": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@simple-libs/stream-utils/-/stream-utils-1.2.0.tgz",
-      "integrity": "sha512-KxXvfapcixpz6rVEB6HPjOUZT22yN6v0vI0urQSk1L8MlEWPDFCZkhw2xmkyoTGYeFw7tWTZd7e3lVzRZRN/EA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://ko-fi.com/dangreen"
-      }
-    },
     "node_modules/@sindresorhus/is": {
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-5.6.0.tgz",
@@ -6380,13 +6067,6 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
-    "node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
-      "license": "Python-2.0"
-    },
     "node_modules/array-back": {
       "version": "6.2.3",
       "resolved": "https://registry.npmjs.org/array-back/-/array-back-6.2.3.tgz",
@@ -6396,13 +6076,6 @@
       "engines": {
         "node": ">=12.17"
       }
-    },
-    "node_modules/array-ify": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
-      "integrity": "sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/assertion-error": {
       "version": "2.0.1",
@@ -6662,16 +6335,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/callsites": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
-      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001787",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001787.tgz",
@@ -6769,21 +6432,6 @@
       "license": "ISC",
       "engines": {
         "node": ">= 12"
-      }
-    },
-    "node_modules/cliui": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.1",
-        "wrap-ansi": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/co": {
@@ -7027,17 +6675,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/compare-func": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/compare-func/-/compare-func-2.0.0.tgz",
-      "integrity": "sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "array-ify": "^1.0.0",
-        "dot-prop": "^5.1.0"
-      }
-    },
     "node_modules/content-disposition": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
@@ -7058,49 +6695,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/conventional-changelog-angular": {
-      "version": "8.3.1",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-8.3.1.tgz",
-      "integrity": "sha512-6gfI3otXK5Ph5DfCOI1dblr+kN3FAm5a97hYoQkqNZxOaYa5WKfXH+AnpsmS+iUH2mgVC2Cg2Qw9m5OKcmNrIg==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "compare-func": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/conventional-changelog-conventionalcommits": {
-      "version": "9.3.1",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-9.3.1.tgz",
-      "integrity": "sha512-dTYtpIacRpcZgrvBYvBfArMmK2xvIpv2TaxM0/ZI5CBtNUzvF2x0t15HsbRABWprS6UPmvj+PzHVjSx4qAVKyw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "compare-func": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/conventional-commits-parser": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-6.4.0.tgz",
-      "integrity": "sha512-tvRg7FIBNlyPzjdG8wWRlPHQJJHI7DylhtRGeU9Lq+JuoPh5BKpPRX83ZdLrvXuOSu5Eo/e7SzOQhU4Hd2Miuw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@simple-libs/stream-utils": "^1.2.0",
-        "meow": "^13.0.0"
-      },
-      "bin": {
-        "conventional-commits-parser": "dist/cli/index.js"
-      },
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/convert-source-map": {
@@ -7171,51 +6765,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/cosmiconfig": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.1.tgz",
-      "integrity": "sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "env-paths": "^2.2.1",
-        "import-fresh": "^3.3.0",
-        "js-yaml": "^4.1.0",
-        "parse-json": "^5.2.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/d-fischer"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.9.5"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/cosmiconfig-typescript-loader": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-6.3.0.tgz",
-      "integrity": "sha512-Akr82WH1Wfqatyiqpj8HDkO2o2KmJRu1FhKfSNJP3K4IdXwHfEyL7MOb62i1AGQVLtIQM+iCE9CGOtrfhR+mmA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "jiti": "2.6.1"
-      },
-      "engines": {
-        "node": ">=v18"
-      },
-      "peerDependencies": {
-        "@types/node": "*",
-        "cosmiconfig": ">=9",
-        "typescript": ">=5"
       }
     },
     "node_modules/cross-spawn": {
@@ -7395,19 +6944,6 @@
         "node": ">=0.10"
       }
     },
-    "node_modules/dot-prop": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
-      "integrity": "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-obj": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/dprint": {
       "version": "0.54.0",
       "resolved": "https://registry.npmjs.org/dprint/-/dprint-0.54.0.tgz",
@@ -7520,26 +7056,6 @@
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
-    "node_modules/env-paths": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
-      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/error-ex": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
-      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-arrayish": "^0.2.1"
       }
     },
     "node_modules/error-stack-parser-es": {
@@ -8495,16 +8011,6 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/get-caller-file": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": "6.* || 8.* || >= 10.*"
-      }
-    },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -8555,23 +8061,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/git-raw-commits": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-5.0.1.tgz",
-      "integrity": "sha512-Y+csSm2GD/PCSh6Isd/WiMjNAydu0VBiG9J7EdQsNA5P9uXvLayqjmTsNlK5Gs9IhblFZqOU0yid5Il5JPoLiQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@conventional-changelog/git-client": "^2.6.0",
-        "meow": "^13.0.0"
-      },
-      "bin": {
-        "git-raw-commits": "src/cli.js"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/glob": {
       "version": "13.0.6",
       "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
@@ -8602,22 +8091,6 @@
       },
       "engines": {
         "node": ">=10.13.0"
-      }
-    },
-    "node_modules/global-directory": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/global-directory/-/global-directory-4.0.1.tgz",
-      "integrity": "sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ini": "4.1.1"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/globalyzer": {
@@ -8888,44 +8361,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/import-fresh": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
-      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "parent-module": "^1.0.0",
-        "resolve-from": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/import-fresh/node_modules/resolve-from": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/import-meta-resolve": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
-      "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -8952,16 +8387,6 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
-    },
-    "node_modules/ini": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-4.1.1.tgz",
-      "integrity": "sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
     },
     "node_modules/inquirer": {
       "version": "13.4.1",
@@ -9007,13 +8432,6 @@
       "engines": {
         "node": ">= 0.10"
       }
-    },
-    "node_modules/is-arrayish": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
@@ -9105,29 +8523,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
-      }
-    },
-    "node_modules/is-obj": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
-      "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/is-plain-obj": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
-      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-potential-custom-element-name": {
@@ -9228,8 +8623,8 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
-      "devOptional": true,
       "license": "MIT",
+      "optional": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -9249,19 +8644,6 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
     },
     "node_modules/jsdom": {
       "version": "29.0.2",
@@ -9331,13 +8713,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/json-parse-even-better-errors": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
-      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true,
       "license": "MIT"
     },
@@ -10130,13 +9505,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/lines-and-columns": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
-      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/lit": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.2.tgz",
@@ -10237,20 +9605,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/lodash.kebabcase": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz",
-      "integrity": "sha512-N8XRTIMMqqDgSy4VLKPnJ/+hpGZN+PHQiJnSenYqPaVV/NCqEogTnAdZLQiGKhxX+JCs8waWq2t1XHWKOmlY8g==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/lodash.mergewith": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
-      "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/lodash.once": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
@@ -10258,31 +9612,10 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/lodash.snakecase": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
-      "integrity": "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/lodash.startcase": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.startcase/-/lodash.startcase-4.4.0.tgz",
-      "integrity": "sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/lodash.truncate": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
       "integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/lodash.upperfirst": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/lodash.upperfirst/-/lodash.upperfirst-4.3.1.tgz",
-      "integrity": "sha512-sReKOYJIJf74dhJONhU4e0/shzi1trVbSWDOhKYE5XV2O+H7Sb2Dihwuc7xWxVl+DgFPyTqIN3zMfT9cq5iWDg==",
       "dev": true,
       "license": "MIT"
     },
@@ -10377,19 +9710,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/meow": {
-      "version": "13.2.0",
-      "resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",
-      "integrity": "sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/merge-descriptors": {
@@ -10544,16 +9864,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/minimist": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/minipass": {
@@ -10824,38 +10134,6 @@
       "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
       "dev": true,
       "license": "(MIT AND Zlib)"
-    },
-    "node_modules/parent-module": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
-      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "callsites": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/parse-json": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
-      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.0.0",
-        "error-ex": "^1.3.1",
-        "json-parse-even-better-errors": "^2.3.0",
-        "lines-and-columns": "^1.1.6"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/parse5": {
       "version": "8.0.0",
@@ -11411,16 +10689,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/require-directory": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -11457,16 +10725,6 @@
       "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/resolve-from": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
-      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/resolve-path": {
       "version": "1.4.0",
@@ -14232,24 +13490,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/wrap-ansi": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -14295,51 +13535,12 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/y18n": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
-      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/yargs": {
-      "version": "17.7.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cliui": "^8.0.1",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.3",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^21.1.1"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/yargs-parser": {
-      "version": "21.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
     },
     "node_modules/ylru": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -210,7 +210,8 @@
     "ci:test": "vitest --c tests/configs/vitest/ci-test-all.config.js",
     "ci:test:unit": "vitest --c tests/configs/vitest/ci-test-unit.config.js",
     "ci:test:browser": "vitest --c tests/configs/vitest/ci-test-browser.config.js",
-    "test:cdn": "cd tools/cdn && npx vitest run --config vitest.config.js"
+    "test:cdn": "cd tools/cdn && npx vitest run --config vitest.config.js",
+    "postinstall": "npx simple-git-hooks"
   },
   "wireit": {
     "dev": {
@@ -346,8 +347,6 @@
     "@pagefind/modular-ui": "^1.3.0"
   },
   "devDependencies": {
-    "@commitlint/cli": "^20.5.0",
-    "@commitlint/config-conventional": "^20.5.0",
     "@types/node": "^25.6.0",
     "@typescript-eslint/eslint-plugin": "^8.58.1",
     "@typescript-eslint/parser": "^8.58.1",
@@ -386,8 +385,8 @@
     "tools/cdn"
   ],
   "simple-git-hooks": {
-    "pre-commit": "STAGED=$(git diff --cached --name-only --diff-filter=ACM); npx dprint fmt --staged && echo \"$STAGED\" | xargs -r git add",
-    "commit-msg": "if grep -qi 'Co-Authored-By:' \"$1\"; then echo 'Error: Commit messages must not contain Co-Authored-By lines.'; exit 1; fi"
+    "pre-commit": "bash tools/hooks/pre-commit",
+    "commit-msg": "bash tools/hooks/commit-msg \"$1\""
   },
   "overrides": {
     "vite": "^7",

--- a/tools/hooks/commit-msg
+++ b/tools/hooks/commit-msg
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+MSG_FILE="$1"
+
+if grep -qi 'Co-Authored-By:' "$MSG_FILE"; then
+  echo 'Error: Commit messages must not contain Co-Authored-By lines.'
+  exit 1
+fi
+
+if [ -n "$CLAUDECODE" ]; then
+  subject=$(head -1 "$MSG_FILE")
+  vocab='Feat|Bug|Docs|Chore|AI|Test|Perf|Refactor|Build|BREAKING'
+  pattern="^(${vocab})(/(${vocab}))?(\\([a-z][a-z0-9-]*\\))?: [A-Z].*[^.]\$"
+  if ! echo "$subject" | grep -qE "$pattern"; then
+    cat <<EOF
+Error: Subject must match 'Category: Description' format.
+Got:      $subject
+Expected: Feat: Add cache for subtemplate renders
+          Feat(reactivity): Add foo                  (with monorepo scope)
+          Feat/Bug: Add protectedKeys to prevent X   (compound, rare)
+Vocabulary: Feat, Bug, Docs, Chore, AI, Test, Perf, Refactor, Build, BREAKING
+Both category and description capitalized. No trailing period.
+EOF
+    exit 1
+  fi
+fi

--- a/tools/hooks/pre-commit
+++ b/tools/hooks/pre-commit
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+if [ -n "$CLAUDECODE" ]; then
+  branch=$(git rev-parse --abbrev-ref HEAD)
+  if [ "$branch" = "main" ]; then
+    echo "Error: Agents cannot commit directly to main. Switch to a branch first."
+    echo "Bypass: SKIP_SIMPLE_GIT_HOOKS=1 (only when explicitly delegated)"
+    exit 1
+  fi
+fi
+
+STAGED=$(git diff --cached --name-only --diff-filter=ACM)
+npx dprint fmt --staged && echo "$STAGED" | xargs -r git add


### PR DESCRIPTION
## Summary

Adds two agent-only commit-hook rules, gated on the `CLAUDECODE` env var so they never fire for human commits:

- **Block direct commits to `main`** — agents must work on a branch. Prevents agent-authored commits from landing in `main` directly (squash via PR is the supported path; quick human bug-fixes to `main` are unaffected).
- **Enforce `Category(scope)?: Description` subject format** — capitalized vocabulary, optional monorepo scope, no trailing period. Compound `Feat/Bug:` prefix supported.

Both rules live in `tools/hooks/{pre-commit,commit-msg}` (called from the existing `simple-git-hooks` config). The existing `dprint fmt --staged` and `Co-Authored-By` block are preserved.

## Other changes

- `postinstall: npx simple-git-hooks` so config changes propagate on `npm install` without manual setup
- Removed unused `@commitlint/cli` and `@commitlint/config-conventional` from devDependencies (never wired up; `config-conventional` is incompatible with this repo's `Category:` format anyway)

## Bypass

`SKIP_SIMPLE_GIT_HOOKS=1 git commit ...` skips both hooks. Use only when explicitly delegating an agent to a human-context commit.

## Test plan

- [x] Subject regex validated against 13 valid + 8 invalid cases (compound prefixes, scopes, BREAKING, all categories)
- [x] Co-Authored-By block fires for both agent and human commits
- [x] Human commits (no `CLAUDECODE`) are unaffected by the vocab check
- [x] `npm install` runs `postinstall` and regenerates `.git/hooks/`
- [x] First real commit (this PR's own commit) passes both new hooks
- [ ] Manual verify: agent commit attempt on `main` is blocked with a clear error message