### PR TITLE
Docs: Trim Cache Header Justification

### DIFF
--- a/packages/renderer/src/engines/native/renderer.js
+++ b/packages/renderer/src/engines/native/renderer.js
@@ -44,11 +44,9 @@ function parseServerMeta(commentData, target) {
 }
 
 // AST → { htmlString, entries, refRoot } cache. Keyed on the AST array,
-// which is immutable after compile, so entries never stale and GC follows
-// naturally. Each entry also holds a lazy `refRoot` — the parsed reference
-// <template>.content for the legacy hydration walker. Parse cost dominates
-// legacy-fallback hydration; bench-hydrate guards the regression when this
-// cache stops landing (packages/component/bench/tachometer/bench-hydrate.js).
+// which is immutable after compile, so entries never stale and GC
+// follows naturally. Each entry also holds a lazy `refRoot` — the
+// parsed reference <template>.content for the legacy hydration walker.
 const buildStringCache = new WeakMap();
 
 function cachedBuildHTMLString(ast, options) {

--- a/packages/renderer/src/engines/native/renderer.js
+++ b/packages/renderer/src/engines/native/renderer.js
@@ -44,11 +44,11 @@ function parseServerMeta(commentData, target) {
 }
 
 // AST → { htmlString, entries, refRoot } cache. Keyed on the AST array,
-// which is immutable after compile, so entries never stale and GC
-// follows naturally. Each entry also holds a lazy `refRoot` — the parsed
-// reference <template>.content for the legacy hydration walker. Parse
-// cost dominates hydration on instance-heavy pages (e.g. 100-row lists),
-// so caching the parsed fragment is what makes the legacy walker viable.
+// which is immutable after compile, so entries never stale and GC follows
+// naturally. Each entry also holds a lazy `refRoot` — the parsed reference
+// <template>.content for the legacy hydration walker. Parse cost dominates
+// legacy-fallback hydration; bench-hydrate guards the regression when this
+// cache stops landing (packages/component/bench/tachometer/bench-hydrate.js).
 const buildStringCache = new WeakMap();
 
 function cachedBuildHTMLString(ast, options) {


### PR DESCRIPTION
Drop the value-justification sentence in `buildStringCache`'s header. The cache existing in source already signals it earns its keep; readers don't need a paragraph defending it. Three intent sentences remain — what's cached, why caching is safe, what `refRoot` is for.