### PR TITLE
Chore: Fix Esbuild Plugin Metadata

### DIFF
--- a/internal-packages/esbuild-callback/package.json
+++ b/internal-packages/esbuild-callback/package.json
@@ -13,10 +13,7 @@
     "README.md"
   ],
   "exports": {
-    ".": {
-      "import": "./src/index.js",
-      "default": "./dist/index.min.js"
-    }
+    ".": "./src/index.js"
   },
   "sideEffects": false,
   "scripts": {
@@ -24,7 +21,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/semantic-org/semantic-ui.git"
+    "url": "git+https://github.com/Semantic-Org/Semantic-Next.git",
+    "directory": "internal-packages/esbuild-callback"
   },
   "keywords": [
     "esbuild",

--- a/internal-packages/esbuild-log/LICENSE
+++ b/internal-packages/esbuild-log/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Jack Lukic
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/internal-packages/esbuild-log/package.json
+++ b/internal-packages/esbuild-log/package.json
@@ -12,23 +12,24 @@
     "LICENSE",
     "README.md"
   ],
+  "exports": {
+    ".": "./src/log.js"
+  },
   "sideEffects": false,
   "scripts": {
     "test": "vitest run"
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/semantic-org/esbuild-resolve-bare-imports.git"
+    "url": "git+https://github.com/Semantic-Org/Semantic-Next.git",
+    "directory": "internal-packages/esbuild-log"
   },
   "keywords": [
     "esbuild",
     "plugin",
-    "cdn",
-    "jsdelivr",
-    "unpkg",
-    "imports",
-    "resolve",
-    "modules",
+    "log",
+    "logging",
+    "chalk",
     "semantic-ui"
   ],
   "peerDependencies": {

--- a/internal-packages/esbuild-resolve-bare-imports/package.json
+++ b/internal-packages/esbuild-resolve-bare-imports/package.json
@@ -13,10 +13,7 @@
     "README.md"
   ],
   "exports": {
-    ".": {
-      "import": "./src/index.js",
-      "default": "./dist/index.min.js"
-    }
+    ".": "./src/index.js"
   },
   "sideEffects": false,
   "scripts": {
@@ -24,7 +21,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/semantic-org/esbuild-resolve-bare-imports.git"
+    "url": "git+https://github.com/Semantic-Org/Semantic-Next.git",
+    "directory": "internal-packages/esbuild-resolve-bare-imports"
   },
   "keywords": [
     "esbuild",


### PR DESCRIPTION
Fix metadata on the three publishable esbuild plugins.

## Changes
- Correct `repository` URLs and add `directory` fields
- Add missing LICENSE to `@semantic-ui/esbuild-log`
- Drop broken `dist/index.min.js` from `exports` map