### PR TITLE
Chore: Polish Renderer Comments

### DIFF
--- a/packages/renderer/src/engines/native/blocks/each.js
+++ b/packages/renderer/src/engines/native/blocks/each.js
@@ -15,29 +15,12 @@ import { registerBlock } from './registry.js';
   over *live* DOM, instead of dereferencing a stale childNodes snapshot
   taken at item-creation time.
 
-  Six plan fixes (ai/plans/native-renderer-blocks.md §EachBlock):
-    (1) dual update path — one set(), always a fresh wrapper object so
-        deep-equality sees distinct content at the outer level. Inner
-        refs are still shared; same-ref mutations still rely on notify()
-        for that one specific case (documented below)
-    (2) parallel collections — a single ordered ItemRecord[] replaces
-        itemMap + currentKeys; key lookup builds a transient Map per run
-    (3) __isItemProxy leakage — replaced with a WeakSet tracked inside
-        this module; template dispatch checks via isItemContext() import
-    (5) showingElse flag — else-content is a single ItemRecord entry with
-        isElse: true, rendered once when items is empty
-    (6) Proxy preservation — unchanged; the parent-data-fallthrough +
-        item-signal-reactivity pattern is load-bearing
-  Hydrate trusts server DOM and registers a dep on the collection — O(1)
-  per-item cost. On the first data change, `update` tries to adopt the
-  server-rendered per-item DOM (guided by `<!--sui-item:v1:KEY-->` markers
-  the ServerRenderer emitted) instead of nuking the region and rebuilding
-  from scratch. Keys that match receive a fresh itemSignal + Proxy and
-  their inner bindings are wired against the existing DOM via
-  hydrateInnerContent; keys that don't match fall through to a fresh
-  createRecord render. Subsequent mutations use the normal keyed reconcile
-  path. See ai/workspace/reference/perf/06-plans/09-each-hydration-dom-
-  reuse.md (Strategy D+E).
+  Hydrate only registers a dep on the collection — no per-item Reactions
+  are wired at hydrate time. Per-item bindings establish on the first
+  data change, when `update` tries to adopt the server-rendered per-item
+  DOM via `<!--sui-item:v1:KEY-->` markers instead of rebuilding from
+  scratch. Mismatched keys fall through to a fresh render; subsequent
+  mutations use the normal reconcile path.
 
 */
 
@@ -137,6 +120,11 @@ function refreshSnapshotAndDetect(snap, item) {
   return changed;
 }
 
+// Load-bearing: the parent-data fallthrough + item-signal reactivity
+// pattern is what lets `{name}` resolve to either an item field or a
+// parent-context binding without the caller knowing which. Flattening
+// this to a merged object would break per-item Signal subscriptions —
+// expressions wouldn't re-evaluate when the item mutates.
 function createItemDataProxy(parentData, itemSignal) {
   const proxy = new Proxy(parentData, {
     get(target, prop) {
@@ -392,26 +380,18 @@ function reconcile({ records, items, collectionType, node, data, scope, region, 
   }
 
   // Phase 3: update item signals where item ref or index changed, OR
-  // where a retained same-ref item has mutated in place.
+  // where a retained same-ref item mutated in place.
   //
-  // Same-ref same-index objects bypass Signal.set's equality gate because
-  // the wrapper's `[as]: item` binding is reference-equal across calls
-  // and `isEqual` stops at ===. That's what forces the else-if notify()
-  // branch — but notify() unconditionally wakes every per-item binding,
-  // which for update-10th means the 900 untouched records pay the cost
-  // of the 100 genuinely-mutated ones. Instead, snapshot each item's
-  // top-level prop values at reconcile end; on the next reconcile,
-  // shallow-compare. Only notify when a prop actually changed.
-  //
-  // Preserves the subtree-caching §8 contract ("should update conditional
-  // branches when item data changes") — that test mutates
-  // `items[i].active` which is a top-level prop, so shallow-compare sees
-  // the change and we still notify. Nested-object mutations (items[i].nested.x)
-  // would slip past the shallow check, but no tests or documented contracts
-  // rely on that — same observable behavior as before for mutations that
-  // touch enumerable own props. The fresh-record skip is still gated by
-  // rec.propsSnapshot === null (created by createRecord with no snapshot;
-  // first phase-3 pass records one, subsequent passes compare).
+  // Same-ref same-index objects bypass Signal.set's equality gate (the
+  // wrapper's `[as]: item` is reference-equal across calls and isEqual
+  // stops at ===). The naive fix — calling notify() unconditionally —
+  // wakes every per-item binding on every reconcile, so unchanged
+  // records pay the cost of mutated ones. Instead, snapshot each item's
+  // top-level props at reconcile end and shallow-compare on the next
+  // pass, only firing notify() when a prop actually changed. Top-level
+  // prop mutations (items[i].active = ...) re-render dependent
+  // expressions; nested-object mutations (items[i].nested.x) slip past
+  // the shallow check, and no documented contract relies on them.
   for (let i = 0; i < newRecords.length; i++) {
     const rec = newRecords[i];
     const item = items[i];
@@ -516,11 +496,11 @@ function extractServerItemGroups(ownedNodes) {
   return groups;
 }
 
-// First-data-change adoption path (Plan 09 Strategy D). Tries to reuse
-// server-rendered per-item DOM by matching item keys, wiring per-item
-// reactivity against the existing nodes via hydrateInnerContent. Returns
-// true on success, false if no server markers are present (legacy SSR
-// output — caller should fall through to nuke-and-rebuild).
+// First-data-change adoption path. Tries to reuse server-rendered per-
+// item DOM by matching item keys, wiring per-item reactivity against the
+// existing nodes via hydrateInnerContent. Returns true on success, false
+// if no server markers are present (legacy SSR output — caller should
+// fall through to a full rebuild).
 function adoptServerItems({
   self,
   items,
@@ -557,9 +537,9 @@ function adoptServerItems({
 
       // Wire per-item reactivity on the existing DOM. hydrateInnerContent
       // moves the nodes into a temporary fragment, walks with
-      // hydrateMarkers (which honors Plan 04's data-sui-bind fast path
-      // against the block's inner entries), and leaves the hydrated
-      // nodes in `mutableNodes`.
+      // hydrateMarkers (which honors the data-sui-bind fast path against
+      // the block's inner entries), and leaves the hydrated nodes in
+      // `mutableNodes`.
       const mutableNodes = [...serverGroup.nodes];
       hydrateInnerContent({
         ownedNodes: mutableNodes,
@@ -677,11 +657,10 @@ const eachBlock = defineBlock({
     if (self.hasHydrated) {
       self.hasHydrated = false;
       if (items.length > 0) {
-        // Plan 09 — try to adopt server-rendered per-item DOM. If the
-        // server emitted sui-item:v1:KEY markers (Plan 09 SSR output),
-        // items whose keys match reuse their DOM; others render fresh.
-        // Subsequent mutations flow through the standard reconcile path
-        // below with a populated records array.
+        // Try to adopt server-rendered per-item DOM. If the server
+        // emitted sui-item:v1:KEY markers, items whose keys match reuse
+        // their DOM; others render fresh. Subsequent mutations flow
+        // through the standard reconcile path below.
         const adopted = adoptServerItems({
           self,
           items,

--- a/packages/renderer/src/engines/native/blocks/index.js
+++ b/packages/renderer/src/engines/native/blocks/index.js
@@ -4,9 +4,6 @@
   so every registered block is available in the registry at first dispatch.
   Order doesn't matter — each block file registers under its own node.type.
 
-  Individual block imports are added here as each construct converts from
-  the monolithic renderer.js switch to the defineBlock shape.
-
 */
 
 import './rerender.js';

--- a/packages/renderer/src/engines/native/blocks/rerender.js
+++ b/packages/renderer/src/engines/native/blocks/rerender.js
@@ -36,9 +36,8 @@ const rerender = defineBlock({
       : '{#rerender}',
 
   create({ renderer }) {
-    // Capture evaluator so hooks can call lookupTokenValue for the single-
-    // token node.key path. The 9-key hook bag doesn't expose it; this is
-    // the create() seam the plan names.
+    // Capture evaluator so hooks can call lookupTokenValue for the
+    // single-token node.key path — the hook bag doesn't expose it.
     return { evaluator: renderer.evaluator };
   },
 

--- a/packages/renderer/src/engines/native/renderer.js
+++ b/packages/renderer/src/engines/native/renderer.js
@@ -43,43 +43,13 @@ function parseServerMeta(commentData, target) {
   }
 }
 
-// buildHTMLStringPure is deterministic for a given (ast, isSVG) pair —
-// `snippets` is only echoed back in the result (build-html-string.js:76,
-// 202) and doesn't affect htmlString/entries. AST is immutable after
-// reaching the Renderer (compiler's optimizeAST runs pre-runtime;
-// collectSnippets only reads), so cache entries never go stale.
-// WeakMap keyed on the AST array — GC'd automatically when no renderer
-// holds the AST.
-//
-// The cache holds BOTH the string+entries AND a pre-parsed reference
-// <template>. Hydration's hot path (hydrateAttributes) reparses the same
-// htmlString into a reference DOM via `innerHTML =` — the parse itself
-// is ~648ms on a 100-card page per the profile, independent of whether
-// the string was cached. Caching the parsed template.content eliminates
-// the reparse entirely. Safe because hydrateAttributes only READS from
-// refRoot (parallel TreeWalker traversal, no mutations).
-//
-// Hot path: hydration recurses via hydrateInnerContent → hydrateMarkers
-// → hydrateAttributes, each of which needs both the string and parsed
-// ref-DOM for the same contentAST. For a 100-item {#each}, that's ~100
-// rebuilds + ~100 innerHTML parses of identical content per hydrate
-// pass without this cache.
+// AST → { htmlString, entries, refRoot } cache. Keyed on the AST array,
+// which is immutable after compile, so entries never stale and GC
+// follows naturally. Each entry also holds a lazy `refRoot` — the parsed
+// reference <template>.content for the legacy hydration walker. Parse
+// cost dominates hydration on instance-heavy pages (e.g. 100-row lists),
+// so caching the parsed fragment is what makes the legacy walker viable.
 const buildStringCache = new WeakMap();
-
-// Temporary diagnostic — hit/miss counters so we can verify cache
-// effectiveness. Expose via globalThis.__cbhCache for inspection.
-// TODO remove after perf investigation closes.
-const cacheDiag = { hits: 0, misses: 0, firstMissKeys: [] };
-if (typeof globalThis !== 'undefined') {
-  globalThis.__cbhCache = {
-    stats: () => ({ ...cacheDiag, ratio: cacheDiag.hits / (cacheDiag.hits + cacheDiag.misses || 1) }),
-    reset: () => {
-      cacheDiag.hits = 0;
-      cacheDiag.misses = 0;
-      cacheDiag.firstMissKeys.length = 0;
-    },
-  };
-}
 
 function cachedBuildHTMLString(ast, options) {
   let entry = buildStringCache.get(ast);
@@ -89,19 +59,11 @@ function cachedBuildHTMLString(ast, options) {
   }
   const slot = options.isSVG ? 'svg' : 'html';
   if (entry[slot] === null) {
-    cacheDiag.misses++;
-    if (cacheDiag.firstMissKeys.length < 10) {
-      cacheDiag.firstMissKeys.push({
-        astLen: Array.isArray(ast) ? ast.length : '?',
-        types: Array.isArray(ast) ? ast.slice(0, 3).map((n) => n?.type) : [],
-      });
-    }
     const built = buildHTMLStringPure(ast, options);
-    // refRoot is a lazy getter — the Plan-04 fast path in hydrateAttributes
-    // never reads it, and paying the `template.innerHTML = htmlString`
-    // parse per instance is the hydration hotspot we're trying to
-    // eliminate. Touch it only when the legacy reference-DOM fallback
-    // runs (older SSR output, or templates without data-sui-bind).
+    // refRoot is a lazy getter — the data-sui-bind fast path in
+    // hydrateAttributes never reads it, so we avoid the per-instance
+    // `template.innerHTML = htmlString` parse. Only the legacy
+    // reference-DOM fallback (templates without data-sui-bind) touches it.
     let refRoot = null;
     entry[slot] = {
       htmlString: built.htmlString,
@@ -116,9 +78,6 @@ function cachedBuildHTMLString(ast, options) {
         return refRoot;
       },
     };
-  }
-  else {
-    cacheDiag.hits++;
   }
   return entry[slot];
 }
@@ -150,11 +109,8 @@ export class Renderer {
     this.inheritsData = inheritsData;
     this.receivesData = receivesData;
     this.protectedKeys = protectedKeys;
-    // Lit uses hashCode({ ast, data, isSVG }) for subtree caching here.
-    // Native renderer doesn't cache subtrees yet, and fnv1a over the full
-    // AST + data context costs ~1.4ms per construction — visible in hydration
-    // flamecharts. Use a cheap sequential ID for debugging until subtree
-    // caching is implemented.
+    // Sequential debug ID. Subtree caching would key on hashCode(ast+data)
+    // but isn't implemented in the native engine.
     this.id = ++Renderer.nextId;
     this.dataDep = new Dependency();
     this.scope = new ReactionScope();
@@ -296,13 +252,10 @@ export class Renderer {
   bindMarkers(root, entries, data, scope, ast) {
     if (entries.length === 0) { return; }
 
-    // Plan 08 — single-pass walker over SHOW_ELEMENT | SHOW_COMMENT. Each
-    // node.nextSibling/firstChild in the walker does one DOM traversal
-    // instead of two, cutting the per-render walk cost roughly in half
-    // for large fragments (1000-row table, etc.). Attribute processing is
-    // safe inline (only touches the element's own attributes); comment
-    // processing is deferred because it mutates the tree structure
-    // (replace/remove) and would invalidate the live walker.
+    // Single-pass walker over SHOW_ELEMENT | SHOW_COMMENT. Attribute
+    // processing is safe inline (only touches the element's own
+    // attributes); comment processing is deferred because it mutates the
+    // tree structure (replace/remove) and would invalidate the live walker.
     const processedAttrIDs = new Set();
     const commentsToProcess = [];
     const walker = document.createTreeWalker(
@@ -331,11 +284,10 @@ export class Renderer {
         if (text.startsWith(COMMENT_MARKER)) {
           const markerID = parseInt(text.slice(COMMENT_MARKER.length));
           if (!isNaN(markerID)) {
-            // processedAttrIDs is finalized only *after* the walk completes,
-            // so defer the attr-ID filter to the processing loop below. In
-            // fresh-render shape (client:load), attribute markers and their
-            // owning elements are discovered in document order — the element
-            // is visited before any comment that would have shared an ID.
+            // Filter deferred until after the walk: elements visit before
+            // sibling comments in document order, so an attr-marker's
+            // owning element is always recorded before any comment that
+            // would share its ID.
             commentsToProcess.push({ comment: node, markerID, type: 'expression' });
           }
         }
@@ -374,7 +326,6 @@ export class Renderer {
       Raw Text Element Bindings
   *******************************/
 
-  // Raw-text element binding — delegates to reactive-data.js.
   bindRawTextContent(comment, entry, data, scope) {
     bindRawTextContentFn({ comment, entry, data, scope, renderer: this });
   }
@@ -412,7 +363,6 @@ export class Renderer {
         Text Bindings
   *******************************/
 
-  // Text-expression binding — delegates to reactive-data.js.
   bindTextExpression(comment, entry, data, scope) {
     bindTextExpressionFn({ comment, entry, data, scope, renderer: this });
   }
@@ -500,23 +450,19 @@ export class Renderer {
   }
 
   hydrateAttributes(root, entries, data, scope, ast) {
-    // Fast path — server stamped data-sui-bind on every element with
-    // dynamic bindings (Plan 04). Presence of the attribute anywhere in
-    // the tree tells us the server is Plan-04-aware; walk elements once,
-    // look up entries[id].attributeBinding for parts + classification,
-    // wire Reactions directly. No reference DOM, no parallel walker, no
-    // block-owned-element discovery pass.
+    // Fast path — server stamps data-sui-bind on every element with
+    // dynamic bindings. Walk elements once, look up
+    // entries[id].attributeBinding for parts + classification, wire
+    // Reactions directly. No reference DOM, no parallel walker.
     if (root.querySelector && root.querySelector(`[${DATA_SUI_BIND}]`)) {
       this.hydrateAttributesViaDataBind(root, entries, data, scope);
       return;
     }
 
-    // Legacy fallback — reference DOM parallel walk. Keeps older cached
-    // SSR content hydrating correctly during a rolling upgrade.
-    // Reference DOM is cached alongside the htmlString — parallel TreeWalker
-    // only reads attribute names off refEls, so sharing the cached fragment
-    // across calls is safe. Eliminates the ~648ms-per-page `innerHTML =`
-    // reparse that the profile identified as the hydration hotspot.
+    // Legacy fallback — reference DOM parallel walk for older SSR output
+    // without data-sui-bind. Reference DOM is cached alongside the
+    // htmlString; the parallel TreeWalker only reads attribute names off
+    // refEls, so sharing the cached fragment is safe.
     const { refRoot } = cachedBuildHTMLString(ast || this.ast, { snippets: this.snippets });
 
     // Build a set of real DOM elements owned by block regions so we can skip
@@ -573,17 +519,12 @@ export class Renderer {
     }
   }
 
-  // Plan 04 fast path — walk SHOW_ELEMENT | SHOW_COMMENT once, process
-  // `data-sui-bind` on elements at block-depth 0 and let block hydrate
-  // hooks recursively handle their own contents via hydrateInnerContent
-  // (which re-enters this method with the block's sub-AST entries). This
-  // matches the blockOwnedElements skip the legacy parallel walker
-  // performed, but without building a reference DOM or a separate Set —
-  // depth is tracked inline from the block markers we encounter.
-  //
-  // The data-sui-bind attribute itself is left on the element until the
-  // post-hydration cleanup pass (base.js removeMarkers, deferred to rAF
-  // per Plan 02) strips it along with comment markers.
+  // Walk SHOW_ELEMENT | SHOW_COMMENT once, process `data-sui-bind` on
+  // elements at block-depth 0, and let block hydrate hooks recurse into
+  // their own contents via hydrateInnerContent. Depth is tracked inline
+  // from the block markers we encounter; no reference DOM, no separate
+  // owned-element set. The data-sui-bind attribute itself is stripped by
+  // the post-hydration cleanup pass (base.js removeMarkers).
   hydrateAttributesViaDataBind(root, entries, data, scope) {
     const walker = document.createTreeWalker(
       root,

--- a/packages/renderer/src/engines/native/server.js
+++ b/packages/renderer/src/engines/native/server.js
@@ -407,12 +407,10 @@ export class ServerRenderer {
       html += this.renderNodes(node.elseContent, data);
     }
     else {
-      // Plan 09 — emit `<!--sui-item:v1:KEY-->` before each item's content
-      // so the client can adopt per-item DOM on first data change instead
-      // of nuking the whole list and re-rendering. The key is computed
-      // from the item via the same `getItemID` heuristic the client uses
-      // (`_id`/`id`/`key`/`hash`/`_hash`/`value`/index fallback), so
-      // server and client agree on identity.
+      // Emit `<!--sui-item:v1:KEY-->` before each item's content so the
+      // client can adopt per-item DOM on first data change instead of
+      // re-rendering the whole list. Key is computed via the same
+      // `getItemID` heuristic the client uses, so the two agree on identity.
       for (let i = 0; i < items.length; i++) {
         const eachData = this.getEachData(items[i], i, collectionType, node);
         const itemData = { ...data, ...eachData };
@@ -530,12 +528,11 @@ export class ServerRenderer {
       Data Helpers
   *******************************/
 
-  // Mirrors the client-side heuristic in blocks/each.js — prefer
-  // user-supplied identity fields, fall back to the positional index.
-  // Always stringified so server-emitted keys match the string-keyed
-  // Map the client builds from the `<!--sui-item:v1:KEY-->` extraction.
-  // Kept in sync manually; see ai/workspace/reference/perf/06-plans/
-  // 09-each-hydration-dom-reuse.md §Server.
+  // Mirrors blocks/each.js getItemID — keep in sync. Server and client
+  // must agree on identity or first-data-change adoption misses keys.
+  // Key = first non-empty of: object.{_id, id, key, hash, _hash, value},
+  // object-collection key, or positional index. Stringified to match
+  // the string-keyed Map the client builds from `<!--sui-item:v1:KEY-->`.
   getItemID(item, indexOrKey, collectionType) {
     let raw;
     if (isPlainObject(item)) {


### PR DESCRIPTION
Comment cleanup pass on `packages/renderer/`. Strip internal plan references and one-off profile numbers, drop a temporary cache-hit diagnostic, restore intent/insight notes at function sites that need them.

## Changes
- Remove `__cbhCache` global + hit/miss counters from the native renderer
- Strip Plan-XX references and `ai/plans` / `ai/workspace` paths
- Drop file-line breadcrumbs and ad-hoc profile millisecond figures
- Restore load-bearing invariant notes (server/client `getItemID` sync, item-data proxy fallthrough, Phase 3 `notify()` rationale) at the sites that need them

A follow-up will add a hydration bench fixture so the cache header can cite a verifiable workload number.