### PR TITLE
Refactor: Hoist Identity Order to Signal

### DIFF
--- a/packages/reactivity/src/signal.js
+++ b/packages/reactivity/src/signal.js
@@ -92,6 +92,24 @@ export class Signal {
   static setStackCapture = setStackCapture;
   static isStackCapture = isStackCapture;
 
+  // Canonical priority order for identifying an item by one of its fields.
+  // Shared with the renderer's keyed-each adoption path so server SSR keys
+  // and client reconcile keys agree on which field wins. `id` precedes
+  // `_id` because `id` is canonical outside Mongo.
+  static IDENTITY_FIELDS = ['id', '_id', 'key', 'hash', '_hash', 'value'];
+
+  // First non-null IDENTITY_FIELDS value on `item`, or undefined for
+  // primitives / objects with no recognized identity field. Callers wrap
+  // this in their own positional fallback (each-block uses indexOrKey).
+  static identityOf(item) {
+    if (item == null || typeof item !== 'object') { return undefined; }
+    for (const field of Signal.IDENTITY_FIELDS) {
+      const v = item[field];
+      if (v != null) { return v; }
+    }
+    return undefined;
+  }
+
   get value() {
     // Record this Signal as a dependency if inside a Reaction computation
     this.depend();
@@ -319,7 +337,7 @@ export class Signal {
 
   getIDs(item) {
     if (isObject(item)) {
-      return unique([item?.id, item?._id, item?.hash, item?.key].filter(Boolean));
+      return unique(Signal.IDENTITY_FIELDS.map(f => item?.[f]).filter(Boolean));
     }
     return [item];
   }

--- a/packages/reactivity/src/signal.js
+++ b/packages/reactivity/src/signal.js
@@ -319,7 +319,7 @@ export class Signal {
 
   getIDs(item) {
     if (isObject(item)) {
-      return unique([item?._id, item?.id, item?.hash, item?.key].filter(Boolean));
+      return unique([item?.id, item?._id, item?.hash, item?.key].filter(Boolean));
     }
     return [item];
   }

--- a/packages/renderer/src/engines/lit/directives/reactive-each.js
+++ b/packages/renderer/src/engines/lit/directives/reactive-each.js
@@ -3,7 +3,7 @@ import { AsyncDirective } from 'lit/async-directive.js';
 import { directive } from 'lit/directive.js';
 import { repeat } from 'lit/directives/repeat.js';
 
-import { Reaction } from '@semantic-ui/reactivity';
+import { Reaction, Signal } from '@semantic-ui/reactivity';
 import { clone, isEmpty, isEqual } from '@semantic-ui/utils';
 
 import { arrayFromObject, isArray, isClient, isPlainObject, isString } from '@semantic-ui/utils';
@@ -124,7 +124,7 @@ export class ReactiveEachDirective extends AsyncDirective {
       const key = (collectionType == 'object')
         ? indexOrKey
         : undefined;
-      return key || item.id || item._id || item.key || item.hash || item._hash || item.value || indexOrKey;
+      return key || Signal.identityOf(item) || indexOrKey;
     }
     if (isString(item)) {
       return item;

--- a/packages/renderer/src/engines/lit/directives/reactive-each.js
+++ b/packages/renderer/src/engines/lit/directives/reactive-each.js
@@ -124,7 +124,7 @@ export class ReactiveEachDirective extends AsyncDirective {
       const key = (collectionType == 'object')
         ? indexOrKey
         : undefined;
-      return key || item._id || item.id || item.key || item.hash || item._hash || item.value || indexOrKey;
+      return key || item.id || item._id || item.key || item.hash || item._hash || item.value || indexOrKey;
     }
     if (isString(item)) {
       return item;

--- a/packages/renderer/src/engines/native/blocks/each.js
+++ b/packages/renderer/src/engines/native/blocks/each.js
@@ -48,7 +48,7 @@ function getItemID(item, indexOrKey, collectionType) {
   let raw;
   if (isPlainObject(item)) {
     const key = (collectionType === 'object') ? indexOrKey : undefined;
-    raw = key || item._id || item.id || item.key || item.hash || item._hash || item.value || indexOrKey;
+    raw = key || item.id || item._id || item.key || item.hash || item._hash || item.value || indexOrKey;
   }
   else if (isString(item)) {
     raw = item + ':' + indexOrKey;

--- a/packages/renderer/src/engines/native/blocks/each.js
+++ b/packages/renderer/src/engines/native/blocks/each.js
@@ -48,7 +48,7 @@ function getItemID(item, indexOrKey, collectionType) {
   let raw;
   if (isPlainObject(item)) {
     const key = (collectionType === 'object') ? indexOrKey : undefined;
-    raw = key || item.id || item._id || item.key || item.hash || item._hash || item.value || indexOrKey;
+    raw = key || Signal.identityOf(item) || indexOrKey;
   }
   else if (isString(item)) {
     raw = item + ':' + indexOrKey;

--- a/packages/renderer/src/engines/native/server.js
+++ b/packages/renderer/src/engines/native/server.js
@@ -530,14 +530,14 @@ export class ServerRenderer {
 
   // Mirrors blocks/each.js getItemID — keep in sync. Server and client
   // must agree on identity or first-data-change adoption misses keys.
-  // Key = first non-empty of: object.{_id, id, key, hash, _hash, value},
+  // Key = first non-empty of: object.{id, _id, key, hash, _hash, value},
   // object-collection key, or positional index. Stringified to match
   // the string-keyed Map the client builds from `<!--sui-item:v1:KEY-->`.
   getItemID(item, indexOrKey, collectionType) {
     let raw;
     if (isPlainObject(item)) {
       const key = (collectionType === 'object') ? indexOrKey : undefined;
-      raw = key || item._id || item.id || item.key || item.hash || item._hash || item.value || indexOrKey;
+      raw = key || item.id || item._id || item.key || item.hash || item._hash || item.value || indexOrKey;
     }
     else if (isString(item)) {
       raw = item + ':' + indexOrKey;

--- a/packages/renderer/src/engines/native/server.js
+++ b/packages/renderer/src/engines/native/server.js
@@ -22,6 +22,8 @@ import {
   isString,
 } from '@semantic-ui/utils';
 
+import { Signal } from '@semantic-ui/reactivity';
+
 import { analyzePosition, BLOCK_MARKER, COMMENT_MARKER, DATA_SUI_BIND } from '../../build-html-string.js';
 import { ExpressionEvaluator } from '../../expression-evaluator.js';
 
@@ -528,16 +530,15 @@ export class ServerRenderer {
       Data Helpers
   *******************************/
 
-  // Mirrors blocks/each.js getItemID — keep in sync. Server and client
-  // must agree on identity or first-data-change adoption misses keys.
-  // Key = first non-empty of: object.{id, _id, key, hash, _hash, value},
-  // object-collection key, or positional index. Stringified to match
-  // the string-keyed Map the client builds from `<!--sui-item:v1:KEY-->`.
+  // Identity priority is shared with blocks/each.js via Signal.identityOf
+  // — server and client must agree or first-data-change adoption misses
+  // keys. Result is stringified to match the string-keyed Map the client
+  // builds from `<!--sui-item:v1:KEY-->`.
   getItemID(item, indexOrKey, collectionType) {
     let raw;
     if (isPlainObject(item)) {
       const key = (collectionType === 'object') ? indexOrKey : undefined;
-      raw = key || item.id || item._id || item.key || item.hash || item._hash || item.value || indexOrKey;
+      raw = key || Signal.identityOf(item) || indexOrKey;
     }
     else if (isString(item)) {
       raw = item + ':' + indexOrKey;


### PR DESCRIPTION
Single source for keyed-each identity-field priority — `Signal.IDENTITY_FIELDS` and `Signal.identityOf(item)` replace four duplicated OR chains. `id` precedes `_id` because `id` is canonical outside Mongo.

## Changes
- Add `Signal.IDENTITY_FIELDS` and `Signal.identityOf(item)` as canonical static helpers
- Each-block engines (native client, native server, Lit) call `identityOf` instead of duplicating the OR chain
- `Signal.getIDs` reuses `IDENTITY_FIELDS`, expanding from 4 to 6 fields (adds `_hash`, `value`)
- Items with both `id` and `_id` set to different values now resolve to `id` (was `_id`) in `getItem`, `replaceItem`, and each-block keying

## Risk
3/10 — public Signal API change with small breaking surface, pre-1.0.