### PR TITLE
Test: Bump hydrate bench to 1000 items

### DIFF
--- a/packages/component/bench/tachometer/bench-hydrate.js
+++ b/packages/component/bench/tachometer/bench-hydrate.js
@@ -96,7 +96,7 @@ const startMark = (name) => `${name}-start`;
 // data-sui-bind markers. The `each` block's hydrate hook stays O(1) on
 // main — it just registers a dep on the items signal. Per-item DOM is
 // already correct from SSR; no mutation triggered.
-const itemsForMount = makeItems(100);
+const itemsForMount = makeItems(1000);
 const dsdHTMLForMount = ssrList(itemsForMount);
 performance.mark(startMark('hydrate-each-100-mount'));
 container.setHTMLUnsafe(dsdHTMLForMount);
@@ -180,7 +180,7 @@ function ssrHelperList(items) {
 // cost difference between strategies that keep hydrate O(1) and
 // strategies that wire per-item Reactions on hydrate to register
 // external-signal deps eagerly.
-const helperItems = makeItems(100);
+const helperItems = makeItems(1000);
 const dsdHTMLForHelper = ssrHelperList(helperItems);
 performance.mark(startMark('hydrate-helper-100-mount'));
 container.setHTMLUnsafe(dsdHTMLForHelper);


### PR DESCRIPTION
The 100-item bench durations (~6-16ms) sit in the ±10-28% noise band per the perf-improvement skill's bench-duration table — too short to resolve small deltas. At 1000 items (~60-160ms) the bench falls into the ±1% band where per-item cost differences become measurable.

Metric names keep the `-100` suffix; only the underlying N changed (one-line edit at two call sites).

## Risk
2/10 — bench-only. Existing report comparisons will look discontinuous (1000-item numbers vs. prior 100-item baseline) but that's correct — the prior numbers were unresolvable.