### PR TITLE
Harness: Add PR Description Format

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,19 @@
+<!--
+Pick the tier that fits. Delete sections you don't need.
+Full spec: <pr_format> in CLAUDE.md.
+
+  Small  — title + one sentence of intent. Delete everything below.
+  Medium — keep all sections.
+  Large  — keep all sections; if plan-driven, lead with `Implements [plan name](SHA-pinned link)`.
+-->
+
+[One sentence — why this PR exists.]
+
+## Changes
+-
+
+## Risk
+N/10 — [one-line reason].
+
+## How to Test
+- [Deviations from standard only. Skip "rerun tests" / "CI passes" — those are assumed.]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,11 +126,16 @@
 
   ## Tiers
 
-  Pick the smallest tier that fits. Round up when unsure.
+  Tier by what the reviewer has to do, not by line count. A 500-line docs PR is Small; a 30-line change to the renderer's hot path is Large.
 
-  - **Small** — single concern, <50 LOC, no user-visible behavior change. Chores, docs, dep bumps, dead-code removal.
-  - **Medium** — user-visible behavior change OR multi-file refactor with bounded blast radius.
-  - **Large** — implements a plan, crosses package boundaries, or touches load-bearing internals (renderer, reactivity, templating).
+  - **Small** — no code behavior change. Reviewer can rubber-stamp. Chores, docs, harness, comments, dead-code removal, dep bumps with no API change, content additions.
+  - **Medium** — code change with user-visible effect bounded to one feature or module. Reviewer reads the diff carefully but doesn't need to think about systemic failure modes.
+  - **Large** — implements a plan, crosses package boundaries, touches load-bearing internals (renderer, reactivity, templating, compiler), or changes a public API. Reviewer should slow down and consider named failure modes.
+
+  Self-test, in order:
+
+  - If you can't name a failure mode worth listing, it's not Large.
+  - If you can't name a user-facing behavior change, it's not Medium.
 
   ## Titles
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,6 +121,88 @@
   PR titles follow this same format — they become the squash commit subject in `main` (with `(#NNN)` appended). Squash body is empty by repo setting; rich context belongs in the PR description (lives on github.com), not in commit bodies.
 </commit_format>
 
+<pr_format>
+  PR descriptions are read by a stranger who didn't watch you build it. They want to know what is now true in the codebase — not what changed in the repo, not how you got here, not whether you verified it. The diff defends itself; process narration belongs in the conversation log.
+
+  ## Tiers
+
+  Pick the smallest tier that fits. Round up when unsure.
+
+  - **Small** — single concern, <50 LOC, no user-visible behavior change. Chores, docs, dep bumps, dead-code removal.
+  - **Medium** — user-visible behavior change OR multi-file refactor with bounded blast radius.
+  - **Large** — implements a plan, crosses package boundaries, or touches load-bearing internals (renderer, reactivity, templating).
+
+  ## Titles
+
+  Title format follows `<commit_format>`. Additional rules:
+
+  - 3–5 words after the prefix. After drafting, cut every word that doesn't carry meaning.
+  - Concept names, not literal paths: `Make Integrations Folder`, not `Move integrations/astro/src/`.
+  - Concrete verbs: Make, Move, Swap, Group, Add. Prefer Remove over Drop. Avoid Relocate, Re-anchor, Configure.
+  - Title is the primary change only. Secondary work goes in body bullets, not in `X and Y` titles.
+
+  | Before | After |
+  |---|---|
+  | Refactor: Relocate astro integration to integrations/ and prep for publish | Chore: Make Integrations Folder and Move Astro |
+  | Build: Move bench tooling under tools/ci/bench/ and relocate bench-history.json | Chore: Group CI Bench Tools |
+  | Chore: Remove broken package.json refs | Chore: Remove Vestigial package.json Entries |
+
+  ## Body by tier
+
+  ### Small
+
+  One or two sentences of intent. `## Changes` is optional; omit when the title says it all.
+
+  ### Medium
+
+  ```
+  [One sentence — why this PR exists.]
+
+  ## Changes
+  - [Outcome bullet]
+  - [Outcome bullet]
+
+  ## Risk
+  N/10 — [one-line reason].
+  Failure modes: [bulleted list — only when score ≥5 or blast radius is non-obvious]
+
+  ## How to Test
+  - [Deviations from standard only. Skip "rerun tests" / "CI passes" — those are assumed.]
+  ```
+
+  ### Large
+
+  Same as Medium, plus:
+
+  - If plan-driven, lead the framing sentence with `Implements [plan name](permalink-at-PR-creation-SHA)`. Get the SHA via `git log -1 --format=%H ai/plans/foo.md` and form `https://github.com/Semantic-Org/Semantic-Next/blob/<sha>/ai/plans/foo.md`.
+  - `## Risk` failure-modes list is mandatory.
+  - Body may be longer, but bullets still describe outcomes, not mechanisms.
+
+  ## Risk score is routing metadata
+
+  The score tells the reviewer (or a code-review subagent / `/ultrareview`) how much attention to spend. A 2/10 Medium says "review this fast." A 7/10 Large says "slow down — look at the failure modes." It is not a confidence performance; keep it honest.
+
+  ## Hotlinking
+
+  Default: don't. Mentioned files do not need links — reviewers can find them.
+
+  Exceptions:
+  - Plan-driven Large PRs always link the plan at the PR-creation SHA.
+  - Large PRs may link a specific line (`...#L123`) when a reviewer should look at one place specifically — e.g. a breaking-change site.
+
+  Package names (`@semantic-ui/astro`) and shell commands (`npm test`) stay backticked, never linked.
+
+  ## Anti-patterns — do not write these
+
+  - Process narration: "verified", "ensured", "tested", "I considered X but went with Y", "to accomplish this"
+  - Parenthetical proofs: "(verified — zero diff on main)", "(per discussion)"
+  - Pre-filled test-plan checkboxes
+  - `## Out of scope` sections — they pre-empt a question that may not be asked
+  - Hedging: "note that", "important to call out", "worth flagging"
+  - Listing every file or knob touched. A bullet at the right concept level often covers many file changes.
+  - Word imprecision: "broken" when the right word is "vestigial" or "stale"
+</pr_format>
+
 <agent_workspace>
   You have access to an agent workspace in `/ai/workspace/`. Use it for scratch files, drafts, and intermediate outputs as needed. Loose files in the workspace root are fine for active work.
 


### PR DESCRIPTION
Agent-authored PR descriptions tend to memorialize process — verification narration, mechanism lists, file-level changelogs. This codifies a tiered shape (Small / Medium / Large) so agent and human PRs converge on the same intent-focused style.

## Changes
- Add tiered PR-description spec to agent guidelines (title rules, body shape per tier, anti-patterns)
- Add a GitHub PR template that mirrors the spec for the web UI