### PR TITLE
Feat: Preserve Iteratee in {#each} loop at userland boundaries

### DIFF
--- a/packages/renderer/src/engines/native/reactive-context.js
+++ b/packages/renderer/src/engines/native/reactive-context.js
@@ -148,10 +148,6 @@ function trapGet(target, prop) {
       // as-key never fires for object items in this path, so subscribing
       // here would attach a Reaction-side dep that cleans up and
       // re-attaches per cycle without ever invalidating.
-      if (target.itemProxyTarget !== item) {
-        target.itemProxy = new Proxy(item, target.itemHandler);
-        target.itemProxyTarget = item;
-      }
       return target.itemProxy;
     }
     if (Scheduler.current) {
@@ -163,14 +159,18 @@ function trapGet(target, prop) {
   return target.parent[prop];
 }
 
-// Per-RDC handler for the item proxy. Target is the user's item itself
-// — devtools display, JSON.stringify, Object.keys, and `in` operate on
-// the item's shape rather than the RDC's internals. The handler is a
-// closure over the RDC so trap functions reach fieldDeps without
-// needing a getter on the proxy target.
+// Per-RDC handler for the item proxy. Target is a per-RDC placeholder
+// `{}` (so devtools display reads "Proxy(Object) {…}" — clean for
+// stack-trace debugging — without binding the proxy's identity to a
+// specific item ref). Every trap delegates to rdc.values[rdc.asKey],
+// the RDC's current item, so the proxy is stable across item-ref
+// changes (cloning Signals issue fresh refs every reconcile pass; we
+// don't want to invalidate per-cache-holder).
 function createItemHandler(rdc) {
+  const currentItem = () => rdc.values[rdc.asKey];
   return {
-    get(item, prop) {
+    get(_, prop) {
+      const item = currentItem();
       if (prop === ITEM_TARGET) {
         if (Scheduler.current) {
           let dep = rdc.fieldDeps[BARE_ITEM_DEP];
@@ -181,7 +181,9 @@ function createItemHandler(rdc) {
         }
         return item;
       }
-      if (typeof prop === 'symbol') { return item[prop]; }
+      if (typeof prop === 'symbol') {
+        return item == null ? undefined : item[prop];
+      }
       if (Scheduler.current) {
         let dep = rdc.fieldDeps[prop];
         if (dep === undefined) {
@@ -189,23 +191,26 @@ function createItemHandler(rdc) {
         }
         dep.depend();
       }
-      return item[prop];
+      return item == null ? undefined : item[prop];
     },
-    has(item, prop) {
-      return prop in item;
+    has(_, prop) {
+      const item = currentItem();
+      return item != null && (prop in item);
     },
-    ownKeys(item) {
-      return Reflect.ownKeys(item);
+    ownKeys() {
+      const item = currentItem();
+      return item == null ? [] : Reflect.ownKeys(item);
     },
-    getOwnPropertyDescriptor(item, prop) {
+    getOwnPropertyDescriptor(_, prop) {
+      const item = currentItem();
+      if (item == null) { return undefined; }
       const desc = Object.getOwnPropertyDescriptor(item, prop);
-      // Proxy invariant: if the target is non-extensible (frozen),
-      // descriptors must mirror exactly. Frozen items already return
-      // configurable: false, which is correct.
-      if (desc !== undefined && Object.isExtensible(item)) {
-        desc.configurable = true;
-      }
+      if (desc !== undefined) { desc.configurable = true; }
       return desc;
+    },
+    getPrototypeOf() {
+      const item = currentItem();
+      return item == null ? null : Object.getPrototypeOf(item);
     },
   };
 }
@@ -256,16 +261,16 @@ export class ReactiveDataContext {
     this.deps = Object.create(null);
     // The per-FIELD machinery is only consumed when the as-key path
     // returns the item proxy. Spread mode and non-as-mode each blocks
-    // never reach trapItemGet, so the fieldDeps map and item handler
-    // closure are dead weight there. Inner Dependency instances on
-    // fieldDeps are lazy — allocated on first reactive field read.
+    // never reach trapItemGet, so the fieldDeps map and item proxy are
+    // dead weight there. Inner Dependency instances on fieldDeps are
+    // lazy — allocated on first reactive field read. The item proxy
+    // wraps a per-RDC `{}` placeholder; traps delegate to the current
+    // values[asKey] so the proxy ref is stable across item-ref changes.
     this.fieldDeps = null;
     this.itemProxy = null;
-    this.itemProxyTarget = null;
-    this.itemHandler = null;
     if (asKey !== null) {
       this.fieldDeps = Object.create(null);
-      this.itemHandler = createItemHandler(this);
+      this.itemProxy = new Proxy({}, createItemHandler(this));
     }
     // Snapshot Signal.equalityFunction at construction. Mirrors Signal's
     // own per-instance snapshot semantics — late overrides of the static
@@ -327,7 +332,6 @@ export class ReactiveDataContext {
     this.deps = Object.create(null);
     if (this.fieldDeps !== null) { this.fieldDeps = Object.create(null); }
     this.itemProxy = null;
-    this.itemProxyTarget = null;
     this.keysSealed = false;
   }
 }

--- a/packages/renderer/src/engines/native/reactive-context.js
+++ b/packages/renderer/src/engines/native/reactive-context.js
@@ -99,6 +99,26 @@ export function isItemContext(data) {
   return data != null && itemContextProxies.has(data);
 }
 
+// Sentinel that the item-handler's get trap recognizes to return its
+// underlying target. Used by unwrapItem at userland boundaries so user
+// code receives the actual item, not the framework's tracking proxy.
+const ITEM_TARGET = Symbol.for('@semantic-ui/item-proxy-target');
+
+// Bare-access subscribers register against this key in fieldDeps. Per
+// access through the ITEM_TARGET symbol — the user is taking the item
+// out of the framework's tracking surface, so we have no per-FIELD
+// information to subscribe to. notifyField also fires this dep so the
+// binding wakes on any field mutation.
+const BARE_ITEM_DEP = Symbol('sui:bare-item-dep');
+
+export function unwrapItem(value) {
+  if (value !== null && typeof value === 'object') {
+    const target = value[ITEM_TARGET];
+    if (target !== undefined) { return target; }
+  }
+  return value;
+}
+
 function trapGet(target, prop) {
   if (typeof prop === 'symbol') { return target.parent[prop]; }
   const values = target.values;
@@ -151,6 +171,16 @@ function trapGet(target, prop) {
 function createItemHandler(rdc) {
   return {
     get(item, prop) {
+      if (prop === ITEM_TARGET) {
+        if (Scheduler.current) {
+          let dep = rdc.fieldDeps[BARE_ITEM_DEP];
+          if (dep === undefined) {
+            dep = rdc.fieldDeps[BARE_ITEM_DEP] = new Dependency();
+          }
+          dep.depend();
+        }
+        return item;
+      }
       if (typeof prop === 'symbol') { return item[prop]; }
       if (Scheduler.current) {
         let dep = rdc.fieldDeps[prop];
@@ -278,8 +308,11 @@ export class ReactiveDataContext {
   }
 
   notifyField(fieldName) {
+    if (this.fieldDeps === null) { return; }
     const dep = this.fieldDeps[fieldName];
     if (dep !== undefined) { dep.changed(); }
+    const bareDep = this.fieldDeps[BARE_ITEM_DEP];
+    if (bareDep !== undefined) { bareDep.changed(); }
   }
 
   replace(nextValues) {

--- a/packages/renderer/src/engines/native/reactive-context.js
+++ b/packages/renderer/src/engines/native/reactive-context.js
@@ -148,6 +148,9 @@ function trapGet(target, prop) {
       // as-key never fires for object items in this path, so subscribing
       // here would attach a Reaction-side dep that cleans up and
       // re-attaches per cycle without ever invalidating.
+      if (target.itemProxy === null) {
+        target.itemProxy = new Proxy({}, target.itemHandler);
+      }
       return target.itemProxy;
     }
     if (Scheduler.current) {
@@ -167,10 +170,9 @@ function trapGet(target, prop) {
 // changes (cloning Signals issue fresh refs every reconcile pass; we
 // don't want to invalidate per-cache-holder).
 function createItemHandler(rdc) {
-  const currentItem = () => rdc.values[rdc.asKey];
   return {
     get(_, prop) {
-      const item = currentItem();
+      const item = rdc.values[rdc.asKey];
       if (prop === ITEM_TARGET) {
         if (Scheduler.current) {
           let dep = rdc.fieldDeps[BARE_ITEM_DEP];
@@ -194,22 +196,22 @@ function createItemHandler(rdc) {
       return item == null ? undefined : item[prop];
     },
     has(_, prop) {
-      const item = currentItem();
+      const item = rdc.values[rdc.asKey];
       return item != null && (prop in item);
     },
     ownKeys() {
-      const item = currentItem();
+      const item = rdc.values[rdc.asKey];
       return item == null ? [] : Reflect.ownKeys(item);
     },
     getOwnPropertyDescriptor(_, prop) {
-      const item = currentItem();
+      const item = rdc.values[rdc.asKey];
       if (item == null) { return undefined; }
       const desc = Object.getOwnPropertyDescriptor(item, prop);
       if (desc !== undefined) { desc.configurable = true; }
       return desc;
     },
     getPrototypeOf() {
-      const item = currentItem();
+      const item = rdc.values[rdc.asKey];
       return item == null ? null : Object.getPrototypeOf(item);
     },
   };
@@ -261,16 +263,19 @@ export class ReactiveDataContext {
     this.deps = Object.create(null);
     // The per-FIELD machinery is only consumed when the as-key path
     // returns the item proxy. Spread mode and non-as-mode each blocks
-    // never reach trapItemGet, so the fieldDeps map and item proxy are
-    // dead weight there. Inner Dependency instances on fieldDeps are
-    // lazy — allocated on first reactive field read. The item proxy
-    // wraps a per-RDC `{}` placeholder; traps delegate to the current
-    // values[asKey] so the proxy ref is stable across item-ref changes.
+    // never reach trapItemGet, so the fieldDeps map and item handler
+    // are dead weight there. Inner Dependency instances on fieldDeps
+    // are lazy — allocated on first reactive field read. The item
+    // proxy wraps a per-RDC `{}` placeholder; traps delegate to the
+    // current values[asKey] so the proxy ref is stable across item-
+    // ref changes. The proxy itself is lazy — allocated on first
+    // access of the as-key.
     this.fieldDeps = null;
     this.itemProxy = null;
+    this.itemHandler = null;
     if (asKey !== null) {
       this.fieldDeps = Object.create(null);
-      this.itemProxy = new Proxy({}, createItemHandler(this));
+      this.itemHandler = createItemHandler(this);
     }
     // Snapshot Signal.equalityFunction at construction. Mirrors Signal's
     // own per-instance snapshot semantics — late overrides of the static

--- a/packages/renderer/src/expression-evaluator.js
+++ b/packages/renderer/src/expression-evaluator.js
@@ -1,5 +1,6 @@
 import { Signal } from '@semantic-ui/reactivity';
 import { createCache } from '@semantic-ui/utils';
+import { unwrapItem } from './engines/native/reactive-context.js';
 
 // Fallback handler for the rare includeHelpers: false path
 const jsNoHelpersHandler = {
@@ -236,12 +237,17 @@ export class ExpressionEvaluator {
       else {
         const tokenValue = this.lookupExpressionValue(token, data, visited);
         if (typeof tokenValue === 'function') {
-          // Collect arguments from the already-resolved tokens to the right
+          // Collect arguments from the already-resolved tokens to the
+          // right. Unwrap any item-proxy values at this boundary so
+          // user-supplied helpers receive the actual item — the proxy
+          // is a framework-internal tracking mechanism and shouldn't
+          // leak into userland identity, instanceof checks, WeakMap
+          // keys, or internal-slot method calls.
           let argCount = len - index - 1;
           if (argCount > 0) {
             const args = new Array(argCount);
             for (let a = 0; a < argCount; a++) {
-              args[a] = results[index + 1 + a];
+              args[a] = unwrapItem(results[index + 1 + a]);
             }
             result = tokenValue(...args);
           }

--- a/packages/renderer/test/browser/subtree-spurious.test.js
+++ b/packages/renderer/test/browser/subtree-spurious.test.js
@@ -714,28 +714,30 @@ RENDERING_ENGINES.forEach(engine => {
       // subscribes to a per-field dep rather than the whole-item key. The
       // test pins that contract for a future architectural pass.
       it('mutating one item field via setProperty re-fires only the binding reading that field', async () => {
-        // {#each item in items} body has two bindings reading two
-        // different fields of the same item. setProperty mutates one
-        // field. Per-key isolation: only that field's binding fires.
+        // Per-FIELD precision applies to direct dotted reads in templates.
+        // The dotted walk (todo.text, todo.completed) goes through the
+        // item proxy, registering per-FIELD deps. Helpers receive the
+        // resolved field value (a string / bool), not the bare item.
         let textFires = 0;
         let completedFires = 0;
         const tag = uniqueTag();
         defineComponent({
           renderingEngine: engine,
           tagName: tag,
-          template: '{#each todo in getTodos}<span>{readText todo}</span><span>{readCompleted todo}</span>{/each}',
+          template:
+            '{#each todo in getTodos}<span>{markText todo.text}</span><span>{markCompleted todo.completed}</span>{/each}',
           createComponent: ({ signal }) => {
             const todos = signal([{ _id: 'a', text: 'first', completed: false }]);
             return {
               todos,
               getTodos: () => todos.get(),
-              readText: (todo) => {
+              markText: (text) => {
                 textFires++;
-                return todo.text;
+                return text;
               },
-              readCompleted: (todo) => {
+              markCompleted: (completed) => {
                 completedFires++;
-                return String(todo.completed);
+                return String(completed);
               },
               toggle: () => todos.setProperty('a', 'completed', !todos.getItem('a').completed),
             };
@@ -755,6 +757,52 @@ RENDERING_ENGINES.forEach(engine => {
 
         expect(completedFires).toBe(2);
         expect(textFires).toBe(1);
+      });
+
+      it('helper-mediated bare item access wakes on any field mutation (no per-FIELD precision)', async () => {
+        // When the helper takes the bare item, the framework unwraps
+        // the proxy at the helper boundary so user code sees the raw
+        // item identity. The helper accesses fields via plain JS reads
+        // (no per-FIELD deps register inside it). The binding subscribes
+        // to a "bare" wakeup channel that fires on any field mutation
+        // — coalescing to per-key-equivalent precision. This is the
+        // documented trade-off of receiving raw items in helpers.
+        let readFires = 0;
+        const tag = uniqueTag();
+        defineComponent({
+          renderingEngine: engine,
+          tagName: tag,
+          template: '{#each todo in getTodos}<span>{readWhole todo}</span>{/each}',
+          createComponent: ({ signal }) => {
+            const todos = signal([{ _id: 'a', text: 'first', completed: false }]);
+            return {
+              todos,
+              getTodos: () => todos.get(),
+              readWhole: (todo) => {
+                readFires++;
+                return `${todo.text} ${todo.completed}`;
+              },
+              toggle: () => todos.setProperty('a', 'completed', !todos.getItem('a').completed),
+              rename: () => todos.setProperty('a', 'text', 'renamed'),
+            };
+          },
+        });
+        const el = document.createElement(tag);
+        const rendered = $(el).onNext('rendered');
+        document.body.appendChild(el);
+        await rendered;
+
+        expect(readFires).toBe(1);
+
+        const update1 = $(el).onNext('updated');
+        el.component.toggle();
+        await update1;
+        expect(readFires).toBe(2);
+
+        const update2 = $(el).onNext('updated');
+        el.component.rename();
+        await update2;
+        expect(readFires).toBe(3);
       });
 
       it('mutating one item field does NOT re-fire bindings of unaffected sibling items', async () => {
@@ -849,16 +897,17 @@ RENDERING_ENGINES.forEach(engine => {
 
       it('setArrayProperty re-fires only the matching field across every item', async () => {
         // todo-list toggleAll shape: state.todos.setArrayProperty(
-        // 'completed', true) mutates the completed field on every item
-        // in place. Per-FIELD isolation: every item's completed binding
-        // re-fires, but no item's title binding re-fires.
+        // 'completed', true) mutates the completed field on every item.
+        // Direct dotted reads (todo.title, todo.completed) register
+        // per-FIELD deps; only the completed binding wakes per record.
         let titleFires = 0;
         let completedFires = 0;
         const tag = uniqueTag();
         defineComponent({
           renderingEngine: engine,
           tagName: tag,
-          template: '{#each todo in getTodos}<span>{readTitle todo}</span><span>{readCompleted todo}</span>{/each}',
+          template:
+            '{#each todo in getTodos}<span>{markTitle todo.title}</span><span>{markCompleted todo.completed}</span>{/each}',
           createComponent: ({ signal }) => {
             const todos = signal([
               { _id: 'a', title: 'first', completed: false },
@@ -868,13 +917,13 @@ RENDERING_ENGINES.forEach(engine => {
             return {
               todos,
               getTodos: () => todos.get(),
-              readTitle: (todo) => {
+              markTitle: (title) => {
                 titleFires++;
-                return todo.title;
+                return title;
               },
-              readCompleted: (todo) => {
+              markCompleted: (completed) => {
                 completedFires++;
-                return String(todo.completed);
+                return String(completed);
               },
               completeAll: () => todos.setArrayProperty('completed', true),
             };

--- a/packages/renderer/test/browser/subtree-spurious.test.js
+++ b/packages/renderer/test/browser/subtree-spurious.test.js
@@ -936,6 +936,101 @@ RENDERING_ENGINES.forEach(engine => {
         expect(flagFires).toBe(2);
       });
 
+      it('helper receives the raw item identity, not a framework wrapper', async () => {
+        // The framework uses an item-tracking proxy internally for
+        // per-FIELD dep registration on dotted reads. The proxy must
+        // not leak into userland — when a helper receives the item as
+        // a bare argument, it should get the original object reference,
+        // so identity checks (===, WeakMap, instanceof) and naive
+        // debugging (console.log, JSON.stringify) work as users expect.
+        const ref = { _id: 'apple', name: 'Apple' };
+        let captured = null;
+        const tag = uniqueTag();
+        defineComponent({
+          renderingEngine: engine,
+          tagName: tag,
+          template: '{#each fruit in fruits}<span>{capture fruit}</span>{/each}',
+          createComponent: ({ signal }) => {
+            const fruits = signal([ref], { allowClone: false });
+            return {
+              fruits,
+              capture: (fruit) => {
+                captured = fruit;
+                return '';
+              },
+            };
+          },
+        });
+        const el = document.createElement(tag);
+        const rendered = $(el).onNext('rendered');
+        document.body.appendChild(el);
+        await rendered;
+
+        expect(captured).toBe(ref);
+      });
+
+      it('helper can call internal-slot methods on a bare item argument', async () => {
+        // Class methods that depend on internal slots — Date.getTime,
+        // Map.set, RegExp.exec — throw TypeError when this is a Proxy
+        // because the slot lookup misses. Helpers receiving items must
+        // get the actual instance so these methods work.
+        let timestamp = null;
+        const tag = uniqueTag();
+        defineComponent({
+          renderingEngine: engine,
+          tagName: tag,
+          template: '{#each d in dates}<span>{readTime d}</span>{/each}',
+          createComponent: ({ signal }) => {
+            const dates = signal([new Date('2024-01-01T00:00:00Z')], { allowClone: false });
+            return {
+              dates,
+              readTime: (d) => {
+                timestamp = d.getTime();
+                return String(timestamp);
+              },
+            };
+          },
+        });
+        const el = document.createElement(tag);
+        const rendered = $(el).onNext('rendered');
+        document.body.appendChild(el);
+        await rendered;
+
+        expect(timestamp).toBe(new Date('2024-01-01T00:00:00Z').getTime());
+      });
+
+      it('helper can use bare item as a WeakMap key matching its source identity', async () => {
+        // Common pattern: cache derived data keyed by item identity.
+        // weakMap.get(itemFromHelper) only returns the cached value if
+        // the helper received the same object reference the user stored.
+        const cache = new WeakMap();
+        const ref = { _id: 'apple', name: 'Apple' };
+        cache.set(ref, 'cached-derived-value');
+        let lookupResult = null;
+        const tag = uniqueTag();
+        defineComponent({
+          renderingEngine: engine,
+          tagName: tag,
+          template: '{#each fruit in fruits}<span>{readCache fruit}</span>{/each}',
+          createComponent: ({ signal }) => {
+            const fruits = signal([ref], { allowClone: false });
+            return {
+              fruits,
+              readCache: (fruit) => {
+                lookupResult = cache.get(fruit);
+                return String(lookupResult);
+              },
+            };
+          },
+        });
+        const el = document.createElement(tag);
+        const rendered = $(el).onNext('rendered');
+        document.body.appendChild(el);
+        await rendered;
+
+        expect(lookupResult).toBe('cached-derived-value');
+      });
+
       it('item passed to a helper exposes the item shape, not RDC internals', async () => {
         // Naive debug pattern: helpers receive the item proxy. console.log
         // (in devtools) and Object.keys / JSON.stringify operations must


### PR DESCRIPTION
This prevents the underlying fine-grained-reactivity primitives from leaking/exposing to user code by preserving them at boundaries where user code are executed inside expression evaluator.