### PR TITLE
Harness: Drop ai/workspace/ links from tracked plan files

### DIFF
--- a/ai/plans/archive/cdn-site.md
+++ b/ai/plans/archive/cdn-site.md
@@ -320,7 +320,7 @@ tools/cdn/
 
 ## Status
 
-Not started. Partial scaffolding exists in `scripts/cdn/`. Fresh-take evaluation at `ai/workspace/tmp/cdn-url-design-evaluation.md`.
+Not started. Partial scaffolding exists in `scripts/cdn/`.
 
 ## Completion
 

--- a/ai/plans/archive/hydrate-each-external-state.md
+++ b/ai/plans/archive/hydrate-each-external-state.md
@@ -158,7 +158,6 @@ Completed 2026-05-02. Reversed 2026-05-04 (classifier ripped out, canonical eage
 - **PR #175** — bug fix on `bug/hydrate-reactivity`. Adds `each-content-classifier.js`, gates `each.hydrate`, 19 unit tests, unskips one previously-skipped integration test.
 - **PR #176** — test infra on `test/hydrate-bench-real-dsd`. `ssrAndHydrate` uses `setHTMLUnsafe`, `Template.isServer` toggle, `shadowHTML` strips `data-sui-bind`. Adds `hydrate-helper-100-mount` and `hydrate-helper-100-state-change` measurements.
 - **PR #177** — bench resolution on `test/hydrate-bench-1000-items`. One-line `makeItems(100)` → `makeItems(1000)` × 2.
-- Two `<task-notification>`-style fresh-take analyses in `ai/workspace/fresh-takes/` (neutral + challenge lenses) — preserved as historical context for the architectural debate.
 
 ### Methodology notes for future agents
 

--- a/ai/plans/archive/hydration-perf-pass.md
+++ b/ai/plans/archive/hydration-perf-pass.md
@@ -2,22 +2,11 @@
 
 ## Goal
 
-Close the ~425 ms hydration regression the `perf/native` block-decomposition branch had vs `main` on the canonical `/perf/hydrated` benchmark (1000-card `PerfCards` component, SSR + client hydration). Work through the perf corpus in `ai/workspace/reference/perf/` in sequence, measuring before and after each change, landing only what the benchmark justified.
+Close the ~425 ms hydration regression the `perf/native` block-decomposition branch had vs `main` on the canonical `/perf/hydrated` benchmark (1000-card `PerfCards` component, SSR + client hydration). Work through the perf corpus in sequence, measuring before and after each change, landing only what the benchmark justified.
 
-The perf corpus had been produced over multiple prior investigation sessions and organized into seven staged directories:
+The perf corpus had been produced over multiple prior investigation sessions and organized into seven staged directories covering: hypotheses and hot-spots, per-topic open questions, neutral-evaluation reports, solution sketches, industry-survey art, concrete scoped plans, and already-landed plans.
 
-```
-ai/workspace/reference/perf/
-  01-investigation/   — hypotheses, hot-spots, initial profiling
-  02-briefs/          — per-topic open questions
-  03-analysis/        — neutral-evaluation reports from sub-agents
-  04-solutions/       — per-topic solution sketches
-  05-art/             — industry-survey "how other frameworks solve this"
-  06-plans/           — concrete scoped plans (the load-bearing ones)
-  07-complete/        — plans already landed in prior sessions
-```
-
-Going into this pass, `06-plans/` had items 02, 04, 05, 08, 09, 12 open. `07-complete/` already had 01 (unsafe-html anchor), 03 (attach splitting), 06 (expression-eval firstRun), 07 (signal stack-trace), 10 (signal-clone hotpath), 11 (hashCode removal).
+Going into this pass, the open plans were 02, 04, 05, 08, 09, 12. Already complete: 01 (unsafe-html anchor), 03 (attach splitting), 06 (expression-eval firstRun), 07 (signal stack-trace), 10 (signal-clone hotpath), 11 (hashCode removal).
 
 ## Design / Implementation
 
@@ -62,7 +51,7 @@ Effect on hydration: TTI dropped to ~half of main's.
 
 ## Supporting changes
 
-- **Comparison document** (`ai/workspace/perf-log.md`) — continuous record of before/after measurements per plan, with commit hashes linking back to the changes. Includes the Vercel vs dev vs staging calibration.
+- **Comparison document** — continuous record of before/after measurements per plan, with commit hashes linking back to the changes. Includes the Vercel vs dev vs staging calibration.
 - **Vercel preview build strategy** — touch a docs file on each perf commit so Vercel's docs-based cache invalidates (packages/ changes alone don't trigger a rebuild).
 - **PR tachometer integration** — each commit triggers a tachometer run, authoritative prod-like measurement. Updated the pinned PR comment.
 - **Test suite discipline** — every commit ran `npm test` green (920 renderer tests, 79 component tests). The one pre-existing failure (`.claude missing dist/cdn/` in `internal-packages/esbuild-resolve-bare-imports/test/cdn-urls.test.js`) is unrelated.
@@ -111,6 +100,6 @@ Driving the decomposition branch's client-render regression from ~−60% on `sel
 ### Artifacts landed
 
 - 11 commits on `perf/native` (PR #137), `5bb6ae3af` through `deb712cc7`
-- `ai/workspace/perf-log.md` — full measurement trail
+- Perf log — full measurement trail (per-plan before/after with commit hashes)
 - 2 test cases added as `it.skip` in `subtree-spurious.test.js` documenting the fine-grained reactivity gaps (will flip to `it` when the follow-up plan lands)
 - Plan 12 (hydration yielding) moved to `ai/plans/deferred/` with rationale

--- a/ai/plans/archive/mcp-improvements.md
+++ b/ai/plans/archive/mcp-improvements.md
@@ -199,7 +199,7 @@ No manifest generation needed. The file structure IS the API.
 
 **Priority:** High - critical for AI-assisted theming workflows
 
-**See also:** `ai/workspace/plans/css-token-extraction.md` for full implementation details
+**See also:** css-token-extraction plan for full implementation details
 
 ---
 

--- a/ai/plans/archive/receives-data.md
+++ b/ai/plans/archive/receives-data.md
@@ -74,4 +74,4 @@ The renderer-side gate stays. Combined with #1 and #2, the full picture:
   1. `data.uiClasses = () => this.getUIClasses(...)` in `packages/component/src/engines/native/base.js:47` — function form, settings-Signal-tracked.
   2. Dirty flag in `packages/templating/src/template.js:139` — `assignInPlace(this.data, data, { returnChanged: true })`, `dataReplaced` gates `bumpDataVersion()`.
   3. `receivesData` flag in `packages/renderer/src/engines/native/renderer.js:151` — gates `dataDep.depend()` in `lookupExpression()`.
-- Archived 2026-04-29 from workspace draft. Plan was executed without a canonical roadmap entry; this archive entry is the catalog record.
+- Archived 2026-04-29. Plan was executed without a canonical roadmap entry; this archive entry is the catalog record.

--- a/ai/plans/archive/rename-ui-prefix-exports.md
+++ b/ai/plans/archive/rename-ui-prefix-exports.md
@@ -81,4 +81,4 @@ Update references in ai/skills/ markdown files that show import examples.
 
 - **Shipped.** Verified directly in source: `src/primitives/index.js` exports `Button`, `Card`, `Icon`, `MenuItem` (no `UI` prefix). `src/primitives/button/button.js` exports `Button`. `src/primitives/menu/specs/menu-item.spec.js` has `exportName: 'MenuItem'` (the corner case the plan called out).
 - Web component tags (`<ui-button>`) unchanged as planned — required by HTML spec.
-- Archived 2026-04-29 from workspace draft. Plan was executed without a canonical roadmap entry; this archive entry is the catalog record.
+- Archived 2026-04-29. Plan was executed without a canonical roadmap entry; this archive entry is the catalog record.

--- a/ai/plans/archive/sizing-system-reconcile.md
+++ b/ai/plans/archive/sizing-system-reconcile.md
@@ -8,9 +8,7 @@ Reorganize and consolidate the sizing/spacing/padding/margin token system with c
 
 ## Phase 1: Inventory Existing System
 
-**Create scratch file:** `ai/workspace/memory/sizing-inventory.md`
-
-Document all existing groupings from:
+Inventory all existing groupings from:
 - `src/css/tokens/global/sizing.css`
 - `src/css/tokens/global/spacing.css`
 - `src/css/tokens/computed/em-sizing.css`
@@ -27,7 +25,7 @@ For each grouping, record:
 
 ## Phase 2: Extract to Scratch Files
 
-Move each logical grouping to: `ai/workspace/memory/sizing/[groupname].css`
+Extract each logical grouping into a scratch file per group:
 
 Proposed groupings:
 1. `base-values.css` - unitless base numbers (--size-3xs-base, --em-size, etc.)
@@ -49,7 +47,7 @@ Proposed groupings:
 
 ## Phase 3: Design New System
 
-**Create:** `ai/workspace/memory/sizing-new-system.css`
+Draft the new system in a scratch file.
 
 Requirements:
 1. **Base values** (unitless) - foundation for calculations
@@ -98,7 +96,7 @@ Move sections from `sizing-new-system.css` to src/css files:
 
 ## Phase 5: Verify Completeness
 
-Compare new system against extracted files in `ai/workspace/memory/sizing/`:
+Compare new system against extracted groupings:
 
 For each old grouping, verify:
 - [ ] Functionality preserved or intentionally removed
@@ -120,10 +118,10 @@ Discuss findings with user before finalizing.
 - `src/css/tokens/computed/em-sizing.css`
 - `src/css/tokens/computed/layout.css`
 
-**Create:**
-- `ai/workspace/memory/sizing-inventory.md`
-- `ai/workspace/memory/sizing/*.css` (extracted groupings)
-- `ai/workspace/memory/sizing-new-system.css`
+**Create (scratch):**
+- Sizing inventory document
+- Per-grouping extracted CSS scratch files
+- New system draft CSS
 
 **Modify:**
 - Source files above (remove old, add new)

--- a/ai/plans/icebox/audit-fix-continuation.md
+++ b/ai/plans/icebox/audit-fix-continuation.md
@@ -46,7 +46,7 @@
 - [ ] ai-rewrite-context.md: skill name → ai-author-context
 - [ ] ai-create-context.md: skill name → ai-author-context, list_docs/get_doc → list_user_docs/get_user_doc
 - [ ] research-component-patterns.md: ai/research/[component]/ → ai/research/components/[component]/, fix ui-list path, fix self-reference path
-- [ ] verify-pattern-research.md: Fix research paths, ai/artifacts/ → ai/workspace/artifacts/
+- [ ] verify-pattern-research.md: Fix research paths, ai/artifacts/ → ai/research/
 - [ ] docs-add-links.md: All URL paths need /docs/guides/ or /docs/ prefix
 - [ ] docs-evaluate-text.md: Remove nonexistent file refs, fix all page paths with /docs/guides/ prefix
 - [ ] primitive-scaffold.md: Spec separator -component.js → .component.js, spec barrel .spec segment, CSS tree levels, plural template braces, Astro registry pattern

--- a/ai/plans/icebox/registry.md
+++ b/ai/plans/icebox/registry.md
@@ -1,6 +1,6 @@
 # Registry
 
-> **Status:** Draft (workspace) — workshop pending, not yet on the roadmap.
+> **Status:** Draft — workshop pending, not yet on the roadmap.
 > **Goal:** SUI registry for components and behaviors with runtime + compile-time consumption, an open author namespace, and an editorial canonical layer above it.
 > **Roadmap home:** Post-Phase 4. Almost certainly post-Phase 5.
 

--- a/ai/plans/lsp-and-type-intelligence-tdd.md
+++ b/ai/plans/lsp-and-type-intelligence-tdd.md
@@ -33,7 +33,7 @@ None of this can be represented in TypeScript. Templates need their own language
 
 ## Validated Type Results
 
-Prototype files at `ai/workspace/tmp/exp-thistype-both.ts` (10 tests, `tsc --strict` clean). Solver experiments at `ai/workspace/tmp/lsp-self-type-findings.md`.
+Prototype validated with 10 tests, `tsc --strict` clean.
 
 | Target | Mechanism | tsc | IDE | Status |
 |--------|-----------|-----|-----|--------|

--- a/ai/plans/lsp-and-type-intelligence.md
+++ b/ai/plans/lsp-and-type-intelligence.md
@@ -26,7 +26,7 @@ Only first-party primitives (~14 today, ~80 target) use `componentSpec`. The maj
 
 Rework `defineComponent` generics. `M` inferred from `createComponent` return. `S` from `defaultSettings`. `St` from `defaultState`. Uses `ThisType<M>` on the return and `FactoryParams` (self omitted from M, added back as `Record<string, any>`) to break circularity.
 
-Results (all validated with `tsc --strict`, prototype at `ai/workspace/tmp/exp-thistype-both.ts`):
+Results (all validated with `tsc --strict`):
 
 - `settings.*` -- fully typed everywhere
 - `state.*` -- fully typed everywhere (wrapped in `Signal<T>`)
@@ -45,7 +45,6 @@ Results (all validated with `tsc --strict`, prototype at `ai/workspace/tmp/exp-t
 
 For users who want fully typed `self` in createComponent without using `this`. Intercepts `getScriptSnapshot` to inject JSDoc annotations. Same pattern as `typescript-plugin-css-modules` and Angular TCBs.
 
-Research at `ai/workspace/reference/typescript-plugin-research.md`.
 
 ### Architecture — Transport-Agnostic Core
 


### PR DESCRIPTION
Keeping archived plans as authored