### PR TITLE
Refactor: Consolidate Native Hydrate Path

### DIFF
--- a/ai/skills/authoring/ssr-hydration.md
+++ b/ai/skills/authoring/ssr-hydration.md
@@ -356,7 +356,7 @@ hydrate(prototypeTemplate) {
 
 Two passes over the server-rendered DOM:
 
-**Pass 1: Attribute bindings** — The server stamps `data-sui-bind="attr=N,..."` on every element with dynamic bindings (Plan 04 fast path). The client walks `[data-sui-bind]` elements at top level and wires Reactions directly via `entries[id].attributeBinding`. Block-owned elements (inside `{#if}`/`{#each}`/etc., tracked via `blockDepth` from comment markers) are skipped — block handlers recurse into their own contents via `hydrateInnerContent`. A legacy fallback (parallel ref-DOM walker) exists for older SSR output without `data-sui-bind`.
+**Pass 1: Attribute bindings** — The server stamps `data-sui-bind="attr=N,..."` on every element with dynamic bindings (Plan 04 fast path). The client walks `[data-sui-bind]` elements at top level and wires Reactions directly via `entries[id].attributeParts`. Block-owned elements (inside `{#if}`/`{#each}`/etc., tracked via `blockDepth` from comment markers) are skipped — block handlers recurse into their own contents via `hydrateInnerContent`.
 
 **Pass 2: Comment markers** — A TreeWalker finds `<!--sui:v1:N-->` (text expressions) and `<!--sui-block:v1:N-->` (block directives) at top level. `blockDepth` tracking skips inner markers; block handlers process their own children.
 

--- a/ai/skills/contributing/author-pull-requests.md
+++ b/ai/skills/contributing/author-pull-requests.md
@@ -72,6 +72,7 @@ After the prefix:
 - **Concrete verbs.** Make / Move / Swap / Group / Add / Remove. Avoid Relocate / Re-anchor / Configure (formal/abstract). Avoid Drop (SQL connotations).
 - **Title is the primary change only.** Secondary work goes in body bullets — never `X and Y` titles.
 - **Don't lead with `BREAKING:` even for breaking changes.** The Risk score + changelog automation already signal the breaking nature. Use the prefix that describes the change *kind* — `Refactor:`, `Perf:`, `Feat:` — and let the Risk/changelog do the warning work.
+- **Don't leak iteration history into commit subjects** — no "Round 2 fixes," "post-review cleanup," "second pass," or similar. Even with squash-on-merge protecting `main`, branch commits are read by code-review subagents working on the PR, and round-numbering subtly biases them toward assuming earlier rounds caught the obvious issues. State what changed, not which review pass produced it. Same applies inside multi-commit branches that humans bisect.
 
 ### Worked examples (real PRs from this project)
 

--- a/ai/skills/contributing/code-review.md
+++ b/ai/skills/contributing/code-review.md
@@ -32,6 +32,10 @@ Launch all 6 in parallel. Always use **Opus** — never Sonnet or Haiku for revi
 
 Each agent runs `gh pr diff {number}` and examines the changes through its lens.
 
+**Don't leak round number or iteration history to lens agents.** Each round's prompt should read as a first review against the current PR diff. Hints like "round 3", "round-2 fixes", "after iteration", or "previous reviewers already covered X" subtly bias the agent toward assuming earlier rounds caught the obvious issues — they read with less rigor and less skepticism. Frame every round as a cold first read of the current state. The agent has no way to verify what previous rounds covered, so the bias is unfalsifiable from its end.
+
+Same applies to scorers: don't tell a scoring agent "this finding came up in round 3" — strip iteration context before passing the finding.
+
 **Lens agent output format:** Each lens agent returns a structured list of findings. For each issue:
 - **File path and line number(s)**
 - **What's wrong** — one sentence

--- a/ai/skills/contributing/native-renderer.md
+++ b/ai/skills/contributing/native-renderer.md
@@ -273,7 +273,7 @@ Without recovery, hook throws propagate so failures are loud — the browser log
 
 | Block | AST type | Notes |
 |---|---|---|
-| `conditional.js` | `if` | Linear branch match. `matchIndex 1000` = main body, ≥0 = branches. Server stamps `serverMeta.branchIndex` on the closing marker; mismatch triggers a re-render with a dev warning (env guards `isClient`/`isServer` exempted). |
+| `conditional.js` | `if` | Linear branch match. `matchIndex` = `MAIN_BRANCH_INDEX` (1000) for main body, ≥0 for branches. Server stamps `serverMeta.branchIndex` on the closing marker; mismatch triggers a re-render with a dev warning (env guards `isClient`/`isServer` exempted). |
 | `each.js` | `each` | Keyed reconciliation with per-item `Signal` + Proxy + per-item start/end text-node markers. `WeakSet itemContextProxies` replaces the old `__isItemProxy` flag; `template.js` checks via `isItemContext()` import. Snapshot-based dirty detection avoids full deep-equality on the steady-state path. |
 | `async.js` | `async` | Three states (loading / success / error). Generation counter discards stale promise resolutions. Recovery wraps sync throws and dispatches into `errorContent` via the `error` hook. |
 | `rerender.js` | `rerender` | Both `{#rerender expr}` and `{#guard key}` compile to the same node type. Guard wraps tracking in `Reaction.guard` (deep-equality gate); rerender uses plain `lookupExpression`. |
@@ -310,7 +310,7 @@ Collects all DOM nodes between the opening `sui-block:v1:N` and matching `/sui-b
 
 ### Why `data-sui-bind` matters
 
-Profiling identified a ~648 ms `template.innerHTML = htmlString` reparse per 100-card page in the legacy hydration path. The fast path skips that entirely — entries already carry `attributeBinding: { parts, classification }` from `buildHTMLString`. The reference DOM is now a lazy getter on the cache entry, only built when the legacy path runs (rolling-upgrade tolerance).
+Profiling identified a ~648 ms `template.innerHTML = htmlString` reparse per 100-card page in the legacy hydration path. The fast path skips that entirely — entries already carry `attributeParts` (the parsed alternating static/marker segments) from `buildHTMLString`, and the classification is on the entry itself.
 
 ---
 

--- a/packages/component/bench/tachometer/bench-hydrate.js
+++ b/packages/component/bench/tachometer/bench-hydrate.js
@@ -88,12 +88,10 @@ const startMark = (name) => `${name}-start`;
        + the hydrate microtask)
 *******************************/
 
-// Measured: parsing the DSD via setHTMLUnsafe (which actually attaches
-// the shadow root, unlike innerHTML), connectedCallback, the hydrate
-// microtask scheduled inside it, and the post-hydrate rAF that strips
-// data-sui-bind markers. The `each` block's hydrate hook stays O(1) on
-// main — it just registers a dep on the items signal. Per-item DOM is
-// already correct from SSR; no mutation triggered.
+// Measured: DSD parse via setHTMLUnsafe (innerHTML doesn't attach the
+// shadow root), connectedCallback, the hydrate microtask, and the
+// post-hydrate rAF that strips data-sui-bind. Per-item Reactions wire
+// here; subsequent updates exercise the already-wired graph.
 const itemsForMount = makeItems(1000);
 const dsdHTMLForMount = ssrList(itemsForMount);
 performance.mark(startMark('hydrate-each-100-mount'));
@@ -169,11 +167,9 @@ function ssrHelperList(items) {
     + `</bench-hydrate-helper>`;
 }
 
-// Same mount window shape as above, but with a per-item attribute that
-// calls a helper closing over external `state.activeID`. Surfaces the
-// cost difference between strategies that keep hydrate O(1) and
-// strategies that wire per-item Reactions on hydrate to register
-// external-signal deps eagerly.
+// Same mount-window shape as above, but with a per-item attribute that
+// calls a helper closing over external `state.activeID`. Sensitive to
+// regressions in per-item Reaction wiring at hydrate time.
 const helperItems = makeItems(1000);
 const dsdHTMLForHelper = ssrHelperList(helperItems);
 performance.mark(startMark('hydrate-helper-100-mount'));
@@ -188,10 +184,10 @@ const elHelper = container.firstElementChild;
       (state change after mount)
 *******************************/
 
-// Measured: cost of mutating a state signal that per-item helpers read.
-// On a hydrate path that wires per-item Reactions, this fires 100
-// helper invocations + setAttribute calls. On a hydrate path that
-// defers wiring, this is silent — fast number, broken UX.
+// Mutating a state signal that per-item helpers close over fires 100
+// helper invocations + setAttribute calls. Confirms per-item Reactions
+// wired at hydrate are reactive to external state, not just to
+// itemSignal mutations.
 performance.mark(startMark('hydrate-helper-100-state-change'));
 elHelper.component.setActive('id-50');
 await flush();

--- a/packages/component/bench/tachometer/bench-hydrate.js
+++ b/packages/component/bench/tachometer/bench-hydrate.js
@@ -2,19 +2,17 @@ import { defineComponent } from '@semantic-ui/component';
 import { ServerRenderer } from '@semantic-ui/renderer';
 
 /*
-  Hydrate-each — gates hydration cost across two distinct windows:
+  Hydrate-each — two windows:
 
-  1. `hydrate-each-100-mount` — work paid by the hydrate microtask itself,
-     before any data mutation. Sensitive to designs that move per-item
-     wiring earlier (e.g. eager `adoptServerItems` in `each.hydrate`).
-  2. `hydrate-each-100` — first-data-change adoption: server-emitted
-     `<!--sui-item:v1:KEY-->` markers let `adoptServerItems` reuse DOM
-     and call `hydrateInnerContent` 100×. Sensitive to silent regressions
-     in the AST→string/entries cache (`renderer.js buildStringCache`),
-     which on a miss reverts to a full `buildHTMLStringPure` per item.
+  1. `hydrate-each-100-mount` — DSD parse + connectedCallback + the hydrate
+     microtask (eager `adoptServerItems`) + post-hydrate rAF. Per-item
+     wiring cost lives here.
+  2. `hydrate-each-100` — post-mount items mutation. Items dependency wakes,
+     `each.update` reconciles same keys, hits same-ref path. Mostly the
+     reconcile walk + Phase 3 snapshot diff.
 
-  Both windows require Declarative Shadow DOM to be parsed — `innerHTML`
-  does not process `<template shadowrootmode>`, only `setHTMLUnsafe` does.
+  Both windows require Declarative Shadow DOM — `setHTMLUnsafe` processes
+  `<template shadowrootmode>`, plain `innerHTML` does not.
 */
 
 defineComponent({

--- a/packages/component/bench/tachometer/bench-hydrate.js
+++ b/packages/component/bench/tachometer/bench-hydrate.js
@@ -113,9 +113,9 @@ const elForMutate = container.firstElementChild;
 *******************************/
 
 // Measured: setItems with a fresh array reference whose item keys
-// match the SSR'd markers — Reaction fires, update sees hasHydrated,
-// adoptServerItems reuses the server DOM and calls hydrateInnerContent
-// 100× (one cachedBuildHTMLString call per item).
+// match the SSR'd markers. Per-item DOM was already adopted at hydrate
+// time (see mount window above); this update tick walks the items
+// dependency, hits the equality gate per Signal, and stops.
 performance.mark(startMark('hydrate-each-100'));
 elForMutate.component.setItems(itemsForMount.slice());
 await flush();

--- a/packages/component/bench/tachometer/bench-hydrate.js
+++ b/packages/component/bench/tachometer/bench-hydrate.js
@@ -105,13 +105,11 @@ const elForMutate = container.firstElementChild;
 
 /*******************************
       Hydrate Each-100
-      (post-mount items mutation
-       — DOM already adopted)
+      (post-mount items mutation)
 *******************************/
 
-// setItems with a fresh array reference, same item keys as SSR markers.
-// Adoption ran at mount; this update tick exercises the items dependency
-// + per-Signal equality gate.
+// Fresh array reference, same keys as SSR markers — exercises the items
+// dependency wake + per-Signal equality gate without DOM work.
 performance.mark(startMark('hydrate-each-100'));
 elForMutate.component.setItems(itemsForMount.slice());
 await flush();

--- a/packages/component/bench/tachometer/bench-hydrate.js
+++ b/packages/component/bench/tachometer/bench-hydrate.js
@@ -107,15 +107,13 @@ const elForMutate = container.firstElementChild;
 
 /*******************************
       Hydrate Each-100
-      (first-data-change
-       adoption: 100× per-item
-       hydrateInnerContent)
+      (post-mount items mutation
+       — DOM already adopted)
 *******************************/
 
-// Measured: setItems with a fresh array reference whose item keys
-// match the SSR'd markers. Per-item DOM was already adopted at hydrate
-// time (see mount window above); this update tick walks the items
-// dependency, hits the equality gate per Signal, and stops.
+// setItems with a fresh array reference, same item keys as SSR markers.
+// Adoption ran at mount; this update tick exercises the items dependency
+// + per-Signal equality gate.
 performance.mark(startMark('hydrate-each-100'));
 elForMutate.component.setItems(itemsForMount.slice());
 await flush();

--- a/packages/component/src/engines/native/base.js
+++ b/packages/component/src/engines/native/base.js
@@ -142,12 +142,12 @@ class WebComponentBase extends HTMLElementBase {
     const entries = prototypeTemplate._hydrationEntries;
 
     // Wire reactive bindings to existing server-rendered DOM
-    this.template.renderer.hydrateMarkers(
-      this.shadowRoot,
+    this.template.renderer.hydrateMarkers({
+      root: this.shadowRoot,
       entries,
-      this.template.renderer.data,
-      this.template.renderer.scope,
-    );
+      data: this.template.renderer.data,
+      scope: this.template.renderer.scope,
+    });
 
     this.template.isHydrating = false;
     this.template.markRendered();

--- a/packages/component/src/engines/native/base.js
+++ b/packages/component/src/engines/native/base.js
@@ -1,5 +1,5 @@
 import { $ } from '@semantic-ui/query';
-const MARKER_VERSION = 'v1';
+import { MARKER_VERSION } from '@semantic-ui/renderer';
 import { adoptStylesheet, isFunction, isServer, kebabToCamel } from '@semantic-ui/utils';
 
 import {

--- a/packages/renderer/src/build-html-string.js
+++ b/packages/renderer/src/build-html-string.js
@@ -310,6 +310,10 @@ function populateAttributeBindings(htmlString, entries) {
     if (markerIDs.length === 0) { continue; }
     const entry = entries[markerIDs[0]];
     if (!entry) { continue; }
-    entry.attributeBinding = { rawAttrName, parts, markerIDs };
+    // firstMarkerID is markerIDs[0] but can differ from parts[0].markerID
+    // when the attribute leads with static text (e.g. `class="card {x}"`).
+    // Stored once so reactive-data.js's bindAttribute doesn't `parts.find`
+    // on every binding setup.
+    entry.attributeBinding = { rawAttrName, parts, markerIDs, firstMarkerID: markerIDs[0] };
   }
 }

--- a/packages/renderer/src/build-html-string.js
+++ b/packages/renderer/src/build-html-string.js
@@ -6,7 +6,6 @@
   Pure function: all dependencies passed in, no instance state.
 */
 
-// Marker for expression placeholders in attribute values
 export const ATTR_MARKER_PREFIX = '__sui';
 export const ATTR_MARKER_SUFFIX = '__';
 
@@ -88,7 +87,7 @@ export function parseAttributeParts(attrValue) {
     if (match.index > lastIndex) {
       parts.push({ static: attrValue.slice(lastIndex, match.index) });
     }
-    const markerID = parseInt(match[1]);
+    const markerID = +match[1];
     parts.push({ markerID });
     markerIDs.push(markerID);
     lastIndex = ATTR_MARKER_RE.lastIndex;
@@ -279,36 +278,18 @@ export function buildHTMLString(ast, { snippets = {}, isSVG: initialSVG = false 
   return { htmlString, entries, snippets };
 }
 
-// After the AST walk completes, scan the emitted htmlString for every
-// attribute value that contains one or more `__sui{id}__` markers and
-// attach an `attributeBinding` record to the FIRST entry in that
-// attribute's marker set.
-//
-// attributeBinding = { rawAttrName, parts, markerIDs }
-//   rawAttrName: attribute as written in the template, with optional
-//                `.` / `@` prefix for property/event bindings. Boolean
-//                and regular attributes share the plain name — callers
-//                disambiguate via `entries[id].classification.type`.
-//   parts:       output of parseAttributeParts; alternating
-//                `{static}` and `{markerID}` entries covering the whole
-//                attribute value (including statics between/around
-//                multiple markers).
-//   markerIDs:   entry IDs for every expression inside this attribute,
-//                in document order. First ID is the "representative"
-//                that `data-sui-bind` on the server references.
-//
-// Subsequent entries in markerIDs (the non-first ones for a
-// multi-expression attribute) are reachable via the first entry's
-// attributeBinding. The hydration path processes each attribute once
-// via the first entry; bindAttribute handles the multi-expression
-// reaction internally using the full parts array.
-const ATTR_WITH_MARKER_RE = /\s([.@]?[\w:-]+)\s*=\s*(?:"([^"]*__sui\d+__[^"]*)"|([^\s"'>]*__sui\d+__[^\s"'>]*))/g;
+// Attach `attributeBinding` to the first entry of each attribute whose
+// value carries one or more markers. `parts` covers the full value
+// (alternating static/dynamic segments) so bindAttribute can reconstruct
+// the interpolation in one pass. The hydration path resolves the binding
+// via `data-sui-bind` → first entry → attributeBinding.parts.
+const ATTR_WITH_MARKER_RE = /\s(?:[.@]?[\w:-]+)\s*=\s*(?:"([^"]*__sui\d+__[^"]*)"|([^\s"'>]*__sui\d+__[^\s"'>]*))/g;
 
 function populateAttributeBindings(htmlString, entries) {
   ATTR_WITH_MARKER_RE.lastIndex = 0;
   let match;
   while ((match = ATTR_WITH_MARKER_RE.exec(htmlString)) !== null) {
-    const attrValue = match[2] !== undefined ? match[2] : match[3];
+    const attrValue = match[1] !== undefined ? match[1] : match[2];
     const { parts, markerIDs } = parseAttributeParts(attrValue);
     if (markerIDs.length === 0) { continue; }
     const entry = entries[markerIDs[0]];

--- a/packages/renderer/src/build-html-string.js
+++ b/packages/renderer/src/build-html-string.js
@@ -31,8 +31,7 @@ export const MAIN_BRANCH_INDEX = 1000;
 // where N is the first-entry ID. Name prefixes: `.prop`, `@event`, `?attr`.
 export const DATA_SUI_BIND = 'data-sui-bind';
 
-// Build a closing block marker comment data string. `meta.branchIndex` is
-// the only reserved suffix today; future suffixes added here.
+// Closing-marker payload. `branchIndex` is the only reserved suffix.
 export function formatBlockClose(id, meta) {
   let s = `${BLOCK_CLOSE_PREFIX}${MARKER_VERSION}:${id}`;
   if (meta && meta.branchIndex !== undefined) {
@@ -41,18 +40,15 @@ export function formatBlockClose(id, meta) {
   return s;
 }
 
-// Parse trailing metadata from a closing block marker into target.
 // `bN` → branchIndex; unknown segments ignored.
 export function parseServerMeta(commentData, target) {
   for (const part of commentData.split(':')) {
     if (part.startsWith('b')) {
-      target.branchIndex = parseInt(part.slice(1));
+      target.branchIndex = +part.slice(1);
     }
   }
 }
 
-// Walkers across renderer and each-block share these so prefix literals
-// stay in one place.
 export function isBlockOpen(commentData) {
   return commentData.startsWith(BLOCK_MARKER);
 }
@@ -66,13 +62,13 @@ export function isRawTextMarker(commentData) {
   return commentData.startsWith(RAW_TEXT_MARKER);
 }
 export function parseBlockOpenID(commentData) {
-  return parseInt(commentData.slice(BLOCK_MARKER.length));
+  return +commentData.slice(BLOCK_MARKER.length);
 }
 export function parseExpressionID(commentData) {
-  return parseInt(commentData.slice(COMMENT_MARKER.length));
+  return +commentData.slice(COMMENT_MARKER.length);
 }
 export function parseRawTextID(commentData) {
-  return parseInt(commentData.slice(RAW_TEXT_MARKER.length));
+  return +commentData.slice(RAW_TEXT_MARKER.length);
 }
 
 // Compiled once — `lastIndex` is reset manually per use so the regex can
@@ -312,12 +308,11 @@ function populateAttributeBindings(htmlString, entries) {
   ATTR_WITH_MARKER_RE.lastIndex = 0;
   let match;
   while ((match = ATTR_WITH_MARKER_RE.exec(htmlString)) !== null) {
-    const rawAttrName = match[1];
     const attrValue = match[2] !== undefined ? match[2] : match[3];
     const { parts, markerIDs } = parseAttributeParts(attrValue);
     if (markerIDs.length === 0) { continue; }
     const entry = entries[markerIDs[0]];
     if (!entry) { continue; }
-    entry.attributeBinding = { rawAttrName, parts, markerIDs };
+    entry.attributeBinding = { parts };
   }
 }

--- a/packages/renderer/src/build-html-string.js
+++ b/packages/renderer/src/build-html-string.js
@@ -79,8 +79,8 @@ export function parseRawTextID(commentData) {
 const ATTR_MARKER_RE = new RegExp(`${ATTR_MARKER_PREFIX}(\\d+)${ATTR_MARKER_SUFFIX}`, 'g');
 
 // Split an attribute value like `card __sui0__` or `foo __sui1__ bar __sui2__`
-// into static/dynamic parts. Used by both render-path binding and hydrate
-// lookup via entries[id].attributeBinding.
+// into static/dynamic parts. Used by render-path binding and the hydrate
+// lookup via entries[id].attributeParts.
 export function parseAttributeParts(attrValue) {
   const parts = [];
   const markerIDs = [];

--- a/packages/renderer/src/build-html-string.js
+++ b/packages/renderer/src/build-html-string.js
@@ -39,11 +39,15 @@ export function formatBlockClose(id, meta) {
   return s;
 }
 
-// `bN` → branchIndex; unknown segments ignored.
+// `bN` (signed integer) → branchIndex. Strict digit suffix so future
+// reserved prefixes like `block`/`bypass` don't accidentally clobber.
+// Allows the `-1` sentinel emitted when no conditional branch matched.
+const META_BRANCH_RE = /^b(-?\d+)$/;
 export function parseServerMeta(commentData, target) {
   for (const part of commentData.split(':')) {
-    if (part.startsWith('b')) {
-      target.branchIndex = +part.slice(1);
+    const m = META_BRANCH_RE.exec(part);
+    if (m) {
+      target.branchIndex = +m[1];
     }
   }
 }
@@ -278,11 +282,11 @@ export function buildHTMLString(ast, { snippets = {}, isSVG: initialSVG = false 
   return { htmlString, entries, snippets };
 }
 
-// Attach `attributeBinding` to the first entry of each attribute whose
-// value carries one or more markers. `parts` covers the full value
-// (alternating static/dynamic segments) so bindAttribute can reconstruct
-// the interpolation in one pass. The hydration path resolves the binding
-// via `data-sui-bind` → first entry → attributeBinding.parts.
+// Attach `attributeParts` to the first entry of each attribute whose value
+// carries one or more markers. `parts` covers the full value (alternating
+// static/dynamic segments) so bindAttribute can reconstruct the
+// interpolation in one pass. The hydration path resolves the binding via
+// `data-sui-bind` → first entry → entry.attributeParts.
 const ATTR_WITH_MARKER_RE = /\s(?:[.@]?[\w:-]+)\s*=\s*(?:"([^"]*__sui\d+__[^"]*)"|([^\s"'>]*__sui\d+__[^\s"'>]*))/g;
 
 function populateAttributeBindings(htmlString, entries) {
@@ -294,6 +298,6 @@ function populateAttributeBindings(htmlString, entries) {
     if (markerIDs.length === 0) { continue; }
     const entry = entries[markerIDs[0]];
     if (!entry) { continue; }
-    entry.attributeBinding = { parts };
+    entry.attributeParts = parts;
   }
 }

--- a/packages/renderer/src/build-html-string.js
+++ b/packages/renderer/src/build-html-string.js
@@ -48,6 +48,36 @@ export function parseServerMeta(commentData, target) {
   }
 }
 
+// Comment-marker classifiers — single-source-of-truth predicates over
+// the documented marker prefixes. Walkers in the renderer and each-block
+// use these to recognize block-open / block-close / expression / raw-text
+// boundaries without redeclaring the prefix strings.
+//
+// Each `parse*ID` returns the numeric ID minted in `populateAttributeBindings`
+// or `processNodes`; NaN is returned when the prefix matches but the suffix
+// isn't a number, which never happens for compiler-emitted comments.
+export function isBlockOpen(commentData) {
+  return commentData.startsWith(BLOCK_MARKER);
+}
+export function isBlockClose(commentData) {
+  return commentData.startsWith(BLOCK_CLOSE_PREFIX);
+}
+export function isExpressionMarker(commentData) {
+  return commentData.startsWith(COMMENT_MARKER);
+}
+export function isRawTextMarker(commentData) {
+  return commentData.startsWith(RAW_TEXT_MARKER);
+}
+export function parseBlockOpenID(commentData) {
+  return parseInt(commentData.slice(BLOCK_MARKER.length));
+}
+export function parseExpressionID(commentData) {
+  return parseInt(commentData.slice(COMMENT_MARKER.length));
+}
+export function parseRawTextID(commentData) {
+  return parseInt(commentData.slice(RAW_TEXT_MARKER.length));
+}
+
 // Marker for raw text element content (script, style, textarea, title)
 export const RAW_TEXT_MARKER = `sui-rawtext:${MARKER_VERSION}:`;
 

--- a/packages/renderer/src/build-html-string.js
+++ b/packages/renderer/src/build-html-string.js
@@ -16,8 +16,8 @@ export const COMMENT_MARKER = `sui:${MARKER_VERSION}:`;
 export const BLOCK_MARKER = `sui-block:${MARKER_VERSION}:`;
 export const RAW_TEXT_MARKER = `sui-rawtext:${MARKER_VERSION}:`;
 
-// Closing block markers omit the version segment. Version match is enforced
-// at the open marker; the close just balances depth.
+// Prefix only — full close marker is `/sui-block:v1:N[:bX]`. Version match
+// is enforced at the open marker so `startsWith` callers compare without it.
 export const BLOCK_CLOSE_PREFIX = '/sui-block:';
 
 // Sentinel for {#if} main-body in branchIndex serialization — branches

--- a/packages/renderer/src/build-html-string.js
+++ b/packages/renderer/src/build-html-string.js
@@ -27,7 +27,9 @@ export const MAIN_BRANCH_INDEX = 1000;
 
 // Stamped on elements with dynamic bindings so the client can wire
 // Reactions without a reference-DOM walk. Encoding: `attr=N[,attr=N]*`
-// where N is the first-entry ID. Name prefixes: `.prop`, `@event`, `?attr`.
+// where N is the first-entry ID. Name prefixes: `.prop` for property
+// bindings, `@event` for event listeners; boolean attrs use the bare
+// name (classification.type === 'boolean' on the entry).
 export const DATA_SUI_BIND = 'data-sui-bind';
 
 // Closing-marker payload. `branchIndex` is the only reserved suffix.

--- a/packages/renderer/src/build-html-string.js
+++ b/packages/renderer/src/build-html-string.js
@@ -33,6 +33,12 @@ export const RAW_TEXT_MARKER = `sui-rawtext:${MARKER_VERSION}:`;
 // metadata lives on the prototype-cached entries array.
 export const DATA_SUI_BIND = 'data-sui-bind';
 
+// Sentinel branchIndex for the main {#if} body. Branches array is indexed
+// from 0 ({:elseif}/{:else}); 1000 reserves a value above any plausible
+// branch count to mean "main body matched". Persisted on the closing block
+// marker as `:b1000` for hydration mismatch detection.
+export const MAIN_BRANCH_INDEX = 1000;
+
 // Compiled once — `lastIndex` is reset manually per use so the regex can
 // be reused across parse calls without cross-talk.
 const ATTR_MARKER_RE = new RegExp(`${ATTR_MARKER_PREFIX}(\\d+)${ATTR_MARKER_SUFFIX}`, 'g');

--- a/packages/renderer/src/build-html-string.js
+++ b/packages/renderer/src/build-html-string.js
@@ -20,6 +20,34 @@ export const COMMENT_MARKER = `sui:${MARKER_VERSION}:`;
 // Marker for block-level directive positions
 export const BLOCK_MARKER = `sui-block:${MARKER_VERSION}:`;
 
+// Prefix for closing block markers — version-stripped because version
+// match is enforced at the open marker; the close just balances depth.
+// Read sites use this for `startsWith` checks.
+export const BLOCK_CLOSE_PREFIX = '/sui-block:';
+
+// Build a closing block marker comment data string. `meta.branchIndex`
+// is the only reserved suffix today (conditional block); future suffixes
+// can be added here without touching write/parse sites.
+export function formatBlockClose(id, meta) {
+  let s = `/sui-block:${MARKER_VERSION}:${id}`;
+  if (meta && meta.branchIndex !== undefined) {
+    s += `:b${meta.branchIndex}`;
+  }
+  return s;
+}
+
+// Parse trailing metadata from a closing block marker into target.
+// Reserved suffixes (after the version segment):
+//   bN  → branchIndex (which branch the {#if}/{:elseif}/{:else} server picked)
+// Unknown segments are ignored. Mutates target in place.
+export function parseServerMeta(commentData, target) {
+  for (const part of commentData.split(':')) {
+    if (part.startsWith('b')) {
+      target.branchIndex = parseInt(part.slice(1));
+    }
+  }
+}
+
 // Marker for raw text element content (script, style, textarea, title)
 export const RAW_TEXT_MARKER = `sui-rawtext:${MARKER_VERSION}:`;
 

--- a/packages/renderer/src/build-html-string.js
+++ b/packages/renderer/src/build-html-string.js
@@ -10,26 +10,31 @@
 export const ATTR_MARKER_PREFIX = '__sui';
 export const ATTR_MARKER_SUFFIX = '__';
 
-// Versioned markers — client checks version on hydration,
-// falls back to full render on mismatch
+// Versioned so client can detect server/client mismatches at hydrate time.
 export const MARKER_VERSION = 'v1';
 
-// Marker for text-position expressions (comment nodes)
 export const COMMENT_MARKER = `sui:${MARKER_VERSION}:`;
-
-// Marker for block-level directive positions
 export const BLOCK_MARKER = `sui-block:${MARKER_VERSION}:`;
+export const RAW_TEXT_MARKER = `sui-rawtext:${MARKER_VERSION}:`;
 
-// Prefix for closing block markers — version-stripped because version
-// match is enforced at the open marker; the close just balances depth.
-// Read sites use this for `startsWith` checks.
+// Closing block markers omit the version segment. Version match is enforced
+// at the open marker; the close just balances depth.
 export const BLOCK_CLOSE_PREFIX = '/sui-block:';
 
-// Build a closing block marker comment data string. `meta.branchIndex`
-// is the only reserved suffix today (conditional block); future suffixes
-// can be added here without touching write/parse sites.
+// Sentinel for {#if} main-body in branchIndex serialization — branches
+// array indexes from 0 for {:elseif}/{:else}, so 1000 reserves a value
+// above any plausible branch count.
+export const MAIN_BRANCH_INDEX = 1000;
+
+// Stamped on elements with dynamic bindings so the client can wire
+// Reactions without a reference-DOM walk. Encoding: `attr=N[,attr=N]*`
+// where N is the first-entry ID. Name prefixes: `.prop`, `@event`, `?attr`.
+export const DATA_SUI_BIND = 'data-sui-bind';
+
+// Build a closing block marker comment data string. `meta.branchIndex` is
+// the only reserved suffix today; future suffixes added here.
 export function formatBlockClose(id, meta) {
-  let s = `/sui-block:${MARKER_VERSION}:${id}`;
+  let s = `${BLOCK_CLOSE_PREFIX}${MARKER_VERSION}:${id}`;
   if (meta && meta.branchIndex !== undefined) {
     s += `:b${meta.branchIndex}`;
   }
@@ -37,9 +42,7 @@ export function formatBlockClose(id, meta) {
 }
 
 // Parse trailing metadata from a closing block marker into target.
-// Reserved suffixes (after the version segment):
-//   bN  → branchIndex (which branch the {#if}/{:elseif}/{:else} server picked)
-// Unknown segments are ignored. Mutates target in place.
+// `bN` → branchIndex; unknown segments ignored.
 export function parseServerMeta(commentData, target) {
   for (const part of commentData.split(':')) {
     if (part.startsWith('b')) {
@@ -48,14 +51,8 @@ export function parseServerMeta(commentData, target) {
   }
 }
 
-// Comment-marker classifiers — single-source-of-truth predicates over
-// the documented marker prefixes. Walkers in the renderer and each-block
-// use these to recognize block-open / block-close / expression / raw-text
-// boundaries without redeclaring the prefix strings.
-//
-// Each `parse*ID` returns the numeric ID minted in `populateAttributeBindings`
-// or `processNodes`; NaN is returned when the prefix matches but the suffix
-// isn't a number, which never happens for compiler-emitted comments.
+// Walkers across renderer and each-block share these so prefix literals
+// stay in one place.
 export function isBlockOpen(commentData) {
   return commentData.startsWith(BLOCK_MARKER);
 }
@@ -77,25 +74,6 @@ export function parseExpressionID(commentData) {
 export function parseRawTextID(commentData) {
   return parseInt(commentData.slice(RAW_TEXT_MARKER.length));
 }
-
-// Marker for raw text element content (script, style, textarea, title)
-export const RAW_TEXT_MARKER = `sui-rawtext:${MARKER_VERSION}:`;
-
-// Attribute stamped by the server on elements with dynamic bindings so the
-// client can wire Reactions without reconstructing a reference DOM from the
-// AST (eliminates the parallel-TreeWalker dance in hydrateAttributes).
-// Encoding: `attr=N[,attr=N]*` where N is the first-entry ID for that
-// attribute. Name prefixes: `.prop` property, `@event` event, `?attr`
-// boolean. Entries[N].attributeBinding carries full parts + classification,
-// so the data-sui-bind string stays minimal and all static/multi-expression
-// metadata lives on the prototype-cached entries array.
-export const DATA_SUI_BIND = 'data-sui-bind';
-
-// Sentinel branchIndex for the main {#if} body. Branches array is indexed
-// from 0 ({:elseif}/{:else}); 1000 reserves a value above any plausible
-// branch count to mean "main body matched". Persisted on the closing block
-// marker as `:b1000` for hydration mismatch detection.
-export const MAIN_BRANCH_INDEX = 1000;
 
 // Compiled once — `lastIndex` is reset manually per use so the regex can
 // be reused across parse calls without cross-talk.
@@ -340,10 +318,6 @@ function populateAttributeBindings(htmlString, entries) {
     if (markerIDs.length === 0) { continue; }
     const entry = entries[markerIDs[0]];
     if (!entry) { continue; }
-    // firstMarkerID is markerIDs[0] but can differ from parts[0].markerID
-    // when the attribute leads with static text (e.g. `class="card {x}"`).
-    // Stored once so reactive-data.js's bindAttribute doesn't `parts.find`
-    // on every binding setup.
-    entry.attributeBinding = { rawAttrName, parts, markerIDs, firstMarkerID: markerIDs[0] };
+    entry.attributeBinding = { rawAttrName, parts, markerIDs };
   }
 }

--- a/packages/renderer/src/engines/native/blocks/conditional.js
+++ b/packages/renderer/src/engines/native/blocks/conditional.js
@@ -1,4 +1,5 @@
 import { isDevelopment } from '@semantic-ui/utils';
+import { MAIN_BRANCH_INDEX } from '../../../build-html-string.js';
 import { defineBlock } from '../define-block.js';
 import { registerBlock } from './registry.js';
 
@@ -6,8 +7,8 @@ import { registerBlock } from './registry.js';
 
   {#if} / {:elseif} / {:else} — compiled as a single AST node with
   node.condition + node.branches[]. Branch matching is linear: the first
-  truthy branch wins; matchIndex of 1000 is reserved for the main {#if}
-  body and any numeric index i refers to node.branches[i].
+  truthy branch wins; matchIndex MAIN_BRANCH_INDEX is reserved for the
+  main {#if} body and any numeric index i refers to node.branches[i].
 
   Hydration: the server writes serverMeta.branchIndex on the closing block
   marker. On mount, the block compares server vs. client branch choice
@@ -19,9 +20,7 @@ import { registerBlock } from './registry.js';
 
 function selectBranch(node, lookupExpression) {
   if (lookupExpression(node.condition)) {
-    // matchIndex 1000 distinguishes the main {#if} body from any {:elseif}
-    // or {:else} branch whose index starts at 0. See update's equality check.
-    return { matchIndex: 1000, contentAST: node.content };
+    return { matchIndex: MAIN_BRANCH_INDEX, contentAST: node.content };
   }
   if (node.branches?.length) {
     for (let i = 0; i < node.branches.length; i++) {
@@ -40,7 +39,7 @@ function selectBranch(node, lookupExpression) {
 }
 
 function branchASTByIndex(node, matchIndex) {
-  if (matchIndex === 1000) { return node.content; }
+  if (matchIndex === MAIN_BRANCH_INDEX) { return node.content; }
   if (matchIndex >= 0 && node.branches?.[matchIndex]) {
     return node.branches[matchIndex].content;
   }

--- a/packages/renderer/src/engines/native/blocks/conditional.js
+++ b/packages/renderer/src/engines/native/blocks/conditional.js
@@ -64,7 +64,7 @@ const conditional = defineBlock({
     }
   },
 
-  hydrate({ node, data, scope, region, serverMeta, renderAST, lookupExpression, hydrateInnerContent, self }) {
+  hydrate({ node, scope, region, serverMeta, renderAST, lookupExpression, hydrateInto, self }) {
     const clientBranch = selectBranch(node, lookupExpression);
     const serverBranchIndex = serverMeta?.branchIndex;
     const hasMismatch = serverBranchIndex !== undefined
@@ -96,12 +96,7 @@ const conditional = defineBlock({
       // against the chosen branch's AST, then move nodes into the region.
       const innerAST = branchASTByIndex(node, clientBranch.matchIndex);
       if (innerAST) {
-        const innerScope = scope.child();
-        region.childScopes.push(innerScope);
-        hydrateInnerContent({ ownedNodes: region.ownedNodes, innerAST, data, scope: innerScope });
-        const frag = document.createDocumentFragment();
-        for (const n of region.ownedNodes) { frag.appendChild(n); }
-        region.anchor.after(frag);
+        hydrateInto({ innerAST });
       }
     }
 

--- a/packages/renderer/src/engines/native/blocks/each.js
+++ b/packages/renderer/src/engines/native/blocks/each.js
@@ -1,6 +1,6 @@
 import { Signal } from '@semantic-ui/reactivity';
 import { arrayFromObject, isArray, isEmpty } from '@semantic-ui/utils';
-import { BLOCK_CLOSE_PREFIX, BLOCK_MARKER } from '../../../build-html-string.js';
+import { isBlockClose, isBlockOpen } from '../../../build-html-string.js';
 import { defineBlock } from '../define-block.js';
 import { decodeItemKey, getEachData, getItemID, SUI_ITEM_MARKER } from '../shared/each.js';
 import { registerBlock } from './registry.js';
@@ -424,12 +424,12 @@ function extractServerItemGroups(ownedNodes) {
   for (const n of ownedNodes) {
     if (n.nodeType === Node.COMMENT_NODE) {
       const data = n.data;
-      if (data.startsWith(BLOCK_MARKER)) {
+      if (isBlockOpen(data)) {
         blockDepth++;
         if (current) { current.nodes.push(n); }
         continue;
       }
-      if (data.startsWith(BLOCK_CLOSE_PREFIX)) {
+      if (isBlockClose(data)) {
         blockDepth--;
         if (current) { current.nodes.push(n); }
         continue;

--- a/packages/renderer/src/engines/native/blocks/each.js
+++ b/packages/renderer/src/engines/native/blocks/each.js
@@ -512,9 +512,9 @@ function adoptServerItems({
         serverGroup.startComment.replaceWith(startMarker);
       }
 
-      // Server output may include sibling block markers between item
-      // boundaries — reassemble explicitly so endMarker lands after the
-      // last item node regardless.
+      // Sibling block markers can land between item boundaries —
+      // reassemble via fragment so endMarker follows the last item node,
+      // not whichever node happens to be last.
       const frag = document.createDocumentFragment();
       frag.append(startMarker, ...mutableNodes, endMarker);
       insertAfter.after(frag);

--- a/packages/renderer/src/engines/native/blocks/each.js
+++ b/packages/renderer/src/engines/native/blocks/each.js
@@ -254,7 +254,6 @@ function disposeRecord(record) {
 // Phase 3: itemSignal updates for records whose item/index changed.
 function reconcile({ records, items, collectionType, node, data, scope, region, renderAST, isSVG }) {
   const oldRecords = records.slice();
-  const oldKeys = oldRecords.map((r) => r.key);
   const newKeys = items.map((item, i) => getItemID(item, i, collectionType));
   const newRecords = new Array(items.length);
 
@@ -274,30 +273,30 @@ function reconcile({ records, items, collectionType, node, data, scope, region, 
       oldTail--;
       continue;
     }
-    if (oldKeys[oldHead] === newKeys[newHead]) {
+    if (oldRecords[oldHead].key === newKeys[newHead]) {
       newRecords[newHead++] = oldRecords[oldHead++];
     }
-    else if (oldKeys[oldTail] === newKeys[newTail]) {
+    else if (oldRecords[oldTail].key === newKeys[newTail]) {
       newRecords[newTail--] = oldRecords[oldTail--];
     }
-    else if (oldKeys[oldHead] === newKeys[newTail]) {
+    else if (oldRecords[oldHead].key === newKeys[newTail]) {
       newRecords[newTail--] = oldRecords[oldHead++];
     }
-    else if (oldKeys[oldTail] === newKeys[newHead]) {
+    else if (oldRecords[oldTail].key === newKeys[newHead]) {
       newRecords[newHead++] = oldRecords[oldTail--];
     }
     else {
       if (!oldKeyToIdx) {
         oldKeyToIdx = new Map();
-        for (let i = oldHead; i <= oldTail; i++) { oldKeyToIdx.set(oldKeys[i], i); }
+        for (let i = oldHead; i <= oldTail; i++) { oldKeyToIdx.set(oldRecords[i].key, i); }
         newKeySet = new Set();
         for (let i = newHead; i <= newTail; i++) { newKeySet.add(newKeys[i]); }
       }
-      if (!newKeySet.has(oldKeys[oldHead])) {
+      if (!newKeySet.has(oldRecords[oldHead].key)) {
         disposeRecord(oldRecords[oldHead]);
         oldHead++;
       }
-      else if (!newKeySet.has(oldKeys[oldTail])) {
+      else if (!newKeySet.has(oldRecords[oldTail].key)) {
         disposeRecord(oldRecords[oldTail]);
         oldTail--;
       }

--- a/packages/renderer/src/engines/native/blocks/each.js
+++ b/packages/renderer/src/engines/native/blocks/each.js
@@ -512,9 +512,9 @@ function adoptServerItems({
         serverGroup.startComment.replaceWith(startMarker);
       }
 
-      // Reassemble [startMarker, ...mutableNodes, endMarker] via a fragment
-      // so endMarker lands directly after the last item node regardless of
-      // intervening server output.
+      // Server output may include sibling block markers between item
+      // boundaries — reassemble explicitly so endMarker lands after the
+      // last item node regardless.
       const frag = document.createDocumentFragment();
       frag.append(startMarker, ...mutableNodes, endMarker);
       insertAfter.after(frag);

--- a/packages/renderer/src/engines/native/blocks/each.js
+++ b/packages/renderer/src/engines/native/blocks/each.js
@@ -215,6 +215,7 @@ function disposeRecord(record) {
 // Phase 3: itemSignal updates for records whose item/index changed.
 function reconcile({ records, items, collectionType, node, data, scope, region, renderAST, isSVG }) {
   const oldRecords = records.slice();
+  const oldKeys = oldRecords.map((r) => r.key);
   const newKeys = items.map((item, i) => getItemID(item, i, collectionType));
   const newRecords = new Array(items.length);
 
@@ -234,30 +235,30 @@ function reconcile({ records, items, collectionType, node, data, scope, region, 
       oldTail--;
       continue;
     }
-    if (oldRecords[oldHead].key === newKeys[newHead]) {
+    if (oldKeys[oldHead] === newKeys[newHead]) {
       newRecords[newHead++] = oldRecords[oldHead++];
     }
-    else if (oldRecords[oldTail].key === newKeys[newTail]) {
+    else if (oldKeys[oldTail] === newKeys[newTail]) {
       newRecords[newTail--] = oldRecords[oldTail--];
     }
-    else if (oldRecords[oldHead].key === newKeys[newTail]) {
+    else if (oldKeys[oldHead] === newKeys[newTail]) {
       newRecords[newTail--] = oldRecords[oldHead++];
     }
-    else if (oldRecords[oldTail].key === newKeys[newHead]) {
+    else if (oldKeys[oldTail] === newKeys[newHead]) {
       newRecords[newHead++] = oldRecords[oldTail--];
     }
     else {
       if (!oldKeyToIdx) {
         oldKeyToIdx = new Map();
-        for (let i = oldHead; i <= oldTail; i++) { oldKeyToIdx.set(oldRecords[i].key, i); }
+        for (let i = oldHead; i <= oldTail; i++) { oldKeyToIdx.set(oldKeys[i], i); }
         newKeySet = new Set();
         for (let i = newHead; i <= newTail; i++) { newKeySet.add(newKeys[i]); }
       }
-      if (!newKeySet.has(oldRecords[oldHead].key)) {
+      if (!newKeySet.has(oldKeys[oldHead])) {
         disposeRecord(oldRecords[oldHead]);
         oldHead++;
       }
-      else if (!newKeySet.has(oldRecords[oldTail].key)) {
+      else if (!newKeySet.has(oldKeys[oldTail])) {
         disposeRecord(oldRecords[oldTail]);
         oldTail--;
       }

--- a/packages/renderer/src/engines/native/blocks/each.js
+++ b/packages/renderer/src/engines/native/blocks/each.js
@@ -1,5 +1,6 @@
 import { Signal } from '@semantic-ui/reactivity';
 import { arrayFromObject, isArray, isEmpty, isPlainObject, isString } from '@semantic-ui/utils';
+import { BLOCK_CLOSE_PREFIX, BLOCK_MARKER } from '../../../build-html-string.js';
 import { defineBlock } from '../define-block.js';
 import { registerBlock } from './registry.js';
 
@@ -463,12 +464,12 @@ function extractServerItemGroups(ownedNodes) {
   for (const n of ownedNodes) {
     if (n.nodeType === Node.COMMENT_NODE) {
       const data = n.data;
-      if (data.startsWith('sui-block:v1:')) {
+      if (data.startsWith(BLOCK_MARKER)) {
         blockDepth++;
         if (current) { current.nodes.push(n); }
         continue;
       }
-      if (data.startsWith('/sui-block:')) {
+      if (data.startsWith(BLOCK_CLOSE_PREFIX)) {
         blockDepth--;
         if (current) { current.nodes.push(n); }
         continue;

--- a/packages/renderer/src/engines/native/blocks/each.js
+++ b/packages/renderer/src/engines/native/blocks/each.js
@@ -511,15 +511,11 @@ function adoptServerItems({
         serverGroup.startComment.replaceWith(startMarker);
       }
 
-      // Move [startMarker, ...mutableNodes, endMarker] into position
-      // after `insertAfter`. Server order generally matches client
-      // order so the contiguous range is already close to correct — we
-      // still reassemble via a fragment to guarantee endMarker lands
-      // right after the last item node regardless of intervening nodes.
+      // Reassemble [startMarker, ...mutableNodes, endMarker] via a fragment
+      // so endMarker lands directly after the last item node regardless of
+      // intervening server output.
       const frag = document.createDocumentFragment();
-      frag.appendChild(startMarker);
-      for (const n of mutableNodes) { frag.appendChild(n); }
-      frag.appendChild(endMarker);
+      frag.append(startMarker, ...mutableNodes, endMarker);
       insertAfter.after(frag);
       insertAfter = endMarker;
 
@@ -599,8 +595,6 @@ const eachBlock = defineBlock({
 
     if (items.length === 0) {
       if (node.elseContent) {
-        // isElse record is the signal `update` reads to detect the
-        // else→items transition.
         const elseScope = hydrateInto({ innerAST: node.elseContent });
         self.records.push({
           key: null,

--- a/packages/renderer/src/engines/native/blocks/each.js
+++ b/packages/renderer/src/engines/native/blocks/each.js
@@ -594,32 +594,17 @@ const eachBlock = defineBlock({
     });
   },
 
-  hydrate({ node, data, scope, region, renderAST, lookupExpression, hydrateInnerContent, self, isSVG }) {
+  hydrate({ node, data, scope, region, renderAST, lookupExpression, hydrateInnerContent, hydrateInto, self, isSVG }) {
     // resolveItems registers the items dep via lookupExpression.
     const { items, collectionType } = resolveItems(node, lookupExpression);
 
     if (items.length === 0) {
       if (node.elseContent) {
-        // Server rendered the else branch into region.ownedNodes.
-        // Hydrate it in place and push an isElse record so subsequent
-        // `update` calls recognize the else state and transition
-        // correctly. elseScope goes on region.childScopes so the next
-        // `region.clear()` disposes it (renderElse gets this via
-        // region.setContent; the hydrate path bypasses setContent
-        // because the DOM is already in place).
-        const elseScope = scope.child();
-        region.childScopes.push(elseScope);
-        hydrateInnerContent({
-          ownedNodes: region.ownedNodes,
-          innerAST: node.elseContent,
-          data,
-          scope: elseScope,
-        });
-        // hydrateInnerContent moves nodes into a temp fragment; reinsert
-        // them after the region's anchor.
-        const frag = document.createDocumentFragment();
-        for (const n of region.ownedNodes) { frag.appendChild(n); }
-        region.anchor.after(frag);
+        // Server rendered the else branch. hydrateInto creates the
+        // child elseScope, registers it on region.childScopes, hydrates
+        // in place, and reattaches. We push an isElse record so update
+        // recognizes the else state and transitions correctly.
+        const elseScope = hydrateInto({ innerAST: node.elseContent });
         self.records.push({
           key: null,
           item: null,

--- a/packages/renderer/src/engines/native/blocks/each.js
+++ b/packages/renderer/src/engines/native/blocks/each.js
@@ -1,7 +1,8 @@
 import { Signal } from '@semantic-ui/reactivity';
-import { arrayFromObject, isArray, isEmpty, isPlainObject, isString } from '@semantic-ui/utils';
+import { arrayFromObject, isArray, isEmpty } from '@semantic-ui/utils';
 import { BLOCK_CLOSE_PREFIX, BLOCK_MARKER } from '../../../build-html-string.js';
 import { defineBlock } from '../define-block.js';
+import { decodeItemKey, getEachData, getItemID, SUI_ITEM_MARKER } from '../shared/each.js';
 import { registerBlock } from './registry.js';
 
 /*
@@ -23,8 +24,6 @@ import { registerBlock } from './registry.js';
 
 */
 
-const SUI_ITEM_MARKER = 'sui-item:v1:';
-
 // Proxies created by this module go into the WeakSet; template.js checks
 // membership to decide when expression reads should register deps directly
 // (item context) versus wrapping in Reaction.nonreactive (static data).
@@ -35,45 +34,6 @@ export function isItemContext(data) {
 
 function getCollectionType(items) {
   return isArray(items) ? 'array' : 'object';
-}
-
-function getItemID(item, indexOrKey, collectionType) {
-  // Always stringify — the server emits keys as text inside
-  // `<!--sui-item:v1:KEY-->` comments, and Map / === compare by value
-  // identity. Without stringification, numeric item IDs on the client
-  // miss string keys on the server at adoption time (and records keyed
-  // as numbers from a fresh render would miss string keys on the next
-  // reconcile after adoption).
-  let raw;
-  if (isPlainObject(item)) {
-    const key = (collectionType === 'object') ? indexOrKey : undefined;
-    raw = key || item._id || item.id || item.key || item.hash || item._hash || item.value || indexOrKey;
-  }
-  else if (isString(item)) {
-    raw = item + ':' + indexOrKey;
-  }
-  else {
-    raw = indexOrKey;
-  }
-  return String(raw);
-}
-
-function getEachData(item, indexOrKey, collectionType, node) {
-  let { as, indexAs } = node;
-  if (!indexAs) {
-    indexAs = (collectionType === 'array') ? 'index' : 'key';
-  }
-  if (collectionType === 'object') {
-    indexOrKey = item.key;
-    item = item.value;
-  }
-  // The wrapper is always a fresh object so Signal.set() sees a new
-  // top-level reference and doesn't short-circuit on identity. Inner
-  // properties are shallow-copied from item (for the no-`as` case) so
-  // mutations to item's own properties ARE captured at the wrapper level.
-  return as
-    ? { [as]: item, [indexAs]: indexOrKey }
-    : { ...item, this: item, [indexAs]: indexOrKey };
 }
 
 // Allocate once per record at first reconcile (createSnapshot). On
@@ -476,14 +436,7 @@ function extractServerItemGroups(ownedNodes) {
       }
       if (blockDepth === 0 && data.startsWith(SUI_ITEM_MARKER)) {
         if (current) { groups.push(current); }
-        const rawKey = data.slice(SUI_ITEM_MARKER.length);
-        let key;
-        try {
-          key = decodeURIComponent(rawKey);
-        }
-        catch {
-          key = rawKey;
-        }
+        const key = decodeItemKey(data.slice(SUI_ITEM_MARKER.length));
         current = { key, startComment: n, nodes: [] };
         continue;
       }

--- a/packages/renderer/src/engines/native/blocks/each.js
+++ b/packages/renderer/src/engines/native/blocks/each.js
@@ -595,15 +595,12 @@ const eachBlock = defineBlock({
   },
 
   hydrate({ node, data, scope, region, renderAST, lookupExpression, hydrateInnerContent, hydrateInto, self, isSVG }) {
-    // resolveItems registers the items dep via lookupExpression.
     const { items, collectionType } = resolveItems(node, lookupExpression);
 
     if (items.length === 0) {
       if (node.elseContent) {
-        // Server rendered the else branch. hydrateInto creates the
-        // child elseScope, registers it on region.childScopes, hydrates
-        // in place, and reattaches. We push an isElse record so update
-        // recognizes the else state and transitions correctly.
+        // isElse record is the signal `update` reads to detect the
+        // else→items transition.
         const elseScope = hydrateInto({ innerAST: node.elseContent });
         self.records.push({
           key: null,

--- a/packages/renderer/src/engines/native/blocks/rerender.js
+++ b/packages/renderer/src/engines/native/blocks/rerender.js
@@ -48,14 +48,9 @@ const rerender = defineBlock({
 
   hydrate(ctx) {
     trackDeps(ctx);
-    const { node, data, scope, region, hydrateInnerContent } = ctx;
+    const { node, region, hydrateInto } = ctx;
     if (region.ownedNodes.length > 0 && node.content) {
-      const innerScope = scope.child();
-      region.childScopes.push(innerScope);
-      hydrateInnerContent({ ownedNodes: region.ownedNodes, innerAST: node.content, data, scope: innerScope });
-      const frag = document.createDocumentFragment();
-      for (const n of region.ownedNodes) { frag.appendChild(n); }
-      region.anchor.after(frag);
+      hydrateInto({ innerAST: node.content });
     }
   },
 

--- a/packages/renderer/src/engines/native/blocks/sample.js
+++ b/packages/renderer/src/engines/native/blocks/sample.js
@@ -80,10 +80,10 @@ const sample = defineBlock({
 
   /*
     render(bag) — first mount on the client (no server-rendered DOM to
-    adopt). The bag has the documented 9 keys (node, data, scope, region,
-    isSVG, serverMeta, self, plus the closures lookupExpression /
-    renderAST / hydrateInnerContent). Use them; don't pull from anywhere
-    else.
+    adopt). The bag has node, data, scope, region, isSVG, serverMeta,
+    self, plus the closures lookupExpression / renderAST /
+    hydrateInnerContent / hydrateInto. Use them; don't pull from
+    anywhere else.
 
     Pattern: build a fragment via renderAST(), put it in the region via
     region.setContent(fragment, optionalChildScope). The region owns DOM

--- a/packages/renderer/src/engines/native/blocks/sample.js
+++ b/packages/renderer/src/engines/native/blocks/sample.js
@@ -125,10 +125,6 @@ const sample = defineBlock({
     discards the server's. The whole point of hydrate is to keep the
     server's bytes.
 
-    Pass `asChild: false` if your block's inner Reactions live on the
-    block's own scope rather than a child (snippet pattern). Default is
-    create-and-register a child scope (most blocks).
-
     serverMeta contains anything the ServerRenderer wrote into the
     closing block marker (see parseServerMeta in build-html-string.js
     for the prefix scheme). Use it for branch selection, key recovery,

--- a/packages/renderer/src/engines/native/blocks/sample.js
+++ b/packages/renderer/src/engines/native/blocks/sample.js
@@ -117,35 +117,30 @@ const sample = defineBlock({
       1. Register the same Signal deps render() would (so update() fires
          later) — usually a single lookupExpression() call on the same
          expression render() reads.
-      2. Recursively hydrate inner content via hydrateInnerContent() —
-         this walks the inner markers and adopts their DOM.
-      3. Move ownedNodes into the live position via region.anchor.after().
+      2. Hand the inner content to hydrateInto() — it creates the child
+         scope, walks inner markers, reattaches into the region, and
+         sets region.endAnchor.
 
     DO NOT call renderAST() from hydrate — that builds fresh DOM and
     discards the server's. The whole point of hydrate is to keep the
     server's bytes.
 
-    serverMeta contains anything the ServerRenderer wrote into the closing
-    block marker (see parseServerMeta in renderer.js for the prefix scheme).
-    Use it for branch selection, key recovery, etc.
+    Pass `asChild: false` if your block's inner Reactions live on the
+    block's own scope rather than a child (snippet pattern). Default is
+    create-and-register a child scope (most blocks).
+
+    serverMeta contains anything the ServerRenderer wrote into the
+    closing block marker (see parseServerMeta in build-html-string.js
+    for the prefix scheme). Use it for branch selection, key recovery,
+    etc.
   */
-  hydrate({ node, data, scope, region, lookupExpression, hydrateInnerContent, self }) {
+  hydrate({ node, data, region, lookupExpression, hydrateInto, self }) {
     const value = lookupExpression(node.expression);
     self.lastValue = value;
     self.generation++;
 
     if (region.ownedNodes.length > 0 && node.content) {
-      const innerScope = scope.child();
-      region.childScopes.push(innerScope);
-      hydrateInnerContent({
-        ownedNodes: region.ownedNodes,
-        innerAST: node.content,
-        data: { ...data, sampleValue: value },
-        scope: innerScope,
-      });
-      const frag = document.createDocumentFragment();
-      for (const n of region.ownedNodes) { frag.appendChild(n); }
-      region.anchor.after(frag);
+      hydrateInto({ innerAST: node.content, data: { ...data, sampleValue: value } });
     }
   },
 

--- a/packages/renderer/src/engines/native/blocks/template.js
+++ b/packages/renderer/src/engines/native/blocks/template.js
@@ -226,7 +226,8 @@ const templateBlock = defineBlock({
       if (!snippet) { fatal(`Snippet name resolved to a missing snippet`); }
       const snippetData = buildSnippetProxy(node, data, self.evaluator);
       if (region.ownedNodes.length > 0) {
-        // Snippet Reactions live on the block scope, not a child.
+        // Snippet args reactivity is anchored on the block scope; a child
+        // would dispose with the next region.clear() and break arg reactivity.
         hydrateInto({ innerAST: snippet.content, data: snippetData, asChild: false });
       }
       return;

--- a/packages/renderer/src/engines/native/blocks/template.js
+++ b/packages/renderer/src/engines/native/blocks/template.js
@@ -241,7 +241,6 @@ const templateBlock = defineBlock({
     self.currentInstance = cloneInstance({ template, templateName, templateData, self });
 
     if (region.ownedNodes.length > 0) {
-      // Subtemplate uses its own renderer's data/scope, not the parent block's.
       self.currentInstance.renderer.hydrateInto({
         region,
         innerAST: self.currentInstance.ast,

--- a/packages/renderer/src/engines/native/blocks/template.js
+++ b/packages/renderer/src/engines/native/blocks/template.js
@@ -252,12 +252,12 @@ const templateBlock = defineBlock({
       if (entries.length > 0) {
         const container = document.createDocumentFragment();
         for (const n of [...region.ownedNodes]) { container.appendChild(n); }
-        self.currentInstance.renderer.hydrateMarkers(
-          container,
+        self.currentInstance.renderer.hydrateMarkers({
+          root: container,
           entries,
-          self.currentInstance.renderer.data,
-          self.currentInstance.renderer.scope,
-        );
+          data: self.currentInstance.renderer.data,
+          scope: self.currentInstance.renderer.scope,
+        });
         const frag = document.createDocumentFragment();
         for (const n of [...container.childNodes]) { frag.appendChild(n); }
         region.anchor.after(frag);

--- a/packages/renderer/src/engines/native/blocks/template.js
+++ b/packages/renderer/src/engines/native/blocks/template.js
@@ -217,7 +217,7 @@ const templateBlock = defineBlock({
     attachToRenderRoot(self.currentInstance, region, self);
   },
 
-  hydrate({ node, data, region, scope, hydrateInnerContent, self }) {
+  hydrate({ node, data, region, hydrateInto, self }) {
     const kind = detectKind({ node, data, self });
     if (kind === null) { return; }
 
@@ -226,15 +226,9 @@ const templateBlock = defineBlock({
       if (!snippet) { fatal(`Snippet name resolved to a missing snippet`); }
       const snippetData = buildSnippetProxy(node, data, self.evaluator);
       if (region.ownedNodes.length > 0) {
-        hydrateInnerContent({
-          ownedNodes: region.ownedNodes,
-          innerAST: snippet.content,
-          data: snippetData,
-          scope,
-        });
-        const frag = document.createDocumentFragment();
-        for (const n of region.ownedNodes) { frag.appendChild(n); }
-        region.anchor.after(frag);
+        // Snippet inner Reactions live on the block's scope so they
+        // stop with the block — no separate child scope to manage.
+        hydrateInto({ innerAST: snippet.content, data: snippetData, asChild: false });
       }
       return;
     }
@@ -248,27 +242,16 @@ const templateBlock = defineBlock({
     self.currentInstance = cloneInstance({ template, templateName, templateData, self });
 
     if (region.ownedNodes.length > 0) {
-      const { entries } = self.currentInstance.renderer.buildHTMLString(self.currentInstance.ast);
-      if (entries.length > 0) {
-        const container = document.createDocumentFragment();
-        for (const n of [...region.ownedNodes]) { container.appendChild(n); }
-        self.currentInstance.renderer.hydrateMarkers({
-          root: container,
-          entries,
-          data: self.currentInstance.renderer.data,
-          scope: self.currentInstance.renderer.scope,
-        });
-        const frag = document.createDocumentFragment();
-        for (const n of [...container.childNodes]) { frag.appendChild(n); }
-        region.anchor.after(frag);
-        const collected = [];
-        let sibling = region.anchor.nextSibling;
-        while (sibling) {
-          collected.push(sibling);
-          sibling = sibling.nextSibling;
-        }
-        region.ownedNodes = collected;
-      }
+      // Subtemplate hydrates against its own renderer's data + scope,
+      // not the parent block's. asChild: false because the subtemplate's
+      // scope is the root for its own Reactions, not a child of the parent.
+      self.currentInstance.renderer.hydrateInto({
+        region,
+        innerAST: self.currentInstance.ast,
+        data: self.currentInstance.renderer.data,
+        scope: self.currentInstance.renderer.scope,
+        asChild: false,
+      });
     }
 
     self.currentInstance.markRendered();

--- a/packages/renderer/src/engines/native/blocks/template.js
+++ b/packages/renderer/src/engines/native/blocks/template.js
@@ -226,8 +226,7 @@ const templateBlock = defineBlock({
       if (!snippet) { fatal(`Snippet name resolved to a missing snippet`); }
       const snippetData = buildSnippetProxy(node, data, self.evaluator);
       if (region.ownedNodes.length > 0) {
-        // Snippet inner Reactions live on the block's scope so they
-        // stop with the block — no separate child scope to manage.
+        // Snippet Reactions live on the block scope, not a child.
         hydrateInto({ innerAST: snippet.content, data: snippetData, asChild: false });
       }
       return;
@@ -242,9 +241,7 @@ const templateBlock = defineBlock({
     self.currentInstance = cloneInstance({ template, templateName, templateData, self });
 
     if (region.ownedNodes.length > 0) {
-      // Subtemplate hydrates against its own renderer's data + scope,
-      // not the parent block's. asChild: false because the subtemplate's
-      // scope is the root for its own Reactions, not a child of the parent.
+      // Subtemplate uses its own renderer's data/scope, not the parent block's.
       self.currentInstance.renderer.hydrateInto({
         region,
         innerAST: self.currentInstance.ast,

--- a/packages/renderer/src/engines/native/define-block.js
+++ b/packages/renderer/src/engines/native/define-block.js
@@ -66,6 +66,12 @@ export function defineBlock(config) {
       data: innerData = data,
       scope: innerScope = scope,
     } = {}) => renderer.hydrateInnerContent({ ownedNodes, innerAST, data: innerData, scope: innerScope });
+    const hydrateInto = ({
+      innerAST,
+      data: innerData = data,
+      scope: innerScope = scope,
+      asChild,
+    } = {}) => renderer.hydrateInto({ region, innerAST, data: innerData, scope: innerScope, asChild });
 
     // Interned per-instance bag — same hidden-class shape across all hook
     // calls. hook/err keys are present from construction so the error-hook
@@ -81,6 +87,7 @@ export function defineBlock(config) {
       lookupExpression,
       renderAST,
       hydrateInnerContent,
+      hydrateInto,
       hook: null,
       err: null,
     };

--- a/packages/renderer/src/engines/native/define-block.js
+++ b/packages/renderer/src/engines/native/define-block.js
@@ -65,7 +65,7 @@ export function defineBlock(config) {
       innerAST,
       data: innerData = data,
       scope: innerScope = scope,
-    } = {}) => renderer.hydrateInnerContent(ownedNodes, innerAST, innerData, innerScope);
+    } = {}) => renderer.hydrateInnerContent({ ownedNodes, innerAST, data: innerData, scope: innerScope });
 
     // Interned per-instance bag — same hidden-class shape across all hook
     // calls. hook/err keys are present from construction so the error-hook

--- a/packages/renderer/src/engines/native/dynamic-region.js
+++ b/packages/renderer/src/engines/native/dynamic-region.js
@@ -14,7 +14,7 @@ export class DynamicRegion {
     this.childScopes = [];
     for (const node of this.ownedNodes) { node.remove(); }
     this.ownedNodes = [];
-    // endAnchor is reusable across fills — placeEndAnchor reattaches it.
+    // endAnchor is reusable across fills.
     if (this.endAnchor) { this.endAnchor.remove(); }
   }
 

--- a/packages/renderer/src/engines/native/dynamic-region.js
+++ b/packages/renderer/src/engines/native/dynamic-region.js
@@ -25,16 +25,19 @@ export class DynamicRegion {
     this.ownedNodes = [...fragment.childNodes];
     if (scope) { this.childScopes.push(scope); }
     this.anchor.after(fragment);
-    // Place end sentinel after content for template boundary detection.
-    // isNodeInTemplate uses strict "between" comparisons, so a trailing
-    // sentinel ensures the last content node is included in the range.
+    this.placeEndAnchor();
+  }
+
+  // Boundary sentinel after the last owned node. isNodeInTemplate uses
+  // strict "between" compareDocumentPosition so the trailing anchor ensures
+  // the last content node is included in the range.
+  placeEndAnchor() {
+    const lastNode = this.ownedNodes[this.ownedNodes.length - 1];
+    if (!lastNode) { return; }
     if (!this.endAnchor) {
       this.endAnchor = document.createTextNode('');
     }
-    const lastNode = this.ownedNodes[this.ownedNodes.length - 1];
-    if (lastNode) {
-      lastNode.after(this.endAnchor);
-    }
+    lastNode.after(this.endAnchor);
   }
 
   getLastNode() {

--- a/packages/renderer/src/engines/native/dynamic-region.js
+++ b/packages/renderer/src/engines/native/dynamic-region.js
@@ -26,9 +26,9 @@ export class DynamicRegion {
     this.placeEndAnchor();
   }
 
-  // Boundary sentinel after the last owned node. isNodeInTemplate uses
-  // strict "between" compareDocumentPosition so the trailing anchor ensures
-  // the last content node is included in the range.
+  // isNodeInTemplate uses strict "between" compareDocumentPosition, so a
+  // trailing anchor is required for the last content node to fall inside
+  // the range.
   placeEndAnchor() {
     const lastNode = this.ownedNodes[this.ownedNodes.length - 1];
     if (!lastNode) { return; }

--- a/packages/renderer/src/engines/native/dynamic-region.js
+++ b/packages/renderer/src/engines/native/dynamic-region.js
@@ -14,7 +14,7 @@ export class DynamicRegion {
     this.childScopes = [];
     for (const node of this.ownedNodes) { node.remove(); }
     this.ownedNodes = [];
-    // endAnchor stays allocated — placeEndAnchor reattaches it on next fill.
+    // endAnchor is reusable across fills — placeEndAnchor reattaches it.
     if (this.endAnchor) { this.endAnchor.remove(); }
   }
 

--- a/packages/renderer/src/engines/native/dynamic-region.js
+++ b/packages/renderer/src/engines/native/dynamic-region.js
@@ -14,10 +14,8 @@ export class DynamicRegion {
     this.childScopes = [];
     for (const node of this.ownedNodes) { node.remove(); }
     this.ownedNodes = [];
-    if (this.endAnchor) {
-      this.endAnchor.remove();
-      this.endAnchor = null;
-    }
+    // endAnchor stays allocated — placeEndAnchor reattaches it on next fill.
+    if (this.endAnchor) { this.endAnchor.remove(); }
   }
 
   setContent(fragment, scope) {

--- a/packages/renderer/src/engines/native/reactive-data.js
+++ b/packages/renderer/src/engines/native/reactive-data.js
@@ -19,17 +19,20 @@ import { BLOCK_CLOSE_PREFIX, BLOCK_MARKER, COMMENT_MARKER } from '../../build-ht
 // ifDefined single-expression, single-expression string, and interpolated
 // string attributes. The `skipFirstWrite` flag is used during hydration to
 // establish Signal dependencies without re-writing server-authored values.
+// `firstMarkerID` is the first dynamic-part marker ID in `parts`; cached
+// during `populateAttributeBindings` so callers don't `parts.find` per setup.
 export function bindAttribute({
   element,
   attrName,
   parts,
+  firstMarkerID,
   entries,
   data,
   scope,
   renderer,
   skipFirstWrite = false,
 }) {
-  const { classification } = entries[parts.find((p) => p.markerID !== undefined)?.markerID] || {};
+  const { classification } = entries[firstMarkerID] || {};
   const bindingType = classification?.type;
 
   if (bindingType === 'property') {

--- a/packages/renderer/src/engines/native/reactive-data.js
+++ b/packages/renderer/src/engines/native/reactive-data.js
@@ -1,5 +1,5 @@
 import { isArray, isFunction, isPlainObject } from '@semantic-ui/utils';
-import { BLOCK_MARKER, COMMENT_MARKER } from '../../build-html-string.js';
+import { BLOCK_CLOSE_PREFIX, BLOCK_MARKER, COMMENT_MARKER } from '../../build-html-string.js';
 
 /*
 
@@ -170,7 +170,7 @@ export function hydrateTextExpression({ comment, entry, data, scope, renderer })
     while (
       next && !(next.nodeType === Node.COMMENT_NODE
         && (next.data.startsWith(COMMENT_MARKER) || next.data.startsWith(BLOCK_MARKER)
-          || next.data.startsWith('/sui-block')))
+          || next.data.startsWith(BLOCK_CLOSE_PREFIX)))
     ) {
       ownedNodes.push(next);
       next = next.nextSibling;

--- a/packages/renderer/src/engines/native/reactive-data.js
+++ b/packages/renderer/src/engines/native/reactive-data.js
@@ -19,20 +19,18 @@ import { isBlockClose, isBlockOpen, isExpressionMarker } from '../../build-html-
 // ifDefined single-expression, single-expression string, and interpolated
 // string attributes. The `skipFirstWrite` flag is used during hydration to
 // establish Signal dependencies without re-writing server-authored values.
-// `firstMarkerID` is the first dynamic-part marker ID in `parts`; cached
-// during `populateAttributeBindings` so callers don't `parts.find` per setup.
 export function bindAttribute({
   element,
   attrName,
   parts,
-  firstMarkerID,
   entries,
   data,
   scope,
   renderer,
   skipFirstWrite = false,
 }) {
-  const { classification } = entries[firstMarkerID] || {};
+  const firstMarker = parts.find((p) => p.markerID !== undefined);
+  const { classification } = entries[firstMarker?.markerID] || {};
   const bindingType = classification?.type;
 
   if (bindingType === 'property') {

--- a/packages/renderer/src/engines/native/reactive-data.js
+++ b/packages/renderer/src/engines/native/reactive-data.js
@@ -1,5 +1,5 @@
 import { isArray, isFunction, isPlainObject } from '@semantic-ui/utils';
-import { BLOCK_CLOSE_PREFIX, BLOCK_MARKER, COMMENT_MARKER } from '../../build-html-string.js';
+import { isBlockClose, isBlockOpen, isExpressionMarker } from '../../build-html-string.js';
 
 /*
 
@@ -172,8 +172,7 @@ export function hydrateTextExpression({ comment, entry, data, scope, renderer })
     let next = comment.nextSibling;
     while (
       next && !(next.nodeType === Node.COMMENT_NODE
-        && (next.data.startsWith(COMMENT_MARKER) || next.data.startsWith(BLOCK_MARKER)
-          || next.data.startsWith(BLOCK_CLOSE_PREFIX)))
+        && (isExpressionMarker(next.data) || isBlockOpen(next.data) || isBlockClose(next.data)))
     ) {
       ownedNodes.push(next);
       next = next.nextSibling;

--- a/packages/renderer/src/engines/native/renderer.js
+++ b/packages/renderer/src/engines/native/renderer.js
@@ -529,6 +529,38 @@ export class Renderer {
     }
   }
 
+  // Hydrate-and-attach. Walks markers in `region.ownedNodes` against
+  // `innerAST`, wires Reactions, and reinserts the (now-hydrated) nodes
+  // after `region.anchor`. Sets `region.endAnchor` so consumers that
+  // scan the region's last node (subtemplate attachToRenderRoot) get
+  // the same contract `setContent` provides.
+  //
+  // `asChild: true` (default) creates a child of `scope`, registers it
+  // on `region.childScopes` for cleanup, and uses it for inner Reactions.
+  // `asChild: false` uses `scope` as-is — the snippet path lives on the
+  // block's scope so its Reactions stop when the block does.
+  //
+  // Returns the scope the inner content was hydrated against — callers
+  // that track per-branch scope (each elseContent record) need it.
+  hydrateInto({ region, innerAST, data, scope, asChild = true }) {
+    const targetScope = asChild ? scope.child() : scope;
+    if (asChild) { region.childScopes.push(targetScope); }
+
+    this.hydrateInnerContent({ ownedNodes: region.ownedNodes, innerAST, data, scope: targetScope });
+
+    if (region.ownedNodes.length > 0) {
+      const frag = document.createDocumentFragment();
+      for (const n of region.ownedNodes) { frag.appendChild(n); }
+      region.anchor.after(frag);
+      if (!region.endAnchor) {
+        region.endAnchor = document.createTextNode('');
+      }
+      region.ownedNodes[region.ownedNodes.length - 1].after(region.endAnchor);
+    }
+
+    return targetScope;
+  }
+
   /*******************************
         Data Management
   *******************************/

--- a/packages/renderer/src/engines/native/renderer.js
+++ b/packages/renderer/src/engines/native/renderer.js
@@ -232,17 +232,23 @@ export class Renderer {
     while ((node = walker.nextNode())) {
       if (node.nodeType === Node.ELEMENT_NODE) {
         const element = node;
-        const attrsToProcess = [];
+        // Most elements have zero __sui attrs — defer the array allocation
+        // until we find one. Collect first, then iterate, because
+        // bindAttributeExpression calls element.removeAttribute for property
+        // and event bindings, which mutates the live NamedNodeMap.
+        let attrsToProcess;
         for (let i = 0; i < element.attributes.length; i++) {
           const attr = element.attributes[i];
           if (attr.value.includes(ATTR_MARKER_PREFIX)) {
-            attrsToProcess.push({ name: attr.name, value: attr.value });
+            (attrsToProcess ??= []).push({ name: attr.name, value: attr.value });
           }
         }
-        for (const { name: attrName, value: attrValue } of attrsToProcess) {
-          const { parts, markerIDs } = parseAttributePartsFn(attrValue);
-          for (const id of markerIDs) { processedAttrIDs.add(id); }
-          this.bindAttributeExpression(element, attrName, parts, markerIDs[0], entries, data, scope);
+        if (attrsToProcess) {
+          for (const { name: attrName, value: attrValue } of attrsToProcess) {
+            const { parts, markerIDs } = parseAttributePartsFn(attrValue);
+            for (const id of markerIDs) { processedAttrIDs.add(id); }
+            this.bindAttributeExpression(element, attrName, parts, markerIDs[0], entries, data, scope);
+          }
         }
       }
       else {

--- a/packages/renderer/src/engines/native/renderer.js
+++ b/packages/renderer/src/engines/native/renderer.js
@@ -199,8 +199,17 @@ export class Renderer {
   // the dispatch on entry.classification.type (property / event / boolean
   // / ifDefined / interpolated / single-expression). `skipFirstWrite` is
   // passed through by hydrateAttributes.
-  bindAttributeExpression(element, attrName, parts, entries, data, scope, { skipFirstWrite = false } = {}) {
-    bindAttribute({ element, attrName, parts, entries, data, scope, renderer: this, skipFirstWrite });
+  bindAttributeExpression(
+    element,
+    attrName,
+    parts,
+    firstMarkerID,
+    entries,
+    data,
+    scope,
+    { skipFirstWrite = false } = {},
+  ) {
+    bindAttribute({ element, attrName, parts, firstMarkerID, entries, data, scope, renderer: this, skipFirstWrite });
   }
 
   bindMarkers(root, entries, data, scope, ast) {
@@ -230,7 +239,7 @@ export class Renderer {
         for (const { name: attrName, value: attrValue } of attrsToProcess) {
           const { parts, markerIDs } = parseAttributePartsFn(attrValue);
           for (const id of markerIDs) { processedAttrIDs.add(id); }
-          this.bindAttributeExpression(element, attrName, parts, entries, data, scope);
+          this.bindAttributeExpression(element, attrName, parts, markerIDs[0], entries, data, scope);
         }
       }
       else {
@@ -430,7 +439,7 @@ export class Renderer {
         if (isNaN(entryId)) { continue; }
         const entry = entries[entryId];
         if (!entry || !entry.attributeBinding) { continue; }
-        const { parts } = entry.attributeBinding;
+        const { parts, firstMarkerID } = entry.attributeBinding;
         // Strip `.` / `@` prefix for the DOM attribute name. bindAttribute
         // uses `classification.type` / `classification.attribute` for the
         // real dispatch; the name passed here is only used for the
@@ -439,7 +448,9 @@ export class Renderer {
         const domAttrName = (rawAttrName.charAt(0) === '.' || rawAttrName.charAt(0) === '@')
           ? rawAttrName.slice(1)
           : rawAttrName;
-        this.bindAttributeExpression(node, domAttrName, parts, entries, data, scope, { skipFirstWrite: true });
+        this.bindAttributeExpression(node, domAttrName, parts, firstMarkerID, entries, data, scope, {
+          skipFirstWrite: true,
+        });
       }
     }
   }

--- a/packages/renderer/src/engines/native/renderer.js
+++ b/packages/renderer/src/engines/native/renderer.js
@@ -337,7 +337,7 @@ export class Renderer {
         Hydration
   *******************************/
 
-  hydrateMarkers(root, entries, data, scope) {
+  hydrateMarkers({ root, entries, data, scope }) {
     if (entries.length === 0) { return; }
 
     // Pass 1: walk elements with data-sui-bind, wire attribute Reactions.
@@ -490,8 +490,8 @@ export class Renderer {
     }
   }
 
-  hydrateInnerContent(ownedNodes, contentAST, data, scope) {
-    const { entries } = cachedBuildHTMLString(contentAST, { snippets: this.snippets });
+  hydrateInnerContent({ ownedNodes, innerAST, data, scope }) {
+    const { entries } = cachedBuildHTMLString(innerAST, { snippets: this.snippets });
     if (entries.length === 0) { return; }
 
     // Wrap ownedNodes in a temporary container for TreeWalker traversal
@@ -501,7 +501,7 @@ export class Renderer {
     }
 
     // Recursively hydrate inner markers with the sub-AST's entries.
-    this.hydrateMarkers(container, entries, data, scope);
+    this.hydrateMarkers({ root: container, entries, data, scope });
 
     // Update ownedNodes with the hydrated content (comments may have been removed)
     ownedNodes.length = 0;

--- a/packages/renderer/src/engines/native/renderer.js
+++ b/packages/renderer/src/engines/native/renderer.js
@@ -517,10 +517,9 @@ export class Renderer {
     }
   }
 
-  // `asChild: false` skips child-scope creation so inner Reactions register
-  // on the passed `scope` directly — used by snippet/subtemplate, where the
-  // owning lifetime is already correct. Default true for blocks that want
-  // their own boundary on `region.childScopes`.
+  // `asChild: false` lands inner Reactions on the passed scope directly —
+  // snippet and subtemplate use this because their owning lifetime is
+  // already correct. Default registers a child boundary on region.childScopes.
   hydrateInto({ region, innerAST, data, scope, asChild = true }) {
     const targetScope = asChild ? scope.child() : scope;
     if (asChild) { region.childScopes.push(targetScope); }

--- a/packages/renderer/src/engines/native/renderer.js
+++ b/packages/renderer/src/engines/native/renderer.js
@@ -502,19 +502,15 @@ export class Renderer {
     const { entries } = cachedBuildHTMLString(innerAST, { snippets: this.snippets });
     if (entries.length === 0) { return; }
 
-    // Wrap ownedNodes in a temporary container for TreeWalker traversal
+    // Move into a temporary fragment so TreeWalker has a connected root.
     const container = document.createDocumentFragment();
-    for (const n of [...ownedNodes]) {
-      container.appendChild(n);
-    }
+    container.append(...ownedNodes);
 
     this.hydrateMarkers({ root: container, entries, data, scope });
 
-    // Repopulate from container — hydrateMarkers may have removed comment nodes.
+    // hydrateMarkers strips comment markers — rebuild ownedNodes from live container.
     ownedNodes.length = 0;
-    for (const n of [...container.childNodes]) {
-      ownedNodes.push(n);
-    }
+    ownedNodes.push(...container.childNodes);
   }
 
   // asChild=false reuses the passed scope; default creates and registers
@@ -527,12 +523,9 @@ export class Renderer {
 
     if (region.ownedNodes.length > 0) {
       const frag = document.createDocumentFragment();
-      for (const n of region.ownedNodes) { frag.appendChild(n); }
+      frag.append(...region.ownedNodes);
       region.anchor.after(frag);
-      if (!region.endAnchor) {
-        region.endAnchor = document.createTextNode('');
-      }
-      region.ownedNodes[region.ownedNodes.length - 1].after(region.endAnchor);
+      region.placeEndAnchor();
     }
 
     return targetScope;

--- a/packages/renderer/src/engines/native/renderer.js
+++ b/packages/renderer/src/engines/native/renderer.js
@@ -3,14 +3,17 @@ import { assignInPlace, createCache, filterObject, inArray } from '@semantic-ui/
 
 import {
   ATTR_MARKER_PREFIX,
-  BLOCK_CLOSE_PREFIX,
-  BLOCK_MARKER,
   buildHTMLString as buildHTMLStringPure,
-  COMMENT_MARKER,
   DATA_SUI_BIND,
+  isBlockClose,
+  isBlockOpen,
+  isExpressionMarker,
+  isRawTextMarker,
   parseAttributeParts as parseAttributePartsFn,
+  parseBlockOpenID,
+  parseExpressionID,
+  parseRawTextID,
   parseServerMeta,
-  RAW_TEXT_MARKER,
 } from '../../build-html-string.js';
 import { ExpressionEvaluator } from '../../expression-evaluator.js';
 import { getBlock } from './blocks/registry.js';
@@ -244,8 +247,8 @@ export class Renderer {
       }
       else {
         const text = node.data;
-        if (text.startsWith(COMMENT_MARKER)) {
-          const markerID = parseInt(text.slice(COMMENT_MARKER.length));
+        if (isExpressionMarker(text)) {
+          const markerID = parseExpressionID(text);
           if (!isNaN(markerID)) {
             // Filter deferred until after the walk: elements visit before
             // sibling comments in document order, so an attr-marker's
@@ -254,14 +257,14 @@ export class Renderer {
             commentsToProcess.push({ comment: node, markerID, type: 'expression' });
           }
         }
-        else if (text.startsWith(RAW_TEXT_MARKER)) {
-          const markerID = parseInt(text.slice(RAW_TEXT_MARKER.length));
+        else if (isRawTextMarker(text)) {
+          const markerID = parseRawTextID(text);
           if (!isNaN(markerID)) {
             commentsToProcess.push({ comment: node, markerID, type: 'rawText' });
           }
         }
-        else if (text.startsWith(BLOCK_MARKER)) {
-          const markerID = parseInt(text.slice(BLOCK_MARKER.length));
+        else if (isBlockOpen(text)) {
+          const markerID = parseBlockOpenID(text);
           if (!isNaN(markerID)) {
             commentsToProcess.push({ comment: node, markerID, type: 'block' });
           }
@@ -364,26 +367,26 @@ export class Renderer {
       const text = comment.data;
 
       // Track block nesting — skip inner markers
-      if (text.startsWith(BLOCK_CLOSE_PREFIX)) {
+      if (isBlockClose(text)) {
         blockDepth--;
         continue;
       }
       if (blockDepth > 0) {
         // Track nested opening markers so closing markers stay balanced
-        if (text.startsWith(BLOCK_MARKER)) {
+        if (isBlockOpen(text)) {
           blockDepth++;
         }
         continue;
       }
 
-      if (text.startsWith(COMMENT_MARKER)) {
-        const markerID = parseInt(text.slice(COMMENT_MARKER.length));
+      if (isExpressionMarker(text)) {
+        const markerID = parseExpressionID(text);
         if (!isNaN(markerID)) {
           commentsToProcess.push({ comment, markerID, type: 'expression' });
         }
       }
-      else if (text.startsWith(BLOCK_MARKER)) {
-        const markerID = parseInt(text.slice(BLOCK_MARKER.length));
+      else if (isBlockOpen(text)) {
+        const markerID = parseBlockOpenID(text);
         if (!isNaN(markerID)) {
           commentsToProcess.push({ comment, markerID, type: 'block' });
           blockDepth++;
@@ -420,10 +423,10 @@ export class Renderer {
     while ((node = walker.nextNode())) {
       if (node.nodeType === Node.COMMENT_NODE) {
         const text = node.data;
-        if (text.startsWith(BLOCK_MARKER)) {
+        if (isBlockOpen(text)) {
           blockDepth++;
         }
-        else if (text.startsWith(BLOCK_CLOSE_PREFIX)) {
+        else if (isBlockClose(text)) {
           blockDepth--;
         }
         continue;
@@ -463,7 +466,6 @@ export class Renderer {
   hydrateBlock(comment, entry, data, scope) {
     const { node } = entry;
     const parentNode = comment.parentNode;
-    const markerID = entry.id;
 
     // Collect all nodes between opening and closing block markers.
     // Track depth because inner blocks (from nested snippets/conditionals)
@@ -474,10 +476,10 @@ export class Renderer {
     let blockDepth = 1;
     while (next) {
       if (next.nodeType === Node.COMMENT_NODE) {
-        if (next.data.startsWith(BLOCK_MARKER)) {
+        if (isBlockOpen(next.data)) {
           blockDepth++;
         }
-        else if (next.data.startsWith(BLOCK_CLOSE_PREFIX)) {
+        else if (isBlockClose(next.data)) {
           blockDepth--;
           if (blockDepth === 0) {
             parseServerMeta(next.data, serverMeta);

--- a/packages/renderer/src/engines/native/renderer.js
+++ b/packages/renderer/src/engines/native/renderer.js
@@ -511,8 +511,6 @@ export class Renderer {
     ownedNodes.push(...container.childNodes);
   }
 
-  // asChild=false reuses the passed scope; default creates and registers
-  // a child on region.childScopes.
   hydrateInto({ region, innerAST, data, scope, asChild = true }) {
     const targetScope = asChild ? scope.child() : scope;
     if (asChild) { region.childScopes.push(targetScope); }

--- a/packages/renderer/src/engines/native/renderer.js
+++ b/packages/renderer/src/engines/native/renderer.js
@@ -3,11 +3,13 @@ import { assignInPlace, createCache, filterObject, inArray } from '@semantic-ui/
 
 import {
   ATTR_MARKER_PREFIX,
+  BLOCK_CLOSE_PREFIX,
   BLOCK_MARKER,
   buildHTMLString as buildHTMLStringPure,
   COMMENT_MARKER,
   DATA_SUI_BIND,
   parseAttributeParts as parseAttributePartsFn,
+  parseServerMeta,
   RAW_TEXT_MARKER,
 } from '../../build-html-string.js';
 import { ExpressionEvaluator } from '../../expression-evaluator.js';
@@ -25,18 +27,6 @@ import './blocks/index.js';
 
 // PreparedTemplate cache — parse once, cloneNode per instance
 const templateCache = createCache({ maxSize: 1000, eviction: 'flush' });
-
-// Parse trailing metadata from a closing block marker into serverMeta.
-// Reserved suffixes (after the version segment):
-//   bN  → branchIndex (which branch the {#if}/{:elseif}/{:else} server picked)
-// Unknown segments are ignored. Mutates target in place.
-function parseServerMeta(commentData, target) {
-  for (const part of commentData.split(':')) {
-    if (part.startsWith('b')) {
-      target.branchIndex = parseInt(part.slice(1));
-    }
-  }
-}
 
 // AST → { html, svg } cache, where each slot holds the buildHTMLString
 // result for that namespace. Keyed on the AST array (immutable after
@@ -365,7 +355,7 @@ export class Renderer {
       const text = comment.data;
 
       // Track block nesting — skip inner markers
-      if (text.startsWith('/sui-block:')) {
+      if (text.startsWith(BLOCK_CLOSE_PREFIX)) {
         blockDepth--;
         continue;
       }
@@ -424,7 +414,7 @@ export class Renderer {
         if (text.startsWith(BLOCK_MARKER)) {
           blockDepth++;
         }
-        else if (text.startsWith('/sui-block:')) {
+        else if (text.startsWith(BLOCK_CLOSE_PREFIX)) {
           blockDepth--;
         }
         continue;
@@ -476,7 +466,7 @@ export class Renderer {
         if (next.data.startsWith(BLOCK_MARKER)) {
           blockDepth++;
         }
-        else if (next.data.startsWith('/sui-block:')) {
+        else if (next.data.startsWith(BLOCK_CLOSE_PREFIX)) {
           blockDepth--;
           if (blockDepth === 0) {
             parseServerMeta(next.data, serverMeta);

--- a/packages/renderer/src/engines/native/renderer.js
+++ b/packages/renderer/src/engines/native/renderer.js
@@ -202,17 +202,8 @@ export class Renderer {
   // the dispatch on entry.classification.type (property / event / boolean
   // / ifDefined / interpolated / single-expression). `skipFirstWrite` is
   // passed through by hydrateAttributes.
-  bindAttributeExpression(
-    element,
-    attrName,
-    parts,
-    firstMarkerID,
-    entries,
-    data,
-    scope,
-    { skipFirstWrite = false } = {},
-  ) {
-    bindAttribute({ element, attrName, parts, firstMarkerID, entries, data, scope, renderer: this, skipFirstWrite });
+  bindAttributeExpression(element, attrName, parts, entries, data, scope, { skipFirstWrite = false } = {}) {
+    bindAttribute({ element, attrName, parts, entries, data, scope, renderer: this, skipFirstWrite });
   }
 
   bindMarkers(root, entries, data, scope, ast) {
@@ -247,7 +238,7 @@ export class Renderer {
           for (const { name: attrName, value: attrValue } of attrsToProcess) {
             const { parts, markerIDs } = parseAttributePartsFn(attrValue);
             for (const id of markerIDs) { processedAttrIDs.add(id); }
-            this.bindAttributeExpression(element, attrName, parts, markerIDs[0], entries, data, scope);
+            this.bindAttributeExpression(element, attrName, parts, entries, data, scope);
           }
         }
       }
@@ -448,7 +439,7 @@ export class Renderer {
         if (isNaN(entryId)) { continue; }
         const entry = entries[entryId];
         if (!entry || !entry.attributeBinding) { continue; }
-        const { parts, firstMarkerID } = entry.attributeBinding;
+        const { parts } = entry.attributeBinding;
         // Strip `.` / `@` prefix for the DOM attribute name. bindAttribute
         // uses `classification.type` / `classification.attribute` for the
         // real dispatch; the name passed here is only used for the
@@ -457,9 +448,7 @@ export class Renderer {
         const domAttrName = (rawAttrName.charAt(0) === '.' || rawAttrName.charAt(0) === '@')
           ? rawAttrName.slice(1)
           : rawAttrName;
-        this.bindAttributeExpression(node, domAttrName, parts, firstMarkerID, entries, data, scope, {
-          skipFirstWrite: true,
-        });
+        this.bindAttributeExpression(node, domAttrName, parts, entries, data, scope, { skipFirstWrite: true });
       }
     }
   }
@@ -519,29 +508,19 @@ export class Renderer {
       container.appendChild(n);
     }
 
-    // Recursively hydrate inner markers with the sub-AST's entries.
     this.hydrateMarkers({ root: container, entries, data, scope });
 
-    // Update ownedNodes with the hydrated content (comments may have been removed)
+    // Repopulate from container — hydrateMarkers may have removed comment nodes.
     ownedNodes.length = 0;
     for (const n of [...container.childNodes]) {
       ownedNodes.push(n);
     }
   }
 
-  // Hydrate-and-attach. Walks markers in `region.ownedNodes` against
-  // `innerAST`, wires Reactions, and reinserts the (now-hydrated) nodes
-  // after `region.anchor`. Sets `region.endAnchor` so consumers that
-  // scan the region's last node (subtemplate attachToRenderRoot) get
-  // the same contract `setContent` provides.
-  //
-  // `asChild: true` (default) creates a child of `scope`, registers it
-  // on `region.childScopes` for cleanup, and uses it for inner Reactions.
-  // `asChild: false` uses `scope` as-is — the snippet path lives on the
-  // block's scope so its Reactions stop when the block does.
-  //
-  // Returns the scope the inner content was hydrated against — callers
-  // that track per-branch scope (each elseContent record) need it.
+  // `asChild: false` skips child-scope creation so inner Reactions register
+  // on the passed `scope` directly — used by snippet/subtemplate, where the
+  // owning lifetime is already correct. Default true for blocks that want
+  // their own boundary on `region.childScopes`.
   hydrateInto({ region, innerAST, data, scope, asChild = true }) {
     const targetScope = asChild ? scope.child() : scope;
     if (asChild) { region.childScopes.push(targetScope); }

--- a/packages/renderer/src/engines/native/renderer.js
+++ b/packages/renderer/src/engines/native/renderer.js
@@ -363,13 +363,11 @@ export class Renderer {
     while ((comment = commentWalker.nextNode())) {
       const text = comment.data;
 
-      // Track block nesting — skip inner markers
       if (isBlockClose(text)) {
         blockDepth--;
         continue;
       }
       if (blockDepth > 0) {
-        // Track nested opening markers so closing markers stay balanced
         if (isBlockOpen(text)) {
           blockDepth++;
         }

--- a/packages/renderer/src/engines/native/renderer.js
+++ b/packages/renderer/src/engines/native/renderer.js
@@ -67,7 +67,6 @@ export class Renderer {
       snippets,
       helpers,
       isSVG = false,
-      inheritsData = true,
       receivesData = false,
       protectedKeys,
     } = {},
@@ -80,7 +79,6 @@ export class Renderer {
     this.collectSnippets(this.ast);
     this.helpers = helpers || {};
     this.isSVG = isSVG;
-    this.inheritsData = inheritsData;
     this.receivesData = receivesData;
     this.protectedKeys = protectedKeys;
     // Sequential debug ID. Subtree caching would key on hashCode(ast+data)

--- a/packages/renderer/src/engines/native/renderer.js
+++ b/packages/renderer/src/engines/native/renderer.js
@@ -435,7 +435,7 @@ export class Renderer {
         const eqIdx = binding.lastIndexOf('=');
         if (eqIdx === -1) { continue; }
         const rawAttrName = binding.slice(0, eqIdx);
-        const entryId = parseInt(binding.slice(eqIdx + 1));
+        const entryId = +binding.slice(eqIdx + 1);
         if (isNaN(entryId)) { continue; }
         const entry = entries[entryId];
         if (!entry || !entry.attributeBinding) { continue; }
@@ -517,9 +517,8 @@ export class Renderer {
     }
   }
 
-  // `asChild: false` lands inner Reactions on the passed scope directly —
-  // snippet and subtemplate use this because their owning lifetime is
-  // already correct. Default registers a child boundary on region.childScopes.
+  // asChild=false reuses the passed scope; default creates and registers
+  // a child on region.childScopes.
   hydrateInto({ region, innerAST, data, scope, asChild = true }) {
     const targetScope = asChild ? scope.child() : scope;
     if (asChild) { region.childScopes.push(targetScope); }

--- a/packages/renderer/src/engines/native/renderer.js
+++ b/packages/renderer/src/engines/native/renderer.js
@@ -438,8 +438,8 @@ export class Renderer {
         const entryId = +binding.slice(eqIdx + 1);
         if (isNaN(entryId)) { continue; }
         const entry = entries[entryId];
-        if (!entry || !entry.attributeBinding) { continue; }
-        const { parts } = entry.attributeBinding;
+        if (!entry || !entry.attributeParts) { continue; }
+        const parts = entry.attributeParts;
         // Strip `.` / `@` prefix for the DOM attribute name. bindAttribute
         // uses `classification.type` / `classification.attribute` for the
         // real dispatch; the name passed here is only used for the

--- a/packages/renderer/src/engines/native/server.js
+++ b/packages/renderer/src/engines/native/server.js
@@ -405,9 +405,7 @@ export class ServerRenderer {
       html += this.renderNodes(node.elseContent, data);
     }
     else {
-      // Per-item key marker — client adopts the matching node range at
-      // hydrate time. Key derivation lives in shared/each.js so server
-      // and client agree on identity.
+      // Per-item key marker — client adopts the matching node range at hydrate time.
       for (let i = 0; i < items.length; i++) {
         const eachData = getEachData(items[i], i, collectionType, node);
         const itemData = { ...data, ...eachData };
@@ -494,8 +492,7 @@ export class ServerRenderer {
       return instance.render();
     }
 
-    // Plain AST object — render directly. Data flows through renderNodes
-    // and every evaluator lookup takes it as an explicit argument.
+    // Plain AST object — render directly.
     if (template.ast) {
       return this.renderNodes(template.ast, data);
     }

--- a/packages/renderer/src/engines/native/server.js
+++ b/packages/renderer/src/engines/native/server.js
@@ -31,6 +31,7 @@ import {
   MAIN_BRANCH_INDEX,
 } from '../../build-html-string.js';
 import { ExpressionEvaluator } from '../../expression-evaluator.js';
+import { encodeItemKey, getEachData, getItemID, SUI_ITEM_MARKER } from './shared/each.js';
 
 const REMOVE_ATTR = '__SUI_REMOVE__';
 const REMOVE_ATTR_REGEX = /\s+[\w.@-]+\s*=\s*["']?__SUI_REMOVE__["']?/g;
@@ -70,15 +71,6 @@ function attrNameFromBuffer(buffer) {
   return match ? match[1] : null;
 }
 
-// HTML comment contents cannot contain `--` or `>` (WHATWG spec). User-
-// supplied keys may; encode them defensively. URL-encoding covers both
-// classes plus `%` itself. The client-side parser decodes with
-// `decodeURIComponent`. Keys are typically IDs (`x1`, `user-42`) that
-// don't need encoding, so the overhead is negligible in practice.
-function encodeItemKey(key) {
-  const str = String(key ?? '');
-  return encodeURIComponent(str);
-}
 function scanHtmlChunk(chunk, scope) {
   if (!scope.insideTag && chunk.indexOf('<') === -1) {
     scope.htmlBuffer += chunk;
@@ -413,19 +405,19 @@ export class ServerRenderer {
       html += this.renderNodes(node.elseContent, data);
     }
     else {
-      // Emit `<!--sui-item:v1:KEY-->` before each item's content so the
-      // client can adopt per-item DOM on first data change instead of
-      // re-rendering the whole list. Key is computed via the same
-      // `getItemID` heuristic the client uses, so the two agree on identity.
+      // Emit `<!--${SUI_ITEM_MARKER}KEY-->` before each item's content so
+      // the client can adopt per-item DOM on first data change instead of
+      // re-rendering the whole list. Key is computed via the shared
+      // `getItemID` heuristic, so server and client agree on identity.
       for (let i = 0; i < items.length; i++) {
-        const eachData = this.getEachData(items[i], i, collectionType, node);
+        const eachData = getEachData(items[i], i, collectionType, node);
         const itemData = { ...data, ...eachData };
         const itemEvaluator = new ExpressionEvaluator({ data: itemData, helpers: this.helpers });
         const savedEvaluator = this.evaluator;
         this.evaluator = itemEvaluator;
-        const key = this.getItemID(items[i], i, collectionType);
+        const key = getItemID(items[i], i, collectionType);
         try {
-          html += `<!--sui-item:v1:${encodeItemKey(key)}-->`;
+          html += `<!--${SUI_ITEM_MARKER}${encodeItemKey(key)}-->`;
           html += this.renderNodes(node.content, itemData);
         }
         finally {
@@ -533,40 +525,6 @@ export class ServerRenderer {
   /*******************************
       Data Helpers
   *******************************/
-
-  // Mirrors blocks/each.js getItemID — keep in sync. Server and client
-  // must agree on identity or first-data-change adoption misses keys.
-  // Key = first non-empty of: object.{_id, id, key, hash, _hash, value},
-  // object-collection key, or positional index. Stringified to match
-  // the string-keyed Map the client builds from `<!--sui-item:v1:KEY-->`.
-  getItemID(item, indexOrKey, collectionType) {
-    let raw;
-    if (isPlainObject(item)) {
-      const key = (collectionType === 'object') ? indexOrKey : undefined;
-      raw = key || item._id || item.id || item.key || item.hash || item._hash || item.value || indexOrKey;
-    }
-    else if (isString(item)) {
-      raw = item + ':' + indexOrKey;
-    }
-    else {
-      raw = indexOrKey;
-    }
-    return String(raw);
-  }
-
-  getEachData(item, indexOrKey, collectionType, node) {
-    let { as, indexAs } = node;
-    if (!indexAs) {
-      indexAs = (collectionType === 'array') ? 'index' : 'key';
-    }
-    if (collectionType === 'object') {
-      indexOrKey = item.key;
-      item = item.value;
-    }
-    return as
-      ? { [as]: item, [indexAs]: indexOrKey }
-      : { ...item, this: item, [indexAs]: indexOrKey };
-  }
 
   resolveNodeData(node, data) {
     let resolved = { ...data };

--- a/packages/renderer/src/engines/native/server.js
+++ b/packages/renderer/src/engines/native/server.js
@@ -405,13 +405,9 @@ export class ServerRenderer {
       html += this.renderNodes(node.elseContent, data);
     }
     else {
-      // Emit `<!--${SUI_ITEM_MARKER}KEY-->` before each item's content so
-      // the client can adopt per-item DOM on first data change instead of
-      // re-rendering the whole list. Key is computed via the shared
-      // `getItemID` heuristic, so server and client agree on identity.
-      // Per-item data flows through `renderNodes(content, itemData)` and
-      // every evaluator lookup downstream takes data as an explicit
-      // argument — no need to allocate a per-item ExpressionEvaluator.
+      // Per-item key marker — client adopts the matching node range at
+      // hydrate time. Key derivation lives in shared/each.js so server
+      // and client agree on identity.
       for (let i = 0; i < items.length; i++) {
         const eachData = getEachData(items[i], i, collectionType, node);
         const itemData = { ...data, ...eachData };

--- a/packages/renderer/src/engines/native/server.js
+++ b/packages/renderer/src/engines/native/server.js
@@ -22,7 +22,13 @@ import {
   isString,
 } from '@semantic-ui/utils';
 
-import { analyzePosition, BLOCK_MARKER, COMMENT_MARKER, DATA_SUI_BIND } from '../../build-html-string.js';
+import {
+  analyzePosition,
+  BLOCK_MARKER,
+  COMMENT_MARKER,
+  DATA_SUI_BIND,
+  MAIN_BRANCH_INDEX,
+} from '../../build-html-string.js';
 import { ExpressionEvaluator } from '../../expression-evaluator.js';
 
 const REMOVE_ATTR = '__SUI_REMOVE__';
@@ -175,7 +181,7 @@ function scanHtmlChunk(chunk, scope) {
 
 export class ServerRenderer {
   constructor(
-    { ast, data, template, subTemplates, snippets, helpers, isSVG = false, inheritsData = true, protectedKeys } = {},
+    { ast, data, template, subTemplates, snippets, helpers, isSVG = false, protectedKeys } = {},
   ) {
     this.ast = ast || [];
     this.data = data;
@@ -184,7 +190,6 @@ export class ServerRenderer {
     this.snippets = snippets || {};
     this.helpers = helpers || {};
     this.isSVG = isSVG;
-    this.inheritsData = inheritsData;
     this.protectedKeys = protectedKeys;
 
     this.evaluator = new ExpressionEvaluator({
@@ -370,7 +375,7 @@ export class ServerRenderer {
 
     const condition = this.evaluator.lookupExpressionValue(node.condition, data);
     if (condition && node.content) {
-      branchIndex = 1000;
+      branchIndex = MAIN_BRANCH_INDEX;
       html += this.renderNodes(node.content, data);
     }
     else if (node.branches) {

--- a/packages/renderer/src/engines/native/server.js
+++ b/packages/renderer/src/engines/native/server.js
@@ -27,6 +27,7 @@ import {
   BLOCK_MARKER,
   COMMENT_MARKER,
   DATA_SUI_BIND,
+  formatBlockClose,
   MAIN_BRANCH_INDEX,
 } from '../../build-html-string.js';
 import { ExpressionEvaluator } from '../../expression-evaluator.js';
@@ -396,7 +397,7 @@ export class ServerRenderer {
       }
     }
 
-    html += `<!--/sui-block:v1:${id}:b${branchIndex}-->`;
+    html += `<!--${formatBlockClose(id, { branchIndex })}-->`;
     return html;
   }
 
@@ -433,7 +434,7 @@ export class ServerRenderer {
       }
     }
 
-    html += `<!--/sui-block:v1:${id}-->`;
+    html += `<!--${formatBlockClose(id)}-->`;
     return html;
   }
 
@@ -446,7 +447,7 @@ export class ServerRenderer {
       html += this.renderNodes(node.loadingContent, data);
     }
 
-    html += `<!--/sui-block:v1:${id}-->`;
+    html += `<!--${formatBlockClose(id)}-->`;
     return html;
   }
 
@@ -458,7 +459,7 @@ export class ServerRenderer {
       html += this.renderNodes(node.content, data);
     }
 
-    html += `<!--/sui-block:v1:${id}-->`;
+    html += `<!--${formatBlockClose(id)}-->`;
     return html;
   }
 
@@ -499,7 +500,7 @@ export class ServerRenderer {
       }
     }
 
-    html += `<!--/sui-block:v1:${id}-->`;
+    html += `<!--${formatBlockClose(id)}-->`;
     return html;
   }
 

--- a/packages/renderer/src/engines/native/server.js
+++ b/packages/renderer/src/engines/native/server.js
@@ -409,20 +409,15 @@ export class ServerRenderer {
       // the client can adopt per-item DOM on first data change instead of
       // re-rendering the whole list. Key is computed via the shared
       // `getItemID` heuristic, so server and client agree on identity.
+      // Per-item data flows through `renderNodes(content, itemData)` and
+      // every evaluator lookup downstream takes data as an explicit
+      // argument — no need to allocate a per-item ExpressionEvaluator.
       for (let i = 0; i < items.length; i++) {
         const eachData = getEachData(items[i], i, collectionType, node);
         const itemData = { ...data, ...eachData };
-        const itemEvaluator = new ExpressionEvaluator({ data: itemData, helpers: this.helpers });
-        const savedEvaluator = this.evaluator;
-        this.evaluator = itemEvaluator;
         const key = getItemID(items[i], i, collectionType);
-        try {
-          html += `<!--${SUI_ITEM_MARKER}${encodeItemKey(key)}-->`;
-          html += this.renderNodes(node.content, itemData);
-        }
-        finally {
-          this.evaluator = savedEvaluator;
-        }
+        html += `<!--${SUI_ITEM_MARKER}${encodeItemKey(key)}-->`;
+        html += this.renderNodes(node.content, itemData);
       }
     }
 
@@ -468,14 +463,7 @@ export class ServerRenderer {
     if (this.snippets[templateName]) {
       const snippet = this.snippets[templateName];
       const snippetData = this.resolveNodeData(node, data);
-      const savedEvaluator = this.evaluator;
-      this.evaluator = new ExpressionEvaluator({ data: snippetData, helpers: this.helpers });
-      try {
-        html += this.renderNodes(snippet.content, snippetData);
-      }
-      finally {
-        this.evaluator = savedEvaluator;
-      }
+      html += this.renderNodes(snippet.content, snippetData);
     }
     else {
       let template;
@@ -510,13 +498,10 @@ export class ServerRenderer {
       return instance.render();
     }
 
-    // Plain AST object — render directly
+    // Plain AST object — render directly. Data flows through renderNodes
+    // and every evaluator lookup takes it as an explicit argument.
     if (template.ast) {
-      const savedEvaluator = this.evaluator;
-      this.evaluator = new ExpressionEvaluator({ data, helpers: this.helpers });
-      const html = this.renderNodes(template.ast, data);
-      this.evaluator = savedEvaluator;
-      return html;
+      return this.renderNodes(template.ast, data);
     }
 
     return '';

--- a/packages/renderer/src/engines/native/server.js
+++ b/packages/renderer/src/engines/native/server.js
@@ -492,7 +492,6 @@ export class ServerRenderer {
       return instance.render();
     }
 
-    // Plain AST object — render directly.
     if (template.ast) {
       return this.renderNodes(template.ast, data);
     }

--- a/packages/renderer/src/engines/native/shared/each.js
+++ b/packages/renderer/src/engines/native/shared/each.js
@@ -1,0 +1,80 @@
+/*
+  Each-block coordination shared between server and client.
+
+  The server emits `<!--sui-item:v1:KEY-->` markers with keys derived
+  from `getItemID`; the client reads those markers in `adoptServerItems`
+  and re-derives keys via the same `getItemID` to match. Same for
+  `getEachData` (per-item data context shape) — server's `renderEach`
+  and client's `createRecord` / `adoptServerItems` must agree.
+
+  This module is the single source of truth for that coordination.
+  Either side drifting silently produces hydration mismatches.
+*/
+
+import { isPlainObject, isString } from '@semantic-ui/utils';
+
+// Marker prefix for per-item boundaries inside an each block. Server
+// writes `<!--sui-item:v1:KEY-->` before each item's content; client's
+// adoption walker recognizes this prefix to group server-rendered nodes
+// by item.
+export const SUI_ITEM_MARKER = 'sui-item:v1:';
+
+// Identity for an item in a list. Server and client must agree or
+// adoption misses keys. Result is always a string — Map / === compare
+// by value identity, and the server's KEY is always serialized as
+// text inside the comment marker.
+//
+// Order: positional key (object collections), then standard fields
+// (_id, id, key, hash, _hash, value), then index fallback.
+export function getItemID(item, indexOrKey, collectionType) {
+  let raw;
+  if (isPlainObject(item)) {
+    const key = (collectionType === 'object') ? indexOrKey : undefined;
+    raw = key || item._id || item.id || item.key || item.hash || item._hash || item.value || indexOrKey;
+  }
+  else if (isString(item)) {
+    raw = item + ':' + indexOrKey;
+  }
+  else {
+    raw = indexOrKey;
+  }
+  return String(raw);
+}
+
+// Per-item data context shape. The wrapper is always a fresh object so
+// Signal.set() sees a new top-level reference and doesn't short-circuit
+// on identity. Inner properties are shallow-copied from item (no-`as`
+// case) so item-property mutations are captured at the wrapper level.
+export function getEachData(item, indexOrKey, collectionType, node) {
+  let { as, indexAs } = node;
+  if (!indexAs) {
+    indexAs = (collectionType === 'array') ? 'index' : 'key';
+  }
+  if (collectionType === 'object') {
+    indexOrKey = item.key;
+    item = item.value;
+  }
+  return as
+    ? { [as]: item, [indexAs]: indexOrKey }
+    : { ...item, this: item, [indexAs]: indexOrKey };
+}
+
+// HTML comment contents cannot contain `--` or `>` (WHATWG spec).
+// User-supplied keys may; encode them defensively. URL-encoding covers
+// both classes plus `%` itself. Keys are typically IDs (`x1`,
+// `user-42`) that don't need encoding, so the overhead is negligible
+// in practice.
+export function encodeItemKey(key) {
+  return encodeURIComponent(String(key ?? ''));
+}
+
+// Reverse of encodeItemKey. Falls back to the raw input if decoding
+// throws (malformed escape) — preserves whatever the server emitted.
+export function decodeItemKey(rawKey) {
+  try {
+    return decodeURIComponent(rawKey);
+  }
+  catch {
+    return rawKey;
+  }
+}

--- a/packages/renderer/src/engines/native/shared/each.js
+++ b/packages/renderer/src/engines/native/shared/each.js
@@ -6,7 +6,9 @@
 
 import { isPlainObject, isString } from '@semantic-ui/utils';
 
-export const SUI_ITEM_MARKER = 'sui-item:v1:';
+import { MARKER_VERSION } from '../../../build-html-string.js';
+
+export const SUI_ITEM_MARKER = `sui-item:${MARKER_VERSION}:`;
 
 // Stringified — Map / === compare by value identity, and the server's
 // KEY is always serialized as text inside the comment marker.

--- a/packages/renderer/src/engines/native/shared/each.js
+++ b/packages/renderer/src/engines/native/shared/each.js
@@ -1,31 +1,15 @@
 /*
-  Each-block coordination shared between server and client.
-
-  The server emits `<!--sui-item:v1:KEY-->` markers with keys derived
-  from `getItemID`; the client reads those markers in `adoptServerItems`
-  and re-derives keys via the same `getItemID` to match. Same for
-  `getEachData` (per-item data context shape) — server's `renderEach`
-  and client's `createRecord` / `adoptServerItems` must agree.
-
-  This module is the single source of truth for that coordination.
-  Either side drifting silently produces hydration mismatches.
+  Each-block coordination shared between server and client. Both sides
+  must agree on item key, item-data shape, and marker encoding or hydration
+  silently mismatches.
 */
 
 import { isPlainObject, isString } from '@semantic-ui/utils';
 
-// Marker prefix for per-item boundaries inside an each block. Server
-// writes `<!--sui-item:v1:KEY-->` before each item's content; client's
-// adoption walker recognizes this prefix to group server-rendered nodes
-// by item.
 export const SUI_ITEM_MARKER = 'sui-item:v1:';
 
-// Identity for an item in a list. Server and client must agree or
-// adoption misses keys. Result is always a string — Map / === compare
-// by value identity, and the server's KEY is always serialized as
-// text inside the comment marker.
-//
-// Order: positional key (object collections), then standard fields
-// (_id, id, key, hash, _hash, value), then index fallback.
+// Stringified — Map / === compare by value identity, and the server's
+// KEY is always serialized as text inside the comment marker.
 export function getItemID(item, indexOrKey, collectionType) {
   let raw;
   if (isPlainObject(item)) {
@@ -41,10 +25,8 @@ export function getItemID(item, indexOrKey, collectionType) {
   return String(raw);
 }
 
-// Per-item data context shape. The wrapper is always a fresh object so
-// Signal.set() sees a new top-level reference and doesn't short-circuit
-// on identity. Inner properties are shallow-copied from item (no-`as`
-// case) so item-property mutations are captured at the wrapper level.
+// Wrapper is always a fresh object so Signal.set() sees a new top-level
+// reference and doesn't short-circuit on identity.
 export function getEachData(item, indexOrKey, collectionType, node) {
   let { as, indexAs } = node;
   if (!indexAs) {
@@ -59,17 +41,14 @@ export function getEachData(item, indexOrKey, collectionType, node) {
     : { ...item, this: item, [indexAs]: indexOrKey };
 }
 
-// HTML comment contents cannot contain `--` or `>` (WHATWG spec).
-// User-supplied keys may; encode them defensively. URL-encoding covers
-// both classes plus `%` itself. Keys are typically IDs (`x1`,
-// `user-42`) that don't need encoding, so the overhead is negligible
-// in practice.
+// HTML comment contents cannot contain `--` or `>` (WHATWG spec); user
+// keys may. URL-encoding covers both plus `%`.
 export function encodeItemKey(key) {
   return encodeURIComponent(String(key ?? ''));
 }
 
-// Reverse of encodeItemKey. Falls back to the raw input if decoding
-// throws (malformed escape) — preserves whatever the server emitted.
+// Falls back to raw input if decoding throws (malformed escape) so the
+// roundtrip can't strand the value mid-flight.
 export function decodeItemKey(rawKey) {
   try {
     return decodeURIComponent(rawKey);

--- a/packages/renderer/src/index.js
+++ b/packages/renderer/src/index.js
@@ -1,5 +1,5 @@
 // shared
-export { analyzePosition, buildHTMLString, MARKER_VERSION } from './build-html-string.js';
+export { analyzePosition, buildHTMLString, MAIN_BRANCH_INDEX, MARKER_VERSION } from './build-html-string.js';
 export { ExpressionEvaluator } from './expression-evaluator.js';
 export { isRecovery, isTracing, setRecovery, setTracing } from './helpers.js';
 

--- a/tools/ci/bench/reporter/reporter.js
+++ b/tools/ci/bench/reporter/reporter.js
@@ -827,23 +827,33 @@ function computeHistoryStatus(metric, peakHist, driftHist) {
   const currentPctCi = metric.percentDelta;
   const peakPctCi = peakMetric.percent_delta_ci;
 
+  // Difference in midpoints. Positive = regressed from peak; negative = new
+  // best vs peak. Used both for the JND gate below and the rendered delta.
+  const currentMid = (currentPctCi[0] + currentPctCi[1]) / 2;
+  const peakMid = (peakPctCi[0] + peakPctCi[1]) / 2;
+  const deltaFromPeakPct = currentMid - peakMid;
+
   let status;
   if (currentPctCi[1] < peakPctCi[0]) { status = 'WIN'; }
   else if (peakPctCi[1] < currentPctCi[0]) { status = 'REOPENED'; }
   else { status = 'TIED-PEAK'; }
 
-  // Bisect candidates: commits after peak that also report this metric.
+  // Same JND as the same-session classifier. Sub-NOISE_FLOOR doesn't count
+  // as "moved" vs main, so it shouldn't count as "moved" vs peak either.
+  // Holds even when the within-session CIs are statistically non-overlapping.
+  if (Math.abs(deltaFromPeakPct) < NOISE_FLOOR) { status = 'TIED-PEAK'; }
+
+  // Candidates between peak and HEAD. Filter out commits that didn't touch
+  // packages/** — they couldn't have moved a runtime metric, so they
+  // shouldn't appear as bisect or credit candidates. `touches_packages`
+  // is set by `fetch-pr-history.js` per run; absent on legacy entries
+  // (default include for back-compat).
   const peakHistIdx = peakHist.commits.findIndex((c) => c.sha === peakEntry.sha);
   const bisectCandidates = peakHist.commits
     .slice(peakHistIdx + 1)
     .filter((c) => c.metrics?.[metric.name]?.percent_delta_ci)
+    .filter((c) => c.touches_packages !== false)
     .map((c) => ({ sha: c.sha, msg: c.msg, pr: c.pr ?? null }));
-
-  // Difference in percentage points (not %): current's pct-delta midpoint
-  // minus peak's. Positive reads as "regressed N pp of improvement."
-  const currentMid = (currentPctCi[0] + currentPctCi[1]) / 2;
-  const peakMid = (peakPctCi[0] + peakPctCi[1]) / 2;
-  const deltaFromPeakPct = currentMid - peakMid;
 
   const drift = computeBaselineDrift(
     metric.name,


### PR DESCRIPTION
This PR is designed to simplify hydration by abstracting helpers used during hydration, adding constants where they were necessary, and creating a specialized helper `hydrateInto` that blocks can use to avoid repeated code. 

This also modifies code comments to be more precise, and consolidates logic for coordinating `each` blocks on server and client where logic was reproduced, as well as various minor fixes to improve legibility, coherence and simplicity for hydration.

## Risk

5/10 - renderer is the hot path for everything, but the logic is preserved generally just refactored.

## How to Test

Tests handle a lot of coverage but the real confirmation is visual tests across code components in docs, src, examples.