### PR TITLE
Chore: Remove Vestigial package.json Entries

### DIFF
--- a/package.json
+++ b/package.json
@@ -187,8 +187,6 @@
     "build:specs": "wireit",
     "build:icons": "wireit",
     "dev": "wireit",
-    "dev:workspace": "node ./internal-packages/scripts/src/build-ai-workspace.js --serve",
-    "mcp": "wireit",
     "deploy:mcp": "wireit",
     "build:docs": "wireit",
     "build:docs-packages": "wireit",
@@ -320,10 +318,6 @@
     "update-version": {
       "command": "node ./scripts/update-versions.js"
     },
-    "mcp": {
-      "command": "cd ai/mcp && node agents-server.js",
-      "service": true
-    },
     "deploy:mcp": {
       "dependencies": [
         "./tools/mcp:deploy"
@@ -379,7 +373,6 @@
     "docs/*",
     "examples/*",
     "tools/mcp",
-    "tools/devtools",
     "tools/lsp",
     "tools/benchmark",
     "tools/cdn"


### PR DESCRIPTION
Cleanup — [`package.json`](https://github.com/Semantic-Org/Semantic-Next/blob/main/package.json) entries referencing paths that no longer exist.

## Changes
- Remove vestigial script, wireit task, and workspace entries