### PR TITLE
Build: Bench reporter surfaces wins

### DIFF
--- a/tools/ci/bench/reporter/fetch-pr-history.js
+++ b/tools/ci/bench/reporter/fetch-pr-history.js
@@ -66,17 +66,26 @@ for (const run of prRuns) {
     continue;
   }
 
+  // Did this iteration's commit actually touch packages source? GitHub's
+  // `paths:` filter triggers benches on any commit in a PR whose overall
+  // diff includes packages/**, so harness-only commits ride along when
+  // earlier commits in the PR moved packages. Filtering here keeps those
+  // commits out of bisect/credit candidate suggestions downstream.
+  const touchesPackages = commitTouchesPackages(repo, run.headSha);
+
   commits.push({
     sha: run.headSha,
     msg: run.displayTitle,
     parent_sha: '',
     timestamp: run.createdAt,
     pr: null,
+    touches_packages: touchesPackages,
     metrics,
   });
   console.log(
     `  ${run.headSha.slice(0, 7)} — ${Object.keys(metrics).length} metrics`
-      + (baselineSha ? ` @ baseline ${baselineSha.slice(0, 7)}` : ''),
+      + (baselineSha ? ` @ baseline ${baselineSha.slice(0, 7)}` : '')
+      + (touchesPackages ? '' : ' (harness-only)'),
   );
 }
 
@@ -89,6 +98,24 @@ console.log(`Wrote ${commits.length} entries to ${outPath}`);
 
 function exec(cmd) {
   return execSync(cmd, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
+}
+
+/**
+ * Query the GitHub API for the commit's changed-file list and return true
+ * when any path is under `packages/`. Defaults to true on API failure so
+ * an unreachable commit doesn't silently disappear from candidate lists.
+ */
+function commitTouchesPackages(repoSlug, sha) {
+  try {
+    const filesRaw = exec(
+      `gh api repos/${repoSlug}/commits/${sha} --jq '.files[].filename'`,
+    );
+    const files = filesRaw.split('\n').filter(Boolean);
+    return files.some((f) => f.startsWith('packages/'));
+  }
+  catch {
+    return true;
+  }
 }
 
 function parseArgs(argv) {

--- a/tools/ci/bench/reporter/reporter.js
+++ b/tools/ci/bench/reporter/reporter.js
@@ -103,6 +103,39 @@ const BISECT_MARKDOWN_MAX = 3;
 // long-running PR.
 const DRIFT_THRESHOLD_PP = 5;
 
+// Cross-iteration peak-attribution sections. Both REOPENED ("regression")
+// and WIN ("win") render the same shape — heading, description, table of
+// metric / current / peak / vs peak / candidates, with drift footnotes when
+// peak and current had different baselines and main moved enough to confound
+// the comparison. Only the framing (status filter, sort direction, copy,
+// delta wording) differs.
+const PEAK_SECTIONS = {
+  regression: {
+    status: 'REOPENED',
+    headingPrefix: '📜 Regressions from peak',
+    description:
+      `These metrics were better on a prior iteration than they are now. The peak's percent-delta vs its baseline dominates current's percent-delta vs its baseline — not attributable to per-sample noise. Bisect candidates are the commits between the peak iteration and HEAD; nearest-to-peak is usually the best bet.`,
+    columnHeader: '| metric | current | peak | vs peak | bisect candidates |',
+    // Largest pp regression first (descending on signed delta).
+    sortSign: -1,
+    formatDelta: (delta) =>
+      delta > 0
+        ? `regressed +${delta.toFixed(0)}%`
+        : `${delta.toFixed(0)}%`,
+  },
+  win: {
+    status: 'WIN',
+    headingPrefix: '🏆 New peaks',
+    description:
+      `These metrics reached a new best in this iteration — current's percent-delta vs its baseline dominates the prior peak's percent-delta vs its baseline. Credit candidates are the commits between the prior peak and HEAD; nearest-to-current is usually the cause.`,
+    columnHeader: '| metric | current | prior peak | vs prior peak | credit candidates |',
+    // Most-improved first. delta_from_peak_pct is negative for WIN, so
+    // ascending sort surfaces the best.
+    sortSign: 1,
+    formatDelta: (delta) => `improved ${delta.toFixed(0)}%`,
+  },
+};
+
 /**
  * Expected percent-change CI width for an unresolved CI given the bench's
  * absolute duration. Derived from the standard-error-of-the-difference of
@@ -347,11 +380,11 @@ function renderMarkdown(report) {
     renderFasterSlowerSection(lines, slower, 'slower', report);
   }
 
-  // ─── New peaks (cross-run; auto-expanded when present) ──────────────
-  renderNewPeaks(lines, report);
+  // ─── New peaks (cross-run; auto-expanded when present) ───────────────
+  renderPeakSection(lines, report, 'win');
 
   // ─── Regressions from peak (cross-run; auto-expanded when present) ───
-  renderRegressionsFromPeak(lines, report);
+  renderPeakSection(lines, report, 'regression');
 
   // ─── No Change (always collapsed) ────────────────────────────────────
   if (noChange.length > 0) {
@@ -436,33 +469,31 @@ function renderMarkdown(report) {
 }
 
 /**
- * Append a "Regressions from peak" section when one or more metrics are
- * REOPENED (current pct-delta dominated by a prior iteration's pct-delta).
- * Actionable signal: the metric was once better and this PR — or a commit
- * before it — gave that improvement back.
+ * Append a cross-iteration peak-attribution section. `kind === 'regression'`
+ * surfaces REOPENED metrics (peak dominates current); `kind === 'win'`
+ * surfaces WIN metrics (current dominates peak). Drift footnotes fire when
+ * peak and current had different baselines and main moved enough to confound
+ * the comparison — symmetric across both kinds because false-blame and
+ * false-credit are the same kind of attribution failure in opposite directions.
  *
- * Surface units are within-session percent-deltas (the pct-delta this run
- * achieved vs its baseline; the pct-delta peak achieved vs ITS baseline).
- * `delta_from_peak_pct` is the difference between those two midpoints in
- * percentage points (pp). Drift footnotes fire when peak and current had
- * different baselines and main moved enough on the metric to plausibly
- * confound the comparison.
+ * Surface units: within-session percent-deltas vs each iteration's baseline.
+ * `delta_from_peak_pct` is the difference between those midpoints, rendered
+ * in the same `%` unit as the table cells.
  */
-function renderRegressionsFromPeak(lines, report) {
-  const reopened = report.metrics.filter((m) => m.history_status === 'REOPENED');
-  if (reopened.length === 0) { return; }
+function renderPeakSection(lines, report, kind) {
+  const config = PEAK_SECTIONS[kind];
+  const rows = report.metrics.filter((m) => m.history_status === config.status);
+  if (rows.length === 0) { return; }
 
-  const sorted = [...reopened].sort(
-    (a, b) => (b.delta_from_peak_pct ?? 0) - (a.delta_from_peak_pct ?? 0),
+  const sorted = [...rows].sort(
+    (a, b) => config.sortSign * ((a.delta_from_peak_pct ?? 0) - (b.delta_from_peak_pct ?? 0)),
   );
 
-  lines.push(`#### 📜 Regressions from peak (${reopened.length})`);
+  lines.push(`#### ${config.headingPrefix} (${rows.length})`);
   lines.push('');
-  lines.push(
-    `These metrics were better on a prior iteration than they are now. The peak's percent-delta vs its baseline dominates current's percent-delta vs its baseline — not attributable to per-sample noise. Bisect candidates are the commits between the peak iteration and HEAD; nearest-to-peak is usually the best bet.`,
-  );
+  lines.push(config.description);
   lines.push('');
-  lines.push('| metric | current | peak | vs peak | bisect candidates |');
+  lines.push(config.columnHeader);
   lines.push('|---|---|---|---|---|');
 
   const flagged = [];
@@ -471,104 +502,10 @@ function renderRegressionsFromPeak(lines, report) {
     const currentStr = formatSignedPct(mid(m.percent_change_ci));
     const peakStr = formatSignedPct(mid(m.peak.percent_delta_ci));
     const peakLink = commitOrPrLink(m.peak, report.repo);
-    const deltaStr = m.delta_from_peak_pct > 0
-      ? `regressed +${m.delta_from_peak_pct.toFixed(0)}%`
-      : `${m.delta_from_peak_pct.toFixed(0)}%`;
-    const bisectCell = formatCandidateCell(m.bisect_candidates, report.repo);
-
-    // Fires on threshold breach or chain-gap (magnitude unavailable).
-    let driftFlag = '';
-    if (m.drift?.detected) {
-      const mag = m.drift.magnitude;
-      const fires = mag === null || Math.abs(mag) >= DRIFT_THRESHOLD_PP;
-      if (fires) {
-        const idx = flagged.length + 1;
-        driftFlag = ` ⚠️${idx}`;
-        flagged.push({
-          idx,
-          metric: m.name,
-          drift: m.drift,
-          currentBaseline: m.baseline_sha,
-          peakBaseline: m.peak.baseline_sha,
-        });
-      }
-    }
-
-    lines.push(
-      `| ${
-        metricLink(m, report)
-      } | ${currentStr}${driftFlag} | ${peakStr} @ ${peakLink} | ${deltaStr} | ${bisectCell} |`,
-    );
-  }
-  lines.push('');
-
-  if (flagged.length > 0) {
-    for (const f of flagged) {
-      lines.push(formatDriftFootnote(f));
-    }
-    lines.push('');
-  }
-}
-
-function formatSignedPct(pct) {
-  return pct > 0 ? `+${pct.toFixed(0)}%` : `${pct.toFixed(0)}%`;
-}
-
-/**
- * Render the comma-joined candidate cell for the regressions/wins tables,
- * with an overflow suffix when the list exceeds BISECT_MARKDOWN_MAX. Same
- * shape for both the bisect (regression) and credit (win) sides — only
- * the column heading differs at the call site.
- */
-function formatCandidateCell(candidates, repo) {
-  if (!candidates || candidates.length === 0) { return '—'; }
-  const md = candidates
-    .slice(0, BISECT_MARKDOWN_MAX)
-    .map((c) => commitOrPrLink(c, repo))
-    .join(', ');
-  return candidates.length > BISECT_MARKDOWN_MAX
-    ? `${md} +${candidates.length - BISECT_MARKDOWN_MAX} more`
-    : md;
-}
-
-/**
- * Append a "New peaks" section when one or more metrics are WIN — current
- * pct-delta CI dominates the prior best iteration's CI. Affirmative signal:
- * "this iteration is the new best on metric X." Mirrors
- * `renderRegressionsFromPeak` with the framing flipped — credit candidates
- * are the commits that may have caused the improvement.
- */
-function renderNewPeaks(lines, report) {
-  const wins = report.metrics.filter((m) => m.history_status === 'WIN');
-  if (wins.length === 0) { return; }
-
-  // delta_from_peak_pct is negative for WIN — ascending sort surfaces the
-  // most-improved first.
-  const sorted = [...wins].sort(
-    (a, b) => (a.delta_from_peak_pct ?? 0) - (b.delta_from_peak_pct ?? 0),
-  );
-
-  lines.push(`#### 🏆 New peaks (${wins.length})`);
-  lines.push('');
-  lines.push(
-    `These metrics reached a new best in this iteration — current's percent-delta vs its baseline dominates the prior peak's percent-delta vs its baseline. Credit candidates are the commits between the prior peak and HEAD; nearest-to-current is usually the cause.`,
-  );
-  lines.push('');
-  lines.push('| metric | current | prior peak | vs prior peak | credit candidates |');
-  lines.push('|---|---|---|---|---|');
-
-  const flagged = [];
-
-  for (const m of sorted) {
-    const currentStr = formatSignedPct(mid(m.percent_change_ci));
-    const peakStr = formatSignedPct(mid(m.peak.percent_delta_ci));
-    const peakLink = commitOrPrLink(m.peak, report.repo);
-    const deltaStr = `improved ${m.delta_from_peak_pct.toFixed(0)}%`;
+    const deltaStr = config.formatDelta(m.delta_from_peak_pct);
     const candCell = formatCandidateCell(m.bisect_candidates, report.repo);
 
-    // Drift treatment is symmetric with regressions: a WIN where main moved
-    // between baselines may credit the iteration for movement that's
-    // actually main-side, mirroring the false-blame case for REOPENED.
+    // Drift fires on threshold breach or chain-gap (magnitude unavailable).
     let driftFlag = '';
     if (m.drift?.detected) {
       const mag = m.drift.magnitude;
@@ -598,6 +535,27 @@ function renderNewPeaks(lines, report) {
     }
     lines.push('');
   }
+}
+
+function formatSignedPct(pct) {
+  return pct > 0 ? `+${pct.toFixed(0)}%` : `${pct.toFixed(0)}%`;
+}
+
+/**
+ * Render the comma-joined candidate cell for peak-attribution tables, with
+ * an overflow suffix when the list exceeds BISECT_MARKDOWN_MAX. Same shape
+ * for bisect (regression) and credit (win) sides — only the column heading
+ * differs at the call site.
+ */
+function formatCandidateCell(candidates, repo) {
+  if (!candidates || candidates.length === 0) { return '—'; }
+  const md = candidates
+    .slice(0, BISECT_MARKDOWN_MAX)
+    .map((c) => commitOrPrLink(c, repo))
+    .join(', ');
+  return candidates.length > BISECT_MARKDOWN_MAX
+    ? `${md} +${candidates.length - BISECT_MARKDOWN_MAX} more`
+    : md;
 }
 
 function formatDriftFootnote({ idx, metric, drift, currentBaseline, peakBaseline }) {

--- a/tools/ci/bench/reporter/reporter.js
+++ b/tools/ci/bench/reporter/reporter.js
@@ -557,6 +557,8 @@ function renderNewPeaks(lines, report) {
   lines.push('| metric | current | prior peak | vs prior peak | credit candidates |');
   lines.push('|---|---|---|---|---|');
 
+  const flagged = [];
+
   for (const m of sorted) {
     const currentStr = formatSignedPct(mid(m.percent_change_ci));
     const peakStr = formatSignedPct(mid(m.peak.percent_delta_ci));
@@ -564,11 +566,38 @@ function renderNewPeaks(lines, report) {
     const deltaStr = `improved ${m.delta_from_peak_pct.toFixed(0)}%`;
     const candCell = formatCandidateCell(m.bisect_candidates, report.repo);
 
+    // Drift treatment is symmetric with regressions: a WIN where main moved
+    // between baselines may credit the iteration for movement that's
+    // actually main-side, mirroring the false-blame case for REOPENED.
+    let driftFlag = '';
+    if (m.drift?.detected) {
+      const mag = m.drift.magnitude;
+      const fires = mag === null || Math.abs(mag) >= DRIFT_THRESHOLD_PP;
+      if (fires) {
+        const idx = flagged.length + 1;
+        driftFlag = ` ⚠️${idx}`;
+        flagged.push({
+          idx,
+          metric: m.name,
+          drift: m.drift,
+          currentBaseline: m.baseline_sha,
+          peakBaseline: m.peak.baseline_sha,
+        });
+      }
+    }
+
     lines.push(
-      `| ${metricLink(m, report)} | ${currentStr} | ${peakStr} @ ${peakLink} | ${deltaStr} | ${candCell} |`,
+      `| ${metricLink(m, report)} | ${currentStr}${driftFlag} | ${peakStr} @ ${peakLink} | ${deltaStr} | ${candCell} |`,
     );
   }
   lines.push('');
+
+  if (flagged.length > 0) {
+    for (const f of flagged) {
+      lines.push(formatDriftFootnote(f));
+    }
+    lines.push('');
+  }
 }
 
 function formatDriftFootnote({ idx, metric, drift, currentBaseline, peakBaseline }) {

--- a/tools/ci/bench/reporter/reporter.js
+++ b/tools/ci/bench/reporter/reporter.js
@@ -324,6 +324,10 @@ function renderMarkdown(report) {
     `🔍 ${unsureTotal} unsure`,
     `⚪ ${noChange.length} no change`,
   ];
+  const winCount = report.history_summary?.WIN ?? 0;
+  if (winCount > 0) {
+    resultsParts.push(`🏆 ${winCount} new peak${winCount === 1 ? '' : 's'}`);
+  }
   const reopenedCount = report.history_summary?.REOPENED ?? 0;
   if (reopenedCount > 0) {
     resultsParts.push(`📜 ${reopenedCount} reopened`);
@@ -342,6 +346,10 @@ function renderMarkdown(report) {
   if (slower.length > 0) {
     renderFasterSlowerSection(lines, slower, 'slower', report);
   }
+
+  // ─── New peaks (cross-run; affirmative — same iterations a perf agent ──
+  // wants to credit when something landed and stuck) ─────────────────────
+  renderNewPeaks(lines, report);
 
   // ─── Regressions from peak (cross-run; auto-expanded when present) ───
   renderRegressionsFromPeak(lines, report);
@@ -465,8 +473,8 @@ function renderRegressionsFromPeak(lines, report) {
     const peakStr = formatSignedPct(mid(m.peak.percent_delta_ci));
     const peakLink = commitOrPrLink(m.peak, report.repo);
     const deltaStr = m.delta_from_peak_pct > 0
-      ? `regressed +${m.delta_from_peak_pct.toFixed(0)}pp`
-      : `${m.delta_from_peak_pct.toFixed(0)}pp`;
+      ? `regressed +${m.delta_from_peak_pct.toFixed(0)}%`
+      : `${m.delta_from_peak_pct.toFixed(0)}%`;
     const bisectMd = (m.bisect_candidates ?? [])
       .slice(0, BISECT_MARKDOWN_MAX)
       .map((c) => commitOrPrLink(c, report.repo))
@@ -511,6 +519,52 @@ function renderRegressionsFromPeak(lines, report) {
 
 function formatSignedPct(pct) {
   return pct > 0 ? `+${pct.toFixed(0)}%` : `${pct.toFixed(0)}%`;
+}
+
+/**
+ * Append a "New peaks" section when one or more metrics are WIN — current
+ * pct-delta CI dominates the prior best iteration's CI. Affirmative signal:
+ * "this iteration is the new best on metric X." Mirrors
+ * `renderRegressionsFromPeak` with the framing flipped — credit candidates
+ * are the commits that may have caused the improvement.
+ */
+function renderNewPeaks(lines, report) {
+  const wins = report.metrics.filter((m) => m.history_status === 'WIN');
+  if (wins.length === 0) { return; }
+
+  // Sort by improvement magnitude — biggest gains first. delta_from_peak_pct
+  // is negative for WIN, so ascending order surfaces the most-improved.
+  const sorted = [...wins].sort(
+    (a, b) => (a.delta_from_peak_pct ?? 0) - (b.delta_from_peak_pct ?? 0),
+  );
+
+  lines.push(`#### 🏆 New peaks (${wins.length})`);
+  lines.push('');
+  lines.push(
+    `These metrics reached a new best in this iteration — current's percent-delta vs its baseline dominates the prior peak's percent-delta vs its baseline. Credit candidates are the commits between the prior peak and HEAD; nearest-to-current is usually the cause.`,
+  );
+  lines.push('');
+  lines.push('| metric | current | prior peak | vs prior peak | credit candidates |');
+  lines.push('|---|---|---|---|---|');
+
+  for (const m of sorted) {
+    const currentStr = formatSignedPct(mid(m.percent_change_ci));
+    const peakStr = formatSignedPct(mid(m.peak.percent_delta_ci));
+    const peakLink = commitOrPrLink(m.peak, report.repo);
+    const deltaStr = `improved ${m.delta_from_peak_pct.toFixed(0)}%`;
+    const candMd = (m.bisect_candidates ?? [])
+      .slice(0, BISECT_MARKDOWN_MAX)
+      .map((c) => commitOrPrLink(c, report.repo))
+      .join(', ');
+    const candCell = m.bisect_candidates && m.bisect_candidates.length > BISECT_MARKDOWN_MAX
+      ? `${candMd} +${m.bisect_candidates.length - BISECT_MARKDOWN_MAX} more`
+      : candMd || '—';
+
+    lines.push(
+      `| ${metricLink(m, report)} | ${currentStr} | ${peakStr} @ ${peakLink} | ${deltaStr} | ${candCell} |`,
+    );
+  }
+  lines.push('');
 }
 
 function formatDriftFootnote({ idx, metric, drift, currentBaseline, peakBaseline }) {

--- a/tools/ci/bench/reporter/reporter.js
+++ b/tools/ci/bench/reporter/reporter.js
@@ -132,7 +132,7 @@ const PEAK_SECTIONS = {
     // Most-improved first. delta_from_peak_pct is negative for WIN, so
     // ascending sort surfaces the best.
     sortSign: 1,
-    formatDelta: (delta) => `improved ${delta.toFixed(0)}%`,
+    formatDelta: (delta) => `improved ${Math.abs(delta).toFixed(0)}%`,
   },
 };
 

--- a/tools/ci/bench/reporter/reporter.js
+++ b/tools/ci/bench/reporter/reporter.js
@@ -347,8 +347,7 @@ function renderMarkdown(report) {
     renderFasterSlowerSection(lines, slower, 'slower', report);
   }
 
-  // ─── New peaks (cross-run; affirmative — same iterations a perf agent ──
-  // wants to credit when something landed and stuck) ─────────────────────
+  // ─── New peaks (cross-run; auto-expanded when present) ──────────────
   renderNewPeaks(lines, report);
 
   // ─── Regressions from peak (cross-run; auto-expanded when present) ───
@@ -475,13 +474,7 @@ function renderRegressionsFromPeak(lines, report) {
     const deltaStr = m.delta_from_peak_pct > 0
       ? `regressed +${m.delta_from_peak_pct.toFixed(0)}%`
       : `${m.delta_from_peak_pct.toFixed(0)}%`;
-    const bisectMd = (m.bisect_candidates ?? [])
-      .slice(0, BISECT_MARKDOWN_MAX)
-      .map((c) => commitOrPrLink(c, report.repo))
-      .join(', ');
-    const bisectCell = m.bisect_candidates && m.bisect_candidates.length > BISECT_MARKDOWN_MAX
-      ? `${bisectMd} +${m.bisect_candidates.length - BISECT_MARKDOWN_MAX} more`
-      : bisectMd || '—';
+    const bisectCell = formatCandidateCell(m.bisect_candidates, report.repo);
 
     // Fires on threshold breach or chain-gap (magnitude unavailable).
     let driftFlag = '';
@@ -522,6 +515,23 @@ function formatSignedPct(pct) {
 }
 
 /**
+ * Render the comma-joined candidate cell for the regressions/wins tables,
+ * with an overflow suffix when the list exceeds BISECT_MARKDOWN_MAX. Same
+ * shape for both the bisect (regression) and credit (win) sides — only
+ * the column heading differs at the call site.
+ */
+function formatCandidateCell(candidates, repo) {
+  if (!candidates || candidates.length === 0) { return '—'; }
+  const md = candidates
+    .slice(0, BISECT_MARKDOWN_MAX)
+    .map((c) => commitOrPrLink(c, repo))
+    .join(', ');
+  return candidates.length > BISECT_MARKDOWN_MAX
+    ? `${md} +${candidates.length - BISECT_MARKDOWN_MAX} more`
+    : md;
+}
+
+/**
  * Append a "New peaks" section when one or more metrics are WIN — current
  * pct-delta CI dominates the prior best iteration's CI. Affirmative signal:
  * "this iteration is the new best on metric X." Mirrors
@@ -532,8 +542,8 @@ function renderNewPeaks(lines, report) {
   const wins = report.metrics.filter((m) => m.history_status === 'WIN');
   if (wins.length === 0) { return; }
 
-  // Sort by improvement magnitude — biggest gains first. delta_from_peak_pct
-  // is negative for WIN, so ascending order surfaces the most-improved.
+  // delta_from_peak_pct is negative for WIN — ascending sort surfaces the
+  // most-improved first.
   const sorted = [...wins].sort(
     (a, b) => (a.delta_from_peak_pct ?? 0) - (b.delta_from_peak_pct ?? 0),
   );
@@ -552,13 +562,7 @@ function renderNewPeaks(lines, report) {
     const peakStr = formatSignedPct(mid(m.peak.percent_delta_ci));
     const peakLink = commitOrPrLink(m.peak, report.repo);
     const deltaStr = `improved ${m.delta_from_peak_pct.toFixed(0)}%`;
-    const candMd = (m.bisect_candidates ?? [])
-      .slice(0, BISECT_MARKDOWN_MAX)
-      .map((c) => commitOrPrLink(c, report.repo))
-      .join(', ');
-    const candCell = m.bisect_candidates && m.bisect_candidates.length > BISECT_MARKDOWN_MAX
-      ? `${candMd} +${m.bisect_candidates.length - BISECT_MARKDOWN_MAX} more`
-      : candMd || '—';
+    const candCell = formatCandidateCell(m.bisect_candidates, report.repo);
 
     lines.push(
       `| ${metricLink(m, report)} | ${currentStr} | ${peakStr} @ ${peakLink} | ${deltaStr} | ${candCell} |`,

--- a/tools/ci/bench/reporter/reporter.js
+++ b/tools/ci/bench/reporter/reporter.js
@@ -104,7 +104,7 @@ const BISECT_MARKDOWN_MAX = 3;
 const DRIFT_THRESHOLD_PP = 5;
 
 // Cross-iteration peak-attribution sections. Both REOPENED ("regression")
-// and WIN ("win") render the same shape — heading, description, table of
+// and WIN ("win") render the same shape: heading, description, table of
 // metric / current / peak / vs peak / candidates, with drift footnotes when
 // peak and current had different baselines and main moved enough to confound
 // the comparison. Only the framing (status filter, sort direction, copy,
@@ -116,7 +116,7 @@ const PEAK_SECTIONS = {
     description:
       `These metrics were better on a prior iteration than they are now. The peak's percent-delta vs its baseline dominates current's percent-delta vs its baseline — not attributable to per-sample noise. Bisect candidates are the commits between the peak iteration and HEAD; nearest-to-peak is usually the best bet.`,
     columnHeader: '| metric | current | peak | vs peak | bisect candidates |',
-    // Largest pp regression first (descending on signed delta).
+    // Largest % regression first (descending on signed delta).
     sortSign: -1,
     formatDelta: (delta) =>
       delta > 0
@@ -473,7 +473,7 @@ function renderMarkdown(report) {
  * surfaces REOPENED metrics (peak dominates current); `kind === 'win'`
  * surfaces WIN metrics (current dominates peak). Drift footnotes fire when
  * peak and current had different baselines and main moved enough to confound
- * the comparison — symmetric across both kinds because false-blame and
+ * the comparison. Symmetric across both kinds because false-blame and
  * false-credit are the same kind of attribution failure in opposite directions.
  *
  * Surface units: within-session percent-deltas vs each iteration's baseline.
@@ -544,7 +544,7 @@ function formatSignedPct(pct) {
 /**
  * Render the comma-joined candidate cell for peak-attribution tables, with
  * an overflow suffix when the list exceeds BISECT_MARKDOWN_MAX. Same shape
- * for bisect (regression) and credit (win) sides — only the column heading
+ * for bisect (regression) and credit (win) sides. Only the column heading
  * differs at the call site.
  */
 function formatCandidateCell(candidates, repo) {
@@ -932,7 +932,7 @@ function computeHistoryStatus(metric, peakHist, driftHist) {
  *
  * Returns one of:
  *   { detected: false }                                                   — baselines match (or one/both unknown)
- *   { detected: true, magnitude: N, chain_len: K, missing: M }            — quantified; N in pp, positive = main got slower
+ *   { detected: true, magnitude: N, chain_len: K, missing: M }            — quantified. N in %, positive = main got slower
  *   { detected: true, magnitude: null, chain_len: K, missing: M }         — chain partially or wholly unwalkable
  *
  * Combines multiplicatively: ∏(1 + pct_i) − 1.

--- a/tools/ci/bench/reporter/reporter.test.js
+++ b/tools/ci/bench/reporter/reporter.test.js
@@ -356,7 +356,7 @@ test('cross-run: WIN when current pct-delta dominates historical peak', () => {
   assert.ok(markdown.includes('🏆 New peaks (1)'), 'New peaks section renders');
   assert.ok(markdown.includes('🏆 1 new peak'), 'headline includes new peak count');
   assert.ok(/improved \d+%/.test(markdown), 'delta uses % unit');
-  assert.ok(!/improved -\d+%/.test(markdown), 'delta drops negative sign for WIN — verb already encodes direction');
+  assert.ok(!/improved -\d+%/.test(markdown), 'delta drops negative sign for WIN: verb already encodes direction');
 });
 
 test('cross-run: peak links to PR conversation when PR number is known', () => {

--- a/tools/ci/bench/reporter/reporter.test.js
+++ b/tools/ci/bench/reporter/reporter.test.js
@@ -754,6 +754,91 @@ test('no drift flag when baselines match', () => {
   assert.ok(!markdown.includes('main moved'), 'no drift footnote');
 });
 
+test('drift flag fires symmetrically on WIN rows', () => {
+  // A WIN where main moved between baselines warrants the same drift
+  // disclosure as a REOPENED — the iteration may credit movement that's
+  // actually main-side. Setup mirrors the REOPENED drift test but with
+  // current's pct-delta dominating peak's instead of regressing.
+  const driftHistory = writeFixture({
+    schema_version: 2,
+    commits: [
+      {
+        sha: 'mainA',
+        msg: 'main A',
+        parent_sha: '',
+        timestamp: '2026-04-15T00:00:00Z',
+        pr: null,
+        metrics: { 'update-10th': { ci: [10, 11], mean_ms: 10.5 } },
+      },
+      {
+        sha: 'main-mid',
+        msg: 'main mid',
+        parent_sha: 'mainA',
+        timestamp: '2026-04-16T00:00:00Z',
+        pr: null,
+        metrics: {
+          'update-10th': {
+            ci: [10.5, 11.5],
+            mean_ms: 11,
+            percent_delta_ci: [4, 6],
+            baseline_sha: 'mainA',
+          },
+        },
+      },
+      {
+        sha: 'mainB',
+        msg: 'main B',
+        parent_sha: 'main-mid',
+        timestamp: '2026-04-17T00:00:00Z',
+        pr: null,
+        metrics: {
+          'update-10th': {
+            ci: [11, 12],
+            mean_ms: 11.5,
+            percent_delta_ci: [3, 5],
+            baseline_sha: 'main-mid',
+          },
+        },
+      },
+    ],
+  });
+  // Prior iteration was at -10 to -5 vs mainA. Current at -50 to -45 vs mainB.
+  // Current's pct-delta dominates → WIN. Baselines differ → drift flag fires.
+  const prHistory = writeFixture({
+    schema_version: 2,
+    commits: [{
+      sha: 'pr-prior',
+      msg: 'prior iteration',
+      parent_sha: '',
+      timestamp: '2026-04-15T01:00:00Z',
+      pr: null,
+      metrics: {
+        'update-10th': {
+          ci: [9, 10],
+          mean_ms: 9.5,
+          percent_delta_ci: [-10, -5],
+          baseline_sha: 'mainA',
+        },
+      },
+    }],
+  });
+  const dir = writeHandcraftedResults('update-10th', [5, 6], [11.5, 12.5], [-50, -45], 'mainB');
+  const { report, markdown } = runReporter({
+    resultsDir: dir,
+    sha: 'current',
+    msg: 'x',
+    baseSha: 'def',
+    history: driftHistory,
+    prHistory,
+    scope: 'pr',
+  });
+  const m = report.metrics.find((x) => x.name === 'update-10th');
+  assert.equal(m.history_status, 'WIN');
+  assert.ok(m.drift?.detected, 'drift detected on WIN');
+  assert.ok(/⚠️1 main moved/.test(markdown), 'drift footnote renders on WIN row');
+  assert.ok(markdown.includes('🏆 New peaks (1)'), 'New peaks section present');
+});
+
 test('cross-run: graceful degrade when history file is missing', () => {
   const dir = writeHandcraftedResults('update-10th', [10, 11]);
   const { report, markdown } = runReporter({

--- a/tools/ci/bench/reporter/reporter.test.js
+++ b/tools/ci/bench/reporter/reporter.test.js
@@ -355,7 +355,8 @@ test('cross-run: WIN when current pct-delta dominates historical peak', () => {
   assert.ok(!markdown.includes('Regressions from peak'), 'no reopened section when no REOPENED');
   assert.ok(markdown.includes('🏆 New peaks (1)'), 'New peaks section renders');
   assert.ok(markdown.includes('🏆 1 new peak'), 'headline includes new peak count');
-  assert.ok(/improved -\d+%/.test(markdown), 'delta uses % unit');
+  assert.ok(/improved \d+%/.test(markdown), 'delta uses % unit');
+  assert.ok(!/improved -\d+%/.test(markdown), 'delta drops negative sign for WIN — verb already encodes direction');
 });
 
 test('cross-run: peak links to PR conversation when PR number is known', () => {

--- a/tools/ci/bench/reporter/reporter.test.js
+++ b/tools/ci/bench/reporter/reporter.test.js
@@ -353,6 +353,9 @@ test('cross-run: WIN when current pct-delta dominates historical peak', () => {
   assert.equal(m.peak.sha, 'bbbb222222222222', 'peak entry is the most-improved prior');
   assert.ok(m.delta_from_peak_pct < 0, 'delta_from_peak_pct is negative when current dominates peak');
   assert.ok(!markdown.includes('Regressions from peak'), 'no reopened section when no REOPENED');
+  assert.ok(markdown.includes('🏆 New peaks (1)'), 'New peaks section renders');
+  assert.ok(markdown.includes('🏆 1 new peak'), 'headline includes new peak count');
+  assert.ok(/improved -\d+%/.test(markdown), 'delta uses % unit');
 });
 
 test('cross-run: peak links to PR conversation when PR number is known', () => {
@@ -409,6 +412,8 @@ test('cross-run: REOPENED when a prior iteration dominates current', () => {
   assert.ok(markdown.includes('📜 Regressions from peak (1)'), 'reopened section with count');
   assert.ok(markdown.includes('`bbbb222`'), 'peak SHA linked');
   assert.ok(markdown.includes('📜 1 reopened'), 'headline count includes reopened');
+  assert.ok(/regressed \+\d+%/.test(markdown), 'delta uses % unit (not pp)');
+  assert.ok(!markdown.includes('🏆'), 'no new peaks count when WIN is zero');
 });
 
 test('cross-run: TIED-PEAK when pct-delta CIs overlap', () => {
@@ -424,6 +429,104 @@ test('cross-run: TIED-PEAK when pct-delta CIs overlap', () => {
   });
   const m = report.metrics.find((x) => x.name === 'update-10th');
   assert.equal(m.history_status, 'TIED-PEAK');
+});
+
+test('cross-run: sub-NOISE_FLOOR delta downgrades to TIED-PEAK even with non-overlapping CIs', () => {
+  // Non-overlapping CIs that would naively be REOPENED, but the midpoint
+  // gap is below NOISE_FLOOR (2). The JND gate downgrades to TIED-PEAK so
+  // sub-noise-floor differences don't fire false alarms.
+  const prHistory = writeFixture({
+    schema_version: 2,
+    commits: [{
+      sha: 'pr-iter-1',
+      msg: 'iteration 1',
+      parent_sha: '',
+      timestamp: '2026-04-20T00:00:00Z',
+      pr: null,
+      metrics: {
+        'update-10th': {
+          ci: [10, 11],
+          mean_ms: 10.5,
+          percent_delta_ci: [-2.5, -2.0],
+          baseline_sha: 'mainA',
+        },
+      },
+    }],
+  });
+  // Current pct-delta [-1.5, -1.0] vs peak [-2.5, -2.0]. peak.high (-2) <
+  // current.low (-1.5) → CIs don't overlap. Midpoints: current -1.25,
+  // peak -2.25. delta = +1pp, below NOISE_FLOOR. JND downgrades to TIED.
+  const dir = writeHandcraftedResults('update-10th', [10, 11], [10.5, 11.5], [-1.5, -1.0], 'mainA');
+  const { report, markdown } = runReporter({
+    resultsDir: dir,
+    sha: 'current',
+    msg: 'x',
+    baseSha: 'def',
+    prHistory,
+    scope: 'pr',
+  });
+  const m = report.metrics.find((x) => x.name === 'update-10th');
+  assert.equal(m.history_status, 'TIED-PEAK', 'JND gate downgrades sub-floor delta');
+  assert.ok(!markdown.includes('Regressions from peak'), 'no reopened section');
+  assert.ok(!markdown.includes('New peaks'), 'no new peaks section');
+});
+
+test('cross-run: bisect candidates exclude touches_packages: false entries', () => {
+  // History: peak (touches packages), then a harness-only commit, then
+  // current. The harness-only commit should not appear as a bisect candidate
+  // even though it has percent_delta_ci data.
+  const prHistory = writeFixture({
+    schema_version: 2,
+    commits: [
+      {
+        sha: 'pr-peak-1234567',
+        msg: 'peak iteration',
+        parent_sha: '',
+        timestamp: '2026-04-20T00:00:00Z',
+        pr: null,
+        touches_packages: true,
+        metrics: {
+          'update-10th': {
+            ci: [7, 8],
+            mean_ms: 7.5,
+            percent_delta_ci: [-30, -25],
+            baseline_sha: 'mainA',
+          },
+        },
+      },
+      {
+        sha: 'pr-harness-7654321',
+        msg: 'Harness: tweak some skill',
+        parent_sha: '',
+        timestamp: '2026-04-20T01:00:00Z',
+        pr: null,
+        touches_packages: false,
+        metrics: {
+          'update-10th': {
+            ci: [8, 9],
+            mean_ms: 8.5,
+            percent_delta_ci: [-20, -15],
+            baseline_sha: 'mainA',
+          },
+        },
+      },
+    ],
+  });
+  // Current pct-delta [-5, 0] regresses from peak [-30, -25]. delta ~+25pp.
+  const dir = writeHandcraftedResults('update-10th', [11, 12], [11.5, 12.5], [-5, 0], 'mainA');
+  const { report } = runReporter({
+    resultsDir: dir,
+    sha: 'current',
+    msg: 'x',
+    baseSha: 'def',
+    prHistory,
+    scope: 'pr',
+  });
+  const m = report.metrics.find((x) => x.name === 'update-10th');
+  assert.equal(m.history_status, 'REOPENED');
+  // Only the harness commit sits between peak and current, but it shouldn't
+  // appear because touches_packages is false.
+  assert.equal(m.bisect_candidates.length, 0, 'harness-only commit excluded');
 });
 
 test('--scope pr excludes main-history from peak attribution', () => {


### PR DESCRIPTION
The bench bot surfaces regression-from-peak signals but does not show WIN and TIED-PEAK, only in the JSON in the test runner.  

For perf work that iterates, the affirmative signal matters as much as the regression signal. "This iteration is the new peak" is what tells an agent the change worked.

This PR mirrors the existing `Regressions from peak` section with `New peaks` for the affirmative case.

## Changes

- New peaks surface as a headline `N new peaks` count and a `New peaks` table mirroring the regressions section.
- Drift flags render symmetrically on WIN rows when peak and current iterations had different baselines.
- Regressions table units unified to `%`.
- Harness-only commits no longer appear as bisect or credit candidates.

## Risk

0/10 — internal CI infrastructure. No public code touched.