### PR TITLE
Refactor(renderer): Unify expression dispatch into defineBlock

### DIFF
--- a/packages/renderer/src/engines/native/blocks/expression.js
+++ b/packages/renderer/src/engines/native/blocks/expression.js
@@ -36,16 +36,13 @@ const expression = defineBlock({
   kind: 'value',
   syntax: (node) => `{${node.value}}`,
 
-  // Stash evaluator for the literalValue path (lookupTokenValue doesn't
-  // auto-invoke functions — needed for `{#fn handler}` and event-binding
+  // No `create` hook — renderer.evaluator is reached directly via the bag.
+  // The literalValue path uses `lookupTokenValue` because it doesn't
+  // auto-invoke functions (needed for `{#fn handler}` and event-binding
   // shapes where the value is a function reference, not its call result).
-  create({ renderer }) {
-    return { evaluator: renderer.evaluator };
-  },
-
-  compute({ node, data, self, renderer }) {
+  compute({ node, data, renderer }) {
     if (node.literalValue) {
-      return self.evaluator.lookupTokenValue(node.value, data);
+      return renderer.evaluator.lookupTokenValue(node.value, data);
     }
     const value = renderer.lookupExpression(node.value, data);
     if (node.unsafeHTML) {
@@ -64,9 +61,9 @@ const expression = defineBlock({
   // unsafeHTML the server emitted the parsed HTML payload as siblings; we
   // collect them as ownedNodes and replace the comment with an empty
   // positional anchor.
-  hydrate({ node, data, self, renderer, comment }) {
+  hydrate({ node, data, renderer, comment }) {
     if (node.literalValue) {
-      const value = self.evaluator.lookupTokenValue(node.value, data);
+      const value = renderer.evaluator.lookupTokenValue(node.value, data);
       const anchor = this.adoptValueTextNode(comment, String(value ?? ''));
       return { anchor, ownedNodes: null, matched: value };
     }

--- a/packages/renderer/src/engines/native/blocks/expression.js
+++ b/packages/renderer/src/engines/native/blocks/expression.js
@@ -35,9 +35,16 @@ const expression = defineBlock({
   name: 'expression',
   syntax: (node) => `{${node.value}}`,
 
-  compute({ node, data, renderer, lookupExpression }) {
+  // Stash evaluator for the literalValue path (lookupTokenValue doesn't
+  // auto-invoke functions — needed for `{#fn handler}` and event-binding
+  // shapes where the value is a function reference, not its call result).
+  create({ renderer }) {
+    return { evaluator: renderer.evaluator };
+  },
+
+  compute({ node, data, self, lookupExpression }) {
     if (node.literalValue) {
-      return renderer.evaluator.lookupTokenValue(node.value, data);
+      return self.evaluator.lookupTokenValue(node.value, data);
     }
     const value = lookupExpression(node.value);
     if (node.unsafeHTML) {
@@ -54,11 +61,11 @@ const expression = defineBlock({
   // siblings; we adopt them via region.ownedNodes. The matched content
   // is returned so defineBlock primes place via match() — first
   // compute-driven update tick then dedups instead of re-rendering.
-  hydrate({ node, data, region, renderer, lookupExpression }) {
+  hydrate({ node, data, region, self, lookupExpression }) {
     if (node.literalValue) {
       // One-shot; nothing reactive to set up. Adopt the server text node
       // (or create one if missing) so place finds it on later writes.
-      const value = renderer.evaluator.lookupTokenValue(node.value, data);
+      const value = self.evaluator.lookupTokenValue(node.value, data);
       this.adoptValueTextNode(region, String(value ?? ''));
       return value;
     }

--- a/packages/renderer/src/engines/native/blocks/expression.js
+++ b/packages/renderer/src/engines/native/blocks/expression.js
@@ -7,22 +7,20 @@ import { registerBlock } from './registry.js';
 
   Expression block — text-position dispatch.
 
-  Opts into defineBlock's lean value-emitter path via `kind: 'value'`. The
-  renderer skips DynamicRegion allocation for this shape; the lean dispatch
+  Opts into defineBlock's lean value-emitter path via `type: 'value'`. The
+  renderer skips DynamicRegion allocation for this shape; the dispatch
   manages a single anchor text node (which IS the value text node in the
-  primitive case) and an ownedNodes list for unsafeHTML payloads. Authoring
-  shape is identical to a region-block — compute returns the value, hydrate
-  adopts server DOM, helpers live on the config and are reached via `this`.
+  primitive case) and an ownedNodes list for unsafeHTML payloads.
 
-  Three node flags compute branches on:
-    • unsafeHTML  — wrap evaluated value as `unsafeHTML(value)`; the lean
-                    dispatch parses the string as HTML and inserts the
-                    parsed nodes as ownedNodes after the anchor.
+  Compute has two node-flag branches plus a default path:
+    • unsafeHTML   — wrap evaluated value as `unsafeHTML(value)`; the
+                     dispatch parses the string as HTML and inserts the
+                     parsed nodes as ownedNodes after the anchor.
     • literalValue — read via lookupTokenValue (no auto-invoke for
-                    functions). Used by `{#fn handler}` so the function
-                    reference isn't called for its return value.
-    • default     — read via renderer.lookupExpression; return as a
-                    primitive; the lean dispatch writes anchor.data.
+                     functions). Used by `{#fn handler}` so the function
+                     reference isn't called for its return value.
+    • default      — read via renderer.lookupExpression; return as a
+                     primitive; the dispatch writes anchor.data.
 
   Attribute-position expressions are NOT dispatched here — they're walked
   by bindAttribute in attribute-binding.js as part of an attribute's
@@ -33,8 +31,13 @@ import { registerBlock } from './registry.js';
 
 const expression = defineBlock({
   name: 'expression',
-  kind: 'value',
+  type: 'value',
   syntax: (node) => `{${node.value}}`,
+
+  // {#fn marker} returns a function reference as-is. There's no path that
+  // reads a Signal during compute, so the dispatch skips Reaction wiring
+  // entirely for these markers.
+  static: (node) => Boolean(node.literalValue),
 
   // No `create` hook — renderer.evaluator is reached directly via the bag.
   // The literalValue path uses `lookupTokenValue` because it doesn't
@@ -52,8 +55,9 @@ const expression = defineBlock({
   },
 
   // Hydrate adopts the server-rendered DOM rather than rebuilding. Returns
-  // { anchor, ownedNodes, matched } so the lean dispatch wires its Reaction
-  // on the right node and primes lastContent against `matched` for dedup.
+  // { anchor, ownedNodes } — anchor becomes the dispatch's reactive text
+  // node; ownedNodes (unsafeHTML only) tracks the parsed payload for
+  // replacement on update.
   //
   // For default text expressions the server emits `<!--sui:v1:N-->VALUE`
   // where VALUE may merge with following static text into one text node —
@@ -65,22 +69,20 @@ const expression = defineBlock({
     if (node.literalValue) {
       const value = renderer.evaluator.lookupTokenValue(node.value, data);
       const anchor = this.adoptValueTextNode(comment, String(value ?? ''));
-      return { anchor, ownedNodes: null, matched: value };
+      return { anchor, ownedNodes: null };
     }
 
     if (node.unsafeHTML) {
       const ownedNodes = this.collectServerSiblings(comment);
       const anchor = document.createTextNode('');
       comment.parentNode.replaceChild(anchor, comment);
-      return { anchor, ownedNodes, matched: unsafeHTML(renderer.lookupExpression(node.value, data)) };
+      return { anchor, ownedNodes };
     }
 
     const serverValue = String(renderer.lookupExpression(node.value, data) ?? '');
     const anchor = this.adoptValueTextNode(comment, serverValue);
-    return { anchor, ownedNodes: null, matched: serverValue };
+    return { anchor, ownedNodes: null };
   },
-
-  // ---- helpers ----
 
   // Walk forward from `from` collecting siblings until the next sui marker
   // (open block, close block, or expression). These are the server-emitted

--- a/packages/renderer/src/engines/native/blocks/expression.js
+++ b/packages/renderer/src/engines/native/blocks/expression.js
@@ -7,22 +7,22 @@ import { registerBlock } from './registry.js';
 
   Expression block — text-position dispatch.
 
-  Every text-position `{expression}` reaches the renderer through this
-  block via the standard defineBlock contract: framework constructs a
-  DynamicRegion, wires the outer Reaction, calls compute → place. No
-  separate "value-emitting" dispatch shape — the bag.place primitive is
-  polymorphic on content type (primitive → text-node write; unsafeHTML
-  wrapper → parse-and-insert; AST array → renderAST + setContent).
+  Opts into defineBlock's lean value-emitter path via `kind: 'value'`. The
+  renderer skips DynamicRegion allocation for this shape; the lean dispatch
+  manages a single anchor text node (which IS the value text node in the
+  primitive case) and an ownedNodes list for unsafeHTML payloads. Authoring
+  shape is identical to a region-block — compute returns the value, hydrate
+  adopts server DOM, helpers live on the config and are reached via `this`.
 
   Three node flags compute branches on:
-    • unsafeHTML  — wrap evaluated value as `unsafeHTML(value)`; place
-                    parses the string as HTML and inserts the parsed
-                    nodes as region.ownedNodes.
+    • unsafeHTML  — wrap evaluated value as `unsafeHTML(value)`; the lean
+                    dispatch parses the string as HTML and inserts the
+                    parsed nodes as ownedNodes after the anchor.
     • literalValue — read via lookupTokenValue (no auto-invoke for
                     functions). Used by `{#fn handler}` so the function
                     reference isn't called for its return value.
-    • default     — read via lookupExpression; return as a primitive;
-                    place writes a single owned text node.
+    • default     — read via renderer.lookupExpression; return as a
+                    primitive; the lean dispatch writes anchor.data.
 
   Attribute-position expressions are NOT dispatched here — they're walked
   by bindAttribute in attribute-binding.js as part of an attribute's
@@ -33,6 +33,7 @@ import { registerBlock } from './registry.js';
 
 const expression = defineBlock({
   name: 'expression',
+  kind: 'value',
   syntax: (node) => `{${node.value}}`,
 
   // Stash evaluator for the literalValue path (lookupTokenValue doesn't
@@ -42,56 +43,54 @@ const expression = defineBlock({
     return { evaluator: renderer.evaluator };
   },
 
-  compute({ node, data, self, lookupExpression }) {
+  compute({ node, data, self, renderer }) {
     if (node.literalValue) {
       return self.evaluator.lookupTokenValue(node.value, data);
     }
-    const value = lookupExpression(node.value);
+    const value = renderer.lookupExpression(node.value, data);
     if (node.unsafeHTML) {
       return unsafeHTML(value);
     }
     return value;
   },
 
-  // Hydrate adopts the server-rendered DOM rather than rebuilding. For
-  // default text expressions the server emits `<!--sui:v1:N-->VALUE` and
-  // the text node may concatenate VALUE with following static text — we
-  // split at the server-value boundary so the reactive node covers only
-  // VALUE. For unsafeHTML the server emitted the parsed HTML payload as
-  // siblings; we adopt them via region.ownedNodes. The matched content
-  // is returned so defineBlock primes place via match() — first
-  // compute-driven update tick then dedups instead of re-rendering.
-  hydrate({ node, data, region, self, lookupExpression }) {
+  // Hydrate adopts the server-rendered DOM rather than rebuilding. Returns
+  // { anchor, ownedNodes, matched } so the lean dispatch wires its Reaction
+  // on the right node and primes lastContent against `matched` for dedup.
+  //
+  // For default text expressions the server emits `<!--sui:v1:N-->VALUE`
+  // where VALUE may merge with following static text into one text node —
+  // we split at the boundary so the reactive node covers only VALUE. For
+  // unsafeHTML the server emitted the parsed HTML payload as siblings; we
+  // collect them as ownedNodes and replace the comment with an empty
+  // positional anchor.
+  hydrate({ node, data, self, renderer, comment }) {
     if (node.literalValue) {
-      // One-shot; nothing reactive to set up. Adopt the server text node
-      // (or create one if missing) so place finds it on later writes.
       const value = self.evaluator.lookupTokenValue(node.value, data);
-      this.adoptValueTextNode(region, String(value ?? ''));
-      return value;
+      const anchor = this.adoptValueTextNode(comment, String(value ?? ''));
+      return { anchor, ownedNodes: null, matched: value };
     }
 
     if (node.unsafeHTML) {
-      // Collect server-emitted siblings up to the next sui marker as
-      // ownedNodes. place's unsafeHTML branch clears/replaces ownedNodes
-      // on subsequent writes; pre-populating here is the adopt step.
-      region.ownedNodes = this.collectServerSiblings(region.anchor);
-      if (region.ownedNodes.length > 0) { region.placeEndAnchor(); }
-      return unsafeHTML(lookupExpression(node.value));
+      const ownedNodes = this.collectServerSiblings(comment);
+      const anchor = document.createTextNode('');
+      comment.parentNode.replaceChild(anchor, comment);
+      return { anchor, ownedNodes, matched: unsafeHTML(renderer.lookupExpression(node.value, data)) };
     }
 
-    const serverValue = String(lookupExpression(node.value) ?? '');
-    this.adoptValueTextNode(region, serverValue);
-    return serverValue;
+    const serverValue = String(renderer.lookupExpression(node.value, data) ?? '');
+    const anchor = this.adoptValueTextNode(comment, serverValue);
+    return { anchor, ownedNodes: null, matched: serverValue };
   },
 
   // ---- helpers ----
 
-  // Walk forward from `anchor` collecting siblings until the next sui
-  // marker (open block, close block, or expression). These are the
-  // server-emitted payload nodes belonging to the current region.
-  collectServerSiblings(anchor) {
+  // Walk forward from `from` collecting siblings until the next sui marker
+  // (open block, close block, or expression). These are the server-emitted
+  // payload nodes belonging to the current expression.
+  collectServerSiblings(from) {
     const collected = [];
-    let next = anchor.nextSibling;
+    let next = from.nextSibling;
     while (
       next && !(next.nodeType === Node.COMMENT_NODE
         && (isExpressionMarker(next.data) || isBlockOpen(next.data) || isBlockClose(next.data)))
@@ -102,25 +101,26 @@ const expression = defineBlock({
     return collected;
   },
 
-  // Find or create the single text node that holds this expression's
-  // value. For server-hydrated cases, the server's text node sits right
-  // after the anchor and may include trailing static text — split at the
-  // serverValue boundary so the reactive node covers only the value.
-  adoptValueTextNode(region, serverValue) {
-    const nextNode = region.anchor.nextSibling;
+  // Adopt (or create) the text node that holds this expression's value,
+  // replacing the comment marker. For server-hydrated cases, the text
+  // node sits right after the comment and may include trailing static
+  // text — split at the serverValue boundary so the reactive node covers
+  // only the value.
+  adoptValueTextNode(comment, serverValue) {
+    const nextNode = comment.nextSibling;
     let textNode;
     if (nextNode && nextNode.nodeType === Node.TEXT_NODE) {
       if (nextNode.data.length > serverValue.length && nextNode.data.startsWith(serverValue)) {
         nextNode.splitText(serverValue.length);
       }
       textNode = nextNode;
+      comment.remove();
     }
     else {
       textNode = document.createTextNode(serverValue);
-      region.anchor.after(textNode);
+      comment.replaceWith(textNode);
     }
-    region.ownedNodes = [textNode];
-    region.placeEndAnchor();
+    return textNode;
   },
 });
 

--- a/packages/renderer/src/engines/native/blocks/expression.js
+++ b/packages/renderer/src/engines/native/blocks/expression.js
@@ -1,136 +1,121 @@
 import { isBlockClose, isBlockOpen, isExpressionMarker } from '../../../build-html-string.js';
+import { unsafeHTML } from '../commit-hooks.js';
+import { defineBlock } from '../define-block.js';
 import { registerBlock } from './registry.js';
 
 /*
 
-  Text-position expression dispatch. Routes through the block registry so
-  every AST node type (expression, rawText, if, each, async, rerender,
-  template) reaches the renderer through one primitive: getBlock(type).
+  Expression block — text-position dispatch.
+
+  Every text-position `{expression}` reaches the renderer through this
+  block via the standard defineBlock contract: framework constructs a
+  DynamicRegion, wires the outer Reaction, calls compute → place. No
+  separate "value-emitting" dispatch shape — the bag.place primitive is
+  polymorphic on content type (primitive → text-node write; unsafeHTML
+  wrapper → parse-and-insert; AST array → renderAST + setContent).
+
+  Three node flags compute branches on:
+    • unsafeHTML  — wrap evaluated value as `unsafeHTML(value)`; place
+                    parses the string as HTML and inserts the parsed
+                    nodes as region.ownedNodes.
+    • literalValue — read via lookupTokenValue (no auto-invoke for
+                    functions). Used by `{#fn handler}` so the function
+                    reference isn't called for its return value.
+    • default     — read via lookupExpression; return as a primitive;
+                    place writes a single owned text node.
 
   Attribute-position expressions are NOT dispatched here — they're walked
   by bindAttribute in attribute-binding.js as part of an attribute's
-  combined parts evaluation (one Reaction owns the full attribute string
-  regardless of how many markers it contains). bindAttribute handles both
-  expression and block-type markers in that position.
-
-  Bind vs hydrate share their reactive cores; the only differences are
-  where the anchor/textNode comes from (fresh-created vs adopted from
-  server DOM) and whether the first Reaction run writes to the DOM.
+  combined parts evaluation. One Reaction owns the full attribute string
+  regardless of how many markers it contains.
 
 */
 
-// Reaction body: reactive textNode.data writes. skipFirstWrite is set
-// during hydration so the server's text isn't overwritten on first run;
-// the expression read still registers Signal deps.
-function wireTextReaction({ scope, textNode, exprNode, data, renderer, skipFirstWrite }) {
-  scope.reaction(textNode, (comp) => {
-    const value = renderer.lookupExpression(exprNode.value, data);
-    if (skipFirstWrite && comp.firstRun) { return; }
-    textNode.data = value ?? '';
-  });
-}
+const expression = defineBlock({
+  name: 'expression',
+  syntax: (node) => `{${node.value}}`,
 
-// Reaction body: re-parse HTML, replace ownedNodes after an anchor.
-// skipFirstWrite is set during hydration (server bytes are trusted, so the
-// first run only registers deps).
-function wireUnsafeHTMLReaction({ scope, anchor, ownedNodes, exprNode, data, renderer, skipFirstWrite }) {
-  scope.reaction(anchor, (comp) => {
-    const value = renderer.lookupExpression(exprNode.value, data);
-    if (skipFirstWrite && comp.firstRun) { return; }
-    for (const n of ownedNodes) { n.remove(); }
-    ownedNodes.length = 0;
-    if (value != null && value !== '') {
-      const parsed = renderer.parseHTML(String(value));
-      const nodes = [...parsed.childNodes];
-      anchor.after(parsed);
-      ownedNodes.push(...nodes);
+  compute({ node, data, renderer, lookupExpression }) {
+    if (node.literalValue) {
+      return renderer.evaluator.lookupTokenValue(node.value, data);
     }
-  });
-}
-
-// Collect server-rendered sibling nodes after `comment` until the next sui
-// marker. These nodes are the unsafeHTML payload the server emitted; we
-// adopt them into the ownedNodes array so the hydrating Reaction can
-// replace them on subsequent updates.
-function collectServerSiblings(comment) {
-  const collected = [];
-  let next = comment.nextSibling;
-  while (
-    next && !(next.nodeType === Node.COMMENT_NODE
-      && (isExpressionMarker(next.data) || isBlockOpen(next.data) || isBlockClose(next.data)))
-  ) {
-    collected.push(next);
-    next = next.nextSibling;
-  }
-  return collected;
-}
-
-// Fresh text-expression mount. Three shapes:
-//   unsafeHTML   — parse value as HTML, replace owned nodes on each run
-//   literalValue — static text node, no reaction (one-shot at mount)
-//   default      — reactive text node, update .data on each run
-function bindTextExpression({ comment, entry, data, scope, renderer }) {
-  const exprNode = entry.node;
-
-  if (exprNode.unsafeHTML) {
-    const anchor = document.createTextNode('');
-    comment.replaceWith(anchor);
-    const ownedNodes = [];
-    wireUnsafeHTMLReaction({ scope, anchor, ownedNodes, exprNode, data, renderer, skipFirstWrite: false });
-    return;
-  }
-
-  if (exprNode.literalValue) {
-    const value = renderer.evaluator.lookupTokenValue(exprNode.value, data);
-    const textNode = document.createTextNode(value ?? '');
-    comment.parentNode.replaceChild(textNode, comment);
-    return;
-  }
-
-  const textNode = document.createTextNode('');
-  comment.parentNode.replaceChild(textNode, comment);
-  wireTextReaction({ scope, textNode, exprNode, data, renderer, skipFirstWrite: false });
-}
-
-// Hydrating text-expression — adopts server-rendered DOM rather than
-// rebuilding. The server output merges VALUE with any following static
-// text into one text node; split at the boundary so the reactive node
-// covers only the value portion.
-function hydrateTextExpression({ comment, entry, data, scope, renderer }) {
-  const exprNode = entry.node;
-
-  if (exprNode.unsafeHTML) {
-    const ownedNodes = collectServerSiblings(comment);
-    const anchor = document.createTextNode('');
-    comment.replaceWith(anchor);
-    wireUnsafeHTMLReaction({ scope, anchor, ownedNodes, exprNode, data, renderer, skipFirstWrite: true });
-    return;
-  }
-
-  const nextNode = comment.nextSibling;
-  let textNode;
-  if (nextNode && nextNode.nodeType === Node.TEXT_NODE) {
-    const serverValue = String(renderer.lookupExpression(exprNode.value, data) ?? '');
-    if (nextNode.data.length > serverValue.length && nextNode.data.startsWith(serverValue)) {
-      nextNode.splitText(serverValue.length);
+    const value = lookupExpression(node.value);
+    if (node.unsafeHTML) {
+      return unsafeHTML(value);
     }
-    textNode = nextNode;
-    comment.remove();
-  }
-  else {
-    textNode = document.createTextNode('');
-    comment.replaceWith(textNode);
-  }
-  wireTextReaction({ scope, textNode, exprNode, data, renderer, skipFirstWrite: true });
-}
+    return value;
+  },
 
-const expression = function expression({ comment, entry, data, scope, renderer, hydrating }) {
-  if (hydrating) {
-    hydrateTextExpression({ comment, entry, data, scope, renderer });
-    return;
-  }
-  bindTextExpression({ comment, entry, data, scope, renderer });
-};
+  // Hydrate adopts the server-rendered DOM rather than rebuilding. For
+  // default text expressions the server emits `<!--sui:v1:N-->VALUE` and
+  // the text node may concatenate VALUE with following static text — we
+  // split at the server-value boundary so the reactive node covers only
+  // VALUE. For unsafeHTML the server emitted the parsed HTML payload as
+  // siblings; we adopt them via region.ownedNodes. The matched content
+  // is returned so defineBlock primes place via match() — first
+  // compute-driven update tick then dedups instead of re-rendering.
+  hydrate({ node, data, region, renderer, lookupExpression }) {
+    if (node.literalValue) {
+      // One-shot; nothing reactive to set up. Adopt the server text node
+      // (or create one if missing) so place finds it on later writes.
+      const value = renderer.evaluator.lookupTokenValue(node.value, data);
+      this.adoptValueTextNode(region, String(value ?? ''));
+      return value;
+    }
+
+    if (node.unsafeHTML) {
+      // Collect server-emitted siblings up to the next sui marker as
+      // ownedNodes. place's unsafeHTML branch clears/replaces ownedNodes
+      // on subsequent writes; pre-populating here is the adopt step.
+      region.ownedNodes = this.collectServerSiblings(region.anchor);
+      if (region.ownedNodes.length > 0) { region.placeEndAnchor(); }
+      return unsafeHTML(lookupExpression(node.value));
+    }
+
+    const serverValue = String(lookupExpression(node.value) ?? '');
+    this.adoptValueTextNode(region, serverValue);
+    return serverValue;
+  },
+
+  // ---- helpers ----
+
+  // Walk forward from `anchor` collecting siblings until the next sui
+  // marker (open block, close block, or expression). These are the
+  // server-emitted payload nodes belonging to the current region.
+  collectServerSiblings(anchor) {
+    const collected = [];
+    let next = anchor.nextSibling;
+    while (
+      next && !(next.nodeType === Node.COMMENT_NODE
+        && (isExpressionMarker(next.data) || isBlockOpen(next.data) || isBlockClose(next.data)))
+    ) {
+      collected.push(next);
+      next = next.nextSibling;
+    }
+    return collected;
+  },
+
+  // Find or create the single text node that holds this expression's
+  // value. For server-hydrated cases, the server's text node sits right
+  // after the anchor and may include trailing static text — split at the
+  // serverValue boundary so the reactive node covers only the value.
+  adoptValueTextNode(region, serverValue) {
+    const nextNode = region.anchor.nextSibling;
+    let textNode;
+    if (nextNode && nextNode.nodeType === Node.TEXT_NODE) {
+      if (nextNode.data.length > serverValue.length && nextNode.data.startsWith(serverValue)) {
+        nextNode.splitText(serverValue.length);
+      }
+      textNode = nextNode;
+    }
+    else {
+      textNode = document.createTextNode(serverValue);
+      region.anchor.after(textNode);
+    }
+    region.ownedNodes = [textNode];
+    region.placeEndAnchor();
+  },
+});
 
 registerBlock('expression', expression);
 

--- a/packages/renderer/src/engines/native/blocks/template.js
+++ b/packages/renderer/src/engines/native/blocks/template.js
@@ -8,11 +8,12 @@ import { registerBlock } from './registry.js';
 /*
 
   {>name} template invocation. Handles BOTH snippets and subtemplates —
-  the kind is determined at first render by checking renderer.snippets[name]
-  and locked on self.kind for the lifetime of the block instance. Per
-  the documented constraint (plan §dynamic template names), name must
-  resolve consistently to one kind; kind-swapping mid-life is undefined
-  behavior and we honor the first-resolved kind.
+  the templateType is determined at first render by checking
+  renderer.snippets[name] and locked on self.templateType for the
+  lifetime of the block instance. Per the documented constraint (plan
+  §dynamic template names), name must resolve consistently to one
+  templateType; templateType-swapping mid-life is undefined behavior
+  and we honor the first-resolved value.
 
   Two branches:
   • snippet     — inline expansion. No own scope (uses parent), no
@@ -172,17 +173,17 @@ function buildArgsRecord({ node, parentData, evaluator, target }) {
   return record;
 }
 
-// Read name nonreactively for kind detection so name changes (which
-// shouldn't change kind per the documented constraint) don't fire the
-// outer reaction unnecessarily for snippet-kind blocks. Subtemplate
+// Read name nonreactively for templateType detection so name changes
+// (which shouldn't change the type per the documented constraint)
+// don't fire the outer reaction unnecessarily for snippets. Subtemplate
 // name reactivity is handled separately inside the subtemplate branch
 // where it's needed for instance swap.
-function detectKind({ node, data, self }) {
-  if (self.kind !== null) { return self.kind; }
+function detectTemplateType({ node, data, self }) {
+  if (self.templateType !== null) { return self.templateType; }
   const name = Reaction.nonreactive(() => self.evaluator.lookupExpressionValue(node.name, data));
   if (name == null || name === '') { return null; }
-  self.kind = self.snippets[name] ? 'snippet' : 'subtemplate';
-  return self.kind;
+  self.templateType = self.snippets[name] ? 'snippet' : 'subtemplate';
+  return self.templateType;
 }
 
 function resolveSubtemplate(nameExpr, data, self) {
@@ -320,7 +321,7 @@ const templateBlock = defineBlock({
       snippets: renderer.snippets,
       parentTemplate: renderer.template,
       dataDep: renderer.dataDep,
-      kind: null,
+      templateType: null,
       currentTemplateID: null,
       currentInstance: null,
       settingsScope: null,
@@ -328,10 +329,10 @@ const templateBlock = defineBlock({
   },
 
   render({ node, data, region, scope, renderAST, self, isSVG }) {
-    const kind = detectKind({ node, data, self });
-    if (kind === null) { return; }
+    const templateType = detectTemplateType({ node, data, self });
+    if (templateType === null) { return; }
 
-    if (kind === 'snippet') {
+    if (templateType === 'snippet') {
       const snippet = resolveSnippet(node.name, data, self);
       if (!snippet) { fatal(`Snippet name resolved to a missing snippet`); }
       const snippetData = buildArgsRecord({ node, parentData: data, evaluator: self.evaluator, target: data });
@@ -361,10 +362,10 @@ const templateBlock = defineBlock({
   },
 
   hydrate({ node, data, region, scope, hydrateInto, self }) {
-    const kind = detectKind({ node, data, self });
-    if (kind === null) { return; }
+    const templateType = detectTemplateType({ node, data, self });
+    if (templateType === null) { return; }
 
-    if (kind === 'snippet') {
+    if (templateType === 'snippet') {
       const snippet = resolveSnippet(node.name, data, self);
       if (!snippet) { fatal(`Snippet name resolved to a missing snippet`); }
       const snippetData = buildArgsRecord({ node, parentData: data, evaluator: self.evaluator, target: data });
@@ -410,10 +411,10 @@ const templateBlock = defineBlock({
 
   update({ node, data, region, scope, self }) {
     // Snippets are one-shot at mount — name reactivity at the outer level
-    // is documented as undefined (kind shouldn't change), and inner
-    // expression reactivity is handled by the snippet-arg proxy's lazy
-    // getters via per-marker Reactions wired during render/hydrate.
-    if (self.kind === 'snippet') { return; }
+    // is documented as undefined (templateType shouldn't change), and
+    // inner expression reactivity is handled by the snippet-arg proxy's
+    // lazy getters via per-marker Reactions wired during render/hydrate.
+    if (self.templateType === 'snippet') { return; }
 
     self.dataDep.depend();
     const { template, templateName } = resolveSubtemplate(node.name, data, self);

--- a/packages/renderer/src/engines/native/commit-hooks.js
+++ b/packages/renderer/src/engines/native/commit-hooks.js
@@ -24,24 +24,52 @@ import { isArray, isPlainObject } from '@semantic-ui/utils';
 // reference and from null/undefined so the first call always commits.
 const PLACE_INIT = Symbol('place:init');
 
+// Wrapper marker for "this value should be parsed as HTML and inserted
+// as a sibling sequence" — distinguished from AST arrays (rendered via
+// renderAST) and primitives (written to a text node). Compute returns
+// `unsafeHTML(value)` from a block when it wants place to parse-and-insert.
+const UNSAFE_HTML = Symbol('place:unsafeHTML');
+export function unsafeHTML(value) {
+  return { [UNSAFE_HTML]: value };
+}
+
+function isUnsafeHTML(content) {
+  return content != null && typeof content === 'object' && UNSAFE_HTML in content;
+}
+
 // Construct a {place, match} pair for a text-position block.
 //
-// place(content) — public, exposed on the bag. content is an AST array
-// (the matched branch / template content); null clears the region.
-// Reference equality dedups — selectBranch returns the same node.content
-// reference for the same matched branch, so unchanged-branch re-fires
-// no-op.
+// place(content) — public, exposed on the bag. Polymorphic on content
+// shape:
+//   • AST array (Array.isArray) — render via renderAST + region.setContent
+//     with a fresh child scope. Region-managing blocks (conditional,
+//     rerender, template) use this path.
+//   • unsafeHTML wrapper ({ [UNSAFE_HTML]: 'html string' }) — parse value
+//     as HTML, replace region.ownedNodes with the parsed nodes. Mirror of
+//     the existing unsafeHTML expression path.
+//   • null / undefined — clear the region.
+//   • Any other value (primitive) — coerce to string, write into a
+//     reactive text node that lives inside the region as its single owned
+//     node. The text node is created lazily on first primitive place().
+// Reference equality dedups across all shapes — unchanged content
+// no-ops. region.setContent (when place eventually swaps shape) clears
+// region.childScopes, disposing any hydrate scope hydrateInto pushed.
 //
 // match(content) — internal, called by defineBlock from hydrate's return
-// value. Records "the DOM already matches this content" without performing
-// a DOM op, so the first compute-driven update after hydration dedups
-// against the server DOM instead of triggering a wasteful re-render.
-// region.setContent (when place eventually swaps) clears region.childScopes
-// — disposing the hydrate scope hydrateInto pushed — so no leak from the
-// orphaned child-scope at swap time.
+// value. Records "the DOM already matches this content" without
+// performing a DOM op, so the first compute-driven update after
+// hydration dedups against the server DOM instead of triggering a
+// wasteful re-render.
 export function makePlace({ region, scope, renderer, data, isSVG }) {
   let lastContent = PLACE_INIT;
   let lastChildScope = null;
+  let valueTextNode = null;
+
+  function clearOwnedSiblings() {
+    for (const n of region.ownedNodes) { n.remove(); }
+    region.ownedNodes = [];
+    if (region.endAnchor) { region.endAnchor.remove(); }
+  }
 
   function place(content) {
     if (content === lastContent) { return; }
@@ -53,14 +81,50 @@ export function makePlace({ region, scope, renderer, data, isSVG }) {
     }
 
     if (content == null) {
+      // Reset the value text node so a later primitive place() starts fresh.
+      valueTextNode = null;
       region.clear();
       return;
     }
 
-    const childScope = scope.child();
-    lastChildScope = childScope;
-    const fragment = renderer.readAST({ ast: content, scope: childScope, data, isSVG });
-    region.setContent(fragment, childScope);
+    if (isUnsafeHTML(content)) {
+      // HTML payload — parse and insert after the anchor.
+      valueTextNode = null;
+      clearOwnedSiblings();
+      const html = content[UNSAFE_HTML];
+      const str = html == null ? '' : String(html);
+      if (str) {
+        const parsed = renderer.parseHTML(str);
+        const nodes = [...parsed.childNodes];
+        region.anchor.after(parsed);
+        region.ownedNodes = nodes;
+        region.placeEndAnchor();
+      }
+      return;
+    }
+
+    if (Array.isArray(content)) {
+      valueTextNode = null;
+      const childScope = scope.child();
+      lastChildScope = childScope;
+      const fragment = renderer.readAST({ ast: content, scope: childScope, data, isSVG });
+      region.setContent(fragment, childScope);
+      return;
+    }
+
+    // Primitive value (string / number / boolean). Write to a reactive
+    // text node owned by the region. Create lazily.
+    const str = String(content);
+    if (!valueTextNode || valueTextNode.parentNode == null) {
+      clearOwnedSiblings();
+      valueTextNode = document.createTextNode(str);
+      region.anchor.after(valueTextNode);
+      region.ownedNodes = [valueTextNode];
+      region.placeEndAnchor();
+    }
+    else if (valueTextNode.data !== str) {
+      valueTextNode.data = str;
+    }
   }
 
   function match(content) {

--- a/packages/renderer/src/engines/native/commit-hooks.js
+++ b/packages/renderer/src/engines/native/commit-hooks.js
@@ -28,12 +28,12 @@ const PLACE_INIT = Symbol('place:init');
 // as a sibling sequence" — distinguished from AST arrays (rendered via
 // renderAST) and primitives (written to a text node). Compute returns
 // `unsafeHTML(value)` from a block when it wants place to parse-and-insert.
-const UNSAFE_HTML = Symbol('place:unsafeHTML');
+export const UNSAFE_HTML = Symbol('place:unsafeHTML');
 export function unsafeHTML(value) {
   return { [UNSAFE_HTML]: value };
 }
 
-function isUnsafeHTML(content) {
+export function isUnsafeHTML(content) {
   return content != null && typeof content === 'object' && UNSAFE_HTML in content;
 }
 

--- a/packages/renderer/src/engines/native/commit-hooks.js
+++ b/packages/renderer/src/engines/native/commit-hooks.js
@@ -2,21 +2,23 @@ import { isArray, isPlainObject } from '@semantic-ui/utils';
 
 /*
 
-  Helpers for the position-aware block dispatch refactor.
+  Helpers for position-aware block dispatch.
 
-  renderASTToString walks an AST + data context and returns a string. It is
-  the attribute-position counterpart to renderAST — used when a block lands
-  inside an attribute value and its content needs to be serialized rather
-  than rendered as DOM. Mirrors ServerRenderer.renderNodes minus the
-  data-sui-bind tag tracking (no element scanning inside an attribute
-  value).
+  renderASTToString walks an AST + data context and returns a string —
+  the attribute-position counterpart to renderAST. Used when a block
+  lands inside an attribute value and its content needs serializing
+  rather than rendering as DOM. Mirrors ServerRenderer.renderNodes
+  minus the data-sui-bind tag tracking.
 
-  makePlace constructs the `bag.place(content)` closure that text-position
-  block dispatch uses to swap region content. It owns the child-scope +
-  renderAST + region.setContent sequence every block writes by hand today,
-  plus reference-equality dedup so the same matched branch doesn't re-fire
-  a DOM swap. Block authors using the `compute` shorthand never call this
-  directly; defineBlock invokes it from render and update.
+  makePlace constructs the `bag.place(content)` closure used by region
+  blocks (conditional / rerender / template). It owns the
+  child-scope + renderAST + region.setContent sequence, plus
+  reference-equality dedup so the same matched branch doesn't re-fire
+  a DOM swap. defineBlock invokes it from render and update.
+
+  unsafeHTML / UNSAFE_HTML are the marker pair returned by value-block
+  compute when the emitted value is an HTML string; the unsafeHTML
+  variant of the lean dispatch (define-block.js) consumes them.
 
 */
 
@@ -24,52 +26,27 @@ import { isArray, isPlainObject } from '@semantic-ui/utils';
 // reference and from null/undefined so the first call always commits.
 const PLACE_INIT = Symbol('place:init');
 
-// Wrapper marker for "this value should be parsed as HTML and inserted
-// as a sibling sequence" — distinguished from AST arrays (rendered via
-// renderAST) and primitives (written to a text node). Compute returns
-// `unsafeHTML(value)` from a block when it wants place to parse-and-insert.
 export const UNSAFE_HTML = Symbol('place:unsafeHTML');
 export function unsafeHTML(value) {
   return { [UNSAFE_HTML]: value };
 }
 
-export function isUnsafeHTML(content) {
-  return content != null && typeof content === 'object' && UNSAFE_HTML in content;
-}
-
-// Construct a {place, match} pair for a text-position block.
+// Construct a {place, match} pair for a text-position region block.
 //
-// place(content) — public, exposed on the bag. Polymorphic on content
-// shape:
-//   • AST array (Array.isArray) — render via renderAST + region.setContent
-//     with a fresh child scope. Region-managing blocks (conditional,
-//     rerender, template) use this path.
-//   • unsafeHTML wrapper ({ [UNSAFE_HTML]: 'html string' }) — parse value
-//     as HTML, replace region.ownedNodes with the parsed nodes. Mirror of
-//     the existing unsafeHTML expression path.
-//   • null / undefined — clear the region.
-//   • Any other value (primitive) — coerce to string, write into a
-//     reactive text node that lives inside the region as its single owned
-//     node. The text node is created lazily on first primitive place().
-// Reference equality dedups across all shapes — unchanged content
-// no-ops. region.setContent (when place eventually swaps shape) clears
-// region.childScopes, disposing any hydrate scope hydrateInto pushed.
+// place(content) — public, exposed on the bag. content is an AST array
+// (rendered via renderAST + region.setContent against a fresh child
+// scope) or null (region.clear). Reference equality dedups —
+// unchanged content no-ops. region.setContent clears region.childScopes,
+// disposing any hydrate scope hydrateInto pushed.
 //
-// match(content) — internal, called by defineBlock from hydrate's return
-// value. Records "the DOM already matches this content" without
+// match(content) — internal, called by defineBlock from hydrate's
+// return value. Records "the DOM already matches this content" without
 // performing a DOM op, so the first compute-driven update after
 // hydration dedups against the server DOM instead of triggering a
 // wasteful re-render.
 export function makePlace({ region, scope, renderer, data, isSVG }) {
   let lastContent = PLACE_INIT;
   let lastChildScope = null;
-  let valueTextNode = null;
-
-  function clearOwnedSiblings() {
-    for (const n of region.ownedNodes) { n.remove(); }
-    region.ownedNodes = [];
-    if (region.endAnchor) { region.endAnchor.remove(); }
-  }
 
   function place(content) {
     if (content === lastContent) { return; }
@@ -81,50 +58,14 @@ export function makePlace({ region, scope, renderer, data, isSVG }) {
     }
 
     if (content == null) {
-      // Reset the value text node so a later primitive place() starts fresh.
-      valueTextNode = null;
       region.clear();
       return;
     }
 
-    if (isUnsafeHTML(content)) {
-      // HTML payload — parse and insert after the anchor.
-      valueTextNode = null;
-      clearOwnedSiblings();
-      const html = content[UNSAFE_HTML];
-      const str = html == null ? '' : String(html);
-      if (str) {
-        const parsed = renderer.parseHTML(str);
-        const nodes = [...parsed.childNodes];
-        region.anchor.after(parsed);
-        region.ownedNodes = nodes;
-        region.placeEndAnchor();
-      }
-      return;
-    }
-
-    if (Array.isArray(content)) {
-      valueTextNode = null;
-      const childScope = scope.child();
-      lastChildScope = childScope;
-      const fragment = renderer.readAST({ ast: content, scope: childScope, data, isSVG });
-      region.setContent(fragment, childScope);
-      return;
-    }
-
-    // Primitive value (string / number / boolean). Write to a reactive
-    // text node owned by the region. Create lazily.
-    const str = String(content);
-    if (!valueTextNode || valueTextNode.parentNode == null) {
-      clearOwnedSiblings();
-      valueTextNode = document.createTextNode(str);
-      region.anchor.after(valueTextNode);
-      region.ownedNodes = [valueTextNode];
-      region.placeEndAnchor();
-    }
-    else if (valueTextNode.data !== str) {
-      valueTextNode.data = str;
-    }
+    const childScope = scope.child();
+    lastChildScope = childScope;
+    const fragment = renderer.readAST({ ast: content, scope: childScope, data, isSVG });
+    region.setContent(fragment, childScope);
   }
 
   function match(content) {

--- a/packages/renderer/src/engines/native/define-block.js
+++ b/packages/renderer/src/engines/native/define-block.js
@@ -1,10 +1,6 @@
 import { Reaction } from '@semantic-ui/reactivity';
 import { isRecovery, isTracing } from '../../helpers.js';
-import { isUnsafeHTML, makePlace, UNSAFE_HTML } from './commit-hooks.js';
-
-// Sentinel for "no content placed yet" — distinct from any real value
-// so the first compute write always commits.
-const PLACE_INIT = Symbol('valueDispatch:init');
+import { makePlace, UNSAFE_HTML } from './commit-hooks.js';
 
 // Block-author helper: create a child data context that inherits from
 // `parent` via the prototype chain, with `extras` layered on as own
@@ -323,7 +319,6 @@ function makeValueDispatch(config) {
     let anchor;
     let ownedNodes = null;
     let endAnchor = null;
-    let lastContent = PLACE_INIT;
 
     if (hydrating && hydrate) {
       // Hydrate hook adopts server DOM and reports back the reactive node
@@ -334,50 +329,35 @@ function makeValueDispatch(config) {
       const adopted = Reaction.nonreactive(() => hydrate.call(config, bag));
       anchor = adopted.anchor;
       ownedNodes = adopted.ownedNodes || null;
-      if (adopted.matched !== undefined) { lastContent = adopted.matched; }
     }
     else {
       anchor = document.createTextNode('');
       comment.parentNode.replaceChild(anchor, comment);
     }
 
-    scope.reaction(anchor, (comp) => {
-      // firstRun + hydrating: register Signal deps without overwriting the
-      // server-trusted DOM. lastContent was primed from hydrate.matched.
-      if (comp.firstRun && hydrating) {
-        compute.call(config, bag);
-        return;
-      }
-      const value = compute.call(config, bag);
-      if (value === lastContent && !comp.firstRun) { return; }
-      lastContent = value;
-
-      // Inline polymorphic write — replaces the makePlace closure path.
-      if (value == null) {
-        if (ownedNodes !== null) {
-          for (let i = 0; i < ownedNodes.length; i++) { ownedNodes[i].remove(); }
-          ownedNodes = null;
-          if (endAnchor) {
-            endAnchor.remove();
-            endAnchor = null;
-          }
+    // Specialize the Reaction body by AST flag. `node.unsafeHTML` is set
+    // at compile time, so each dispatch picks one of two bodies and V8
+    // optimizes them independently — primitive expressions don't pay an
+    // unsafeHTML branch per fire, and unsafeHTML expressions don't pay a
+    // primitive-path branch. The primitive body matches the pre-unification
+    // bindTextExpression shape: compute + nullish coalesce + write.
+    if (node.unsafeHTML) {
+      scope.reaction(anchor, (comp) => {
+        if (comp.firstRun && hydrating) {
+          compute.call(config, bag);
+          return;
         }
-        if (anchor.data !== '') { anchor.data = ''; }
-        return;
-      }
-
-      if (isUnsafeHTML(value)) {
-        // unsafeHTML — anchor stays empty, ownedNodes carry the parsed
-        // siblings, endAnchor bounds the region for Template.isNodeInRange.
+        const value = compute.call(config, bag);
         if (ownedNodes !== null) {
           for (let i = 0; i < ownedNodes.length; i++) { ownedNodes[i].remove(); }
         }
         ownedNodes = null;
         if (anchor.data !== '') { anchor.data = ''; }
-        const html = value[UNSAFE_HTML];
-        const str = html == null ? '' : String(html);
-        if (str) {
-          const parsed = renderer.parseHTML(str);
+        const html = value == null || value[UNSAFE_HTML] == null
+          ? ''
+          : String(value[UNSAFE_HTML]);
+        if (html) {
+          const parsed = renderer.parseHTML(html);
           const nodes = [...parsed.childNodes];
           anchor.after(parsed);
           ownedNodes = nodes;
@@ -388,22 +368,21 @@ function makeValueDispatch(config) {
           endAnchor.remove();
           endAnchor = null;
         }
-        return;
-      }
-
-      // Primitive — write directly into the anchor text node. If we were
-      // in unsafeHTML mode, clear owned siblings first.
-      if (ownedNodes !== null) {
-        for (let i = 0; i < ownedNodes.length; i++) { ownedNodes[i].remove(); }
-        ownedNodes = null;
-        if (endAnchor) {
-          endAnchor.remove();
-          endAnchor = null;
+      });
+    }
+    else {
+      // Primitive-only body — equivalent to pre-unification wireTextReaction.
+      // No dedup; signal.set's own equality check suppresses redundant
+      // fires upstream, and the browser no-ops identical text-node writes.
+      // Three ops per fire: compute + nullish coalesce + write.
+      scope.reaction(anchor, (comp) => {
+        if (comp.firstRun && hydrating) {
+          compute.call(config, bag);
+          return;
         }
-      }
-      const str = String(value);
-      if (anchor.data !== str) { anchor.data = str; }
-    });
+        anchor.data = compute.call(config, bag) ?? '';
+      });
+    }
   }
 
   if (config.evaluateText) {

--- a/packages/renderer/src/engines/native/define-block.js
+++ b/packages/renderer/src/engines/native/define-block.js
@@ -309,7 +309,10 @@ function makeValueDispatch(config) {
   function valueDispatch(ctx) {
     const { comment, node, data, scope, renderer, hydrating } = ctx;
 
-    const self = create ? (create.call(config, ctx) || {}) : {};
+    // self stays null when there's no `create` hook — skips the empty-obj
+    // allocation. Authors who do declare `create` get its return value as
+    // `bag.self` per the standard contract.
+    const self = create ? (create.call(config, ctx) || null) : null;
 
     // Reusable bag — same hidden-class shape across firstRun and every
     // subsequent re-fire. comment is filled for the hydrate-call use case
@@ -400,7 +403,7 @@ function makeValueDispatch(config) {
       }
       const str = String(value);
       if (anchor.data !== str) { anchor.data = str; }
-    }, { message: `${config.name}:${node.type}`, block: config.name, node });
+    });
   }
 
   if (config.evaluateText) {

--- a/packages/renderer/src/engines/native/define-block.js
+++ b/packages/renderer/src/engines/native/define-block.js
@@ -297,6 +297,52 @@ export function defineBlock(config) {
 //   • `create(ctx)` returns `self` — same contract.
 //   • `evaluateText` is forwarded for raw-text contexts (each / async fall
 //     through to expression's evaluator when nested in a raw-text element).
+// Module-level Reaction body for primitive value blocks. Shared across
+// every dispatch — V8 sees one function instance at the Reaction call
+// site for all primitive-shape value expressions, making the IC
+// monomorphic on the call shape rather than allocating one closure per
+// dispatch as the closure-capturing pattern would. `state` carries the
+// per-dispatch fields (compute, node, data, renderer, anchor, hydrating).
+function primitiveValueBody(state, comp) {
+  if (comp.firstRun && state.hydrating) {
+    state.compute(state);
+    return;
+  }
+  state.anchor.data = state.compute(state) ?? '';
+}
+
+// Module-level Reaction body for unsafeHTML value blocks. Same shared-
+// function pattern as primitiveValueBody. Mutable per-dispatch fields
+// (ownedNodes, endAnchor) live on the state object so the body can update
+// them across re-fires.
+function unsafeHTMLValueBody(state, comp) {
+  if (comp.firstRun && state.hydrating) {
+    state.compute(state);
+    return;
+  }
+  const value = state.compute(state);
+  if (state.ownedNodes !== null) {
+    for (let i = 0; i < state.ownedNodes.length; i++) { state.ownedNodes[i].remove(); }
+  }
+  state.ownedNodes = null;
+  if (state.anchor.data !== '') { state.anchor.data = ''; }
+  const html = value == null || value[UNSAFE_HTML] == null
+    ? ''
+    : String(value[UNSAFE_HTML]);
+  if (html) {
+    const parsed = state.renderer.parseHTML(html);
+    const nodes = [...parsed.childNodes];
+    state.anchor.after(parsed);
+    state.ownedNodes = nodes;
+    if (!state.endAnchor) { state.endAnchor = document.createTextNode(''); }
+    nodes[nodes.length - 1].after(state.endAnchor);
+  }
+  else if (state.endAnchor) {
+    state.endAnchor.remove();
+    state.endAnchor = null;
+  }
+}
+
 function makeValueDispatch(config) {
   const create = config.create;
   const compute = config.compute;
@@ -306,27 +352,30 @@ function makeValueDispatch(config) {
     const { comment, node, data, scope, renderer, hydrating } = ctx;
 
     // self stays null when there's no `create` hook — skips the empty-obj
-    // allocation. Authors who do declare `create` get its return value as
-    // `bag.self` per the standard contract.
+    // allocation. Authors who do declare `create` get its return value
+    // through `state.self` (compute reads state directly).
     const self = create ? (create.call(config, ctx) || null) : null;
-
-    // Reusable bag — same hidden-class shape across firstRun and every
-    // subsequent re-fire. comment is filled for the hydrate-call use case
-    // and stays as a dead field on the update path (V8 hidden class is
-    // shared either way).
-    const bag = { node, data, self, renderer, comment };
 
     let anchor;
     let ownedNodes = null;
-    let endAnchor = null;
 
     if (hydrating && hydrate) {
-      // Hydrate hook adopts server DOM and reports back the reactive node
-      // identity. Wrap in Reaction.nonreactive so any signal reads inside
-      // the hook (e.g. lookupExpression for serverValue splitting) don't
-      // register on a parent block's outer Reaction — the per-expression
-      // Reaction below registers fresh deps via firstRun.
-      const adopted = Reaction.nonreactive(() => hydrate.call(config, bag));
+      // Hydrate uses the same state shape compute will see at fire time,
+      // plus a `comment` field for the adoption logic. `this === config`
+      // inside the hook so authors can call helpers via `this.X(...)`.
+      const hydrateState = {
+        compute,
+        node,
+        data,
+        renderer,
+        anchor: null,
+        hydrating: true,
+        self,
+        ownedNodes: null,
+        endAnchor: null,
+        comment,
+      };
+      const adopted = Reaction.nonreactive(() => hydrate.call(config, hydrateState));
       anchor = adopted.anchor;
       ownedNodes = adopted.ownedNodes || null;
     }
@@ -335,54 +384,37 @@ function makeValueDispatch(config) {
       comment.parentNode.replaceChild(anchor, comment);
     }
 
-    // Specialize the Reaction body by AST flag. `node.unsafeHTML` is set
-    // at compile time, so each dispatch picks one of two bodies and V8
-    // optimizes them independently — primitive expressions don't pay an
-    // unsafeHTML branch per fire, and unsafeHTML expressions don't pay a
-    // primitive-path branch. The primitive body matches the pre-unification
-    // bindTextExpression shape: compute + nullish coalesce + write.
-    if (node.unsafeHTML) {
-      scope.reaction(anchor, (comp) => {
-        if (comp.firstRun && hydrating) {
-          compute.call(config, bag);
-          return;
-        }
-        const value = compute.call(config, bag);
-        if (ownedNodes !== null) {
-          for (let i = 0; i < ownedNodes.length; i++) { ownedNodes[i].remove(); }
-        }
-        ownedNodes = null;
-        if (anchor.data !== '') { anchor.data = ''; }
-        const html = value == null || value[UNSAFE_HTML] == null
-          ? ''
-          : String(value[UNSAFE_HTML]);
-        if (html) {
-          const parsed = renderer.parseHTML(html);
-          const nodes = [...parsed.childNodes];
-          anchor.after(parsed);
-          ownedNodes = nodes;
-          if (!endAnchor) { endAnchor = document.createTextNode(''); }
-          nodes[nodes.length - 1].after(endAnchor);
-        }
-        else if (endAnchor) {
-          endAnchor.remove();
-          endAnchor = null;
-        }
-      });
-    }
-    else {
-      // Primitive-only body — equivalent to pre-unification wireTextReaction.
-      // No dedup; signal.set's own equality check suppresses redundant
-      // fires upstream, and the browser no-ops identical text-node writes.
-      // Three ops per fire: compute + nullish coalesce + write.
-      scope.reaction(anchor, (comp) => {
-        if (comp.firstRun && hydrating) {
-          compute.call(config, bag);
-          return;
-        }
-        anchor.data = compute.call(config, bag) ?? '';
-      });
-    }
+    // Per-dispatch state — replaces both the per-dispatch bag object AND
+    // the per-dispatch Reaction-body closure that the bag pattern would
+    // need. Same hidden-class shape across primitive and unsafeHTML
+    // variants (V8 keeps a single hidden class for all kind:'value'
+    // dispatches; the body functions destructure / access only the fields
+    // they need).
+    const state = {
+      compute,
+      node,
+      data,
+      renderer,
+      anchor,
+      hydrating,
+      self,
+      ownedNodes,
+      endAnchor: null,
+    };
+
+    // Inline the isConnected guard rather than going through
+    // scope.reaction — that route would allocate an additional wrapper
+    // closure around the user body. The body itself (primitiveValueBody /
+    // unsafeHTMLValueBody) is module-level, so we save one closure
+    // allocation per dispatch compared to the closure-capture pattern.
+    const body = node.unsafeHTML ? unsafeHTMLValueBody : primitiveValueBody;
+    scope.track(Reaction.create((comp) => {
+      if (!comp.firstRun && !anchor.isConnected) {
+        comp.stop();
+        return;
+      }
+      body(state, comp);
+    }));
   }
 
   if (config.evaluateText) {

--- a/packages/renderer/src/engines/native/define-block.js
+++ b/packages/renderer/src/engines/native/define-block.js
@@ -1,5 +1,10 @@
+import { Reaction } from '@semantic-ui/reactivity';
 import { isRecovery, isTracing } from '../../helpers.js';
-import { makePlace } from './commit-hooks.js';
+import { isUnsafeHTML, makePlace, UNSAFE_HTML } from './commit-hooks.js';
+
+// Sentinel for "no content placed yet" — distinct from any real value
+// so the first compute write always commits.
+const PLACE_INIT = Symbol('valueDispatch:init');
 
 // Block-author helper: create a child data context that inherits from
 // `parent` via the prototype chain, with `extras` layered on as own
@@ -44,6 +49,16 @@ export function reportBlockError({ name, syntax, hook, err }) {
 }
 
 export function defineBlock(config) {
+  // `kind: 'value'` opts into the lean dispatch in valueDispatch.js — for
+  // blocks whose `compute` returns a primitive (or unsafeHTML wrapper, or
+  // null) rather than an AST array. The renderer sees `dispatch.shape ===
+  // 'value'` and skips the DynamicRegion allocation; the lean dispatch
+  // manages its own anchor / ownedNodes pair without DR's full machinery.
+  // Authoring shape is identical (defineBlock + compute + helpers via this).
+  if (config.kind === 'value') {
+    return makeValueDispatch(config);
+  }
+
   // Read identity/diagnostic fields directly — they don't need `this`.
   // Hook fields (compute/render/update/hydrate/create/destroy/error) are
   // invoked as `config.X(bag)` below so `this === config` inside the hook,
@@ -249,4 +264,149 @@ export function defineBlock(config) {
 
   dispatch.definition = config;
   return dispatch;
+}
+
+// Lean dispatch path for `kind: 'value'` blocks (currently: expression).
+//
+// What it elides vs. the regular dispatch (per-instance, hot):
+//   • No DynamicRegion — the renderer skips the DR allocation entirely
+//     (shape flag below). The anchor IS the single value text node in
+//     the primitive case (no separate "positional" anchor), matching the
+//     pre-unification bindTextExpression shape.
+//   • No helper closures on the bag (lookupExpression / renderAST /
+//     hydrateInnerContent / hydrateInto). Authors reach renderer methods
+//     directly via the `renderer` bag field.
+//   • No makePlace (no place/match/clearOwnedSiblings closures). The
+//     Reaction body inlines the polymorphic write — primitive, unsafeHTML
+//     wrapper, or null — against the dispatch-local anchor/ownedNodes.
+//   • No safeRun wrapper. Tracing/recovery are not supported on value
+//     blocks; authors who need them should use the region path.
+//   • No notifyUpdate. Text-position expression writes never bubbled to
+//     the host's `updated` lifecycle in the pre-unification path; preserve
+//     that semantics here so coarsely-reactive subtemplates don't pay a
+//     microtask per inner-expression update.
+//   • No onDispose registration when there's no destroy hook. The Reaction
+//     stops via scope.dispose; the text node either dies with its parent
+//     (each-item removal, branch swap) or with the shadow root (unmount).
+//
+// What it preserves (so expression.js still reads like a defineBlock):
+//   • `compute({ node, data, self, renderer })` returns a primitive,
+//     `unsafeHTML(value)` wrapper, or null. Hook is called as
+//     `compute.call(config, bag)` so `this === config` and helpers on the
+//     config object are reachable as `this.helperName(...)`.
+//   • `hydrate(bag)` adopts server DOM and returns `{ anchor, ownedNodes,
+//     matched }`. `anchor` becomes the dispatch's reactive text node;
+//     `ownedNodes` populates the unsafeHTML payload tracking; `matched`
+//     primes lastContent so the first reactive re-fire dedups against it.
+//   • `create(ctx)` returns `self` — same contract.
+//   • `evaluateText` is forwarded for raw-text contexts (each / async fall
+//     through to expression's evaluator when nested in a raw-text element).
+function makeValueDispatch(config) {
+  const create = config.create;
+  const compute = config.compute;
+  const hydrate = config.hydrate;
+
+  function valueDispatch(ctx) {
+    const { comment, node, data, scope, renderer, hydrating } = ctx;
+
+    const self = create ? (create.call(config, ctx) || {}) : {};
+
+    // Reusable bag — same hidden-class shape across firstRun and every
+    // subsequent re-fire. comment is filled for the hydrate-call use case
+    // and stays as a dead field on the update path (V8 hidden class is
+    // shared either way).
+    const bag = { node, data, self, renderer, comment };
+
+    let anchor;
+    let ownedNodes = null;
+    let endAnchor = null;
+    let lastContent = PLACE_INIT;
+
+    if (hydrating && hydrate) {
+      // Hydrate hook adopts server DOM and reports back the reactive node
+      // identity. Wrap in Reaction.nonreactive so any signal reads inside
+      // the hook (e.g. lookupExpression for serverValue splitting) don't
+      // register on a parent block's outer Reaction — the per-expression
+      // Reaction below registers fresh deps via firstRun.
+      const adopted = Reaction.nonreactive(() => hydrate.call(config, bag));
+      anchor = adopted.anchor;
+      ownedNodes = adopted.ownedNodes || null;
+      if (adopted.matched !== undefined) { lastContent = adopted.matched; }
+    }
+    else {
+      anchor = document.createTextNode('');
+      comment.parentNode.replaceChild(anchor, comment);
+    }
+
+    scope.reaction(anchor, (comp) => {
+      // firstRun + hydrating: register Signal deps without overwriting the
+      // server-trusted DOM. lastContent was primed from hydrate.matched.
+      if (comp.firstRun && hydrating) {
+        compute.call(config, bag);
+        return;
+      }
+      const value = compute.call(config, bag);
+      if (value === lastContent && !comp.firstRun) { return; }
+      lastContent = value;
+
+      // Inline polymorphic write — replaces the makePlace closure path.
+      if (value == null) {
+        if (ownedNodes !== null) {
+          for (let i = 0; i < ownedNodes.length; i++) { ownedNodes[i].remove(); }
+          ownedNodes = null;
+          if (endAnchor) {
+            endAnchor.remove();
+            endAnchor = null;
+          }
+        }
+        if (anchor.data !== '') { anchor.data = ''; }
+        return;
+      }
+
+      if (isUnsafeHTML(value)) {
+        // unsafeHTML — anchor stays empty, ownedNodes carry the parsed
+        // siblings, endAnchor bounds the region for Template.isNodeInRange.
+        if (ownedNodes !== null) {
+          for (let i = 0; i < ownedNodes.length; i++) { ownedNodes[i].remove(); }
+        }
+        ownedNodes = null;
+        if (anchor.data !== '') { anchor.data = ''; }
+        const html = value[UNSAFE_HTML];
+        const str = html == null ? '' : String(html);
+        if (str) {
+          const parsed = renderer.parseHTML(str);
+          const nodes = [...parsed.childNodes];
+          anchor.after(parsed);
+          ownedNodes = nodes;
+          if (!endAnchor) { endAnchor = document.createTextNode(''); }
+          nodes[nodes.length - 1].after(endAnchor);
+        }
+        else if (endAnchor) {
+          endAnchor.remove();
+          endAnchor = null;
+        }
+        return;
+      }
+
+      // Primitive — write directly into the anchor text node. If we were
+      // in unsafeHTML mode, clear owned siblings first.
+      if (ownedNodes !== null) {
+        for (let i = 0; i < ownedNodes.length; i++) { ownedNodes[i].remove(); }
+        ownedNodes = null;
+        if (endAnchor) {
+          endAnchor.remove();
+          endAnchor = null;
+        }
+      }
+      const str = String(value);
+      if (anchor.data !== str) { anchor.data = str; }
+    }, { message: `${config.name}:${node.type}`, block: config.name, node });
+  }
+
+  if (config.evaluateText) {
+    valueDispatch.evaluateText = (bag) => config.evaluateText(bag);
+  }
+  valueDispatch.definition = config;
+  valueDispatch.shape = 'value';
+  return valueDispatch;
 }

--- a/packages/renderer/src/engines/native/define-block.js
+++ b/packages/renderer/src/engines/native/define-block.js
@@ -45,13 +45,10 @@ export function reportBlockError({ name, syntax, hook, err }) {
 }
 
 export function defineBlock(config) {
-  // `kind: 'value'` opts into the lean dispatch in valueDispatch.js — for
-  // blocks whose `compute` returns a primitive (or unsafeHTML wrapper, or
-  // null) rather than an AST array. The renderer sees `dispatch.shape ===
-  // 'value'` and skips the DynamicRegion allocation; the lean dispatch
-  // manages its own anchor / ownedNodes pair without DR's full machinery.
-  // Authoring shape is identical (defineBlock + compute + helpers via this).
-  if (config.kind === 'value') {
+  // `type: 'value'` selects the lean dispatch (see makeValueDispatch
+  // below). The renderer reads `dispatch.type === 'value'` and skips
+  // DynamicRegion allocation.
+  if (config.type === 'value') {
     return makeValueDispatch(config);
   }
 
@@ -262,41 +259,6 @@ export function defineBlock(config) {
   return dispatch;
 }
 
-// Lean dispatch path for `kind: 'value'` blocks (currently: expression).
-//
-// What it elides vs. the regular dispatch (per-instance, hot):
-//   • No DynamicRegion — the renderer skips the DR allocation entirely
-//     (shape flag below). The anchor IS the single value text node in
-//     the primitive case (no separate "positional" anchor), matching the
-//     pre-unification bindTextExpression shape.
-//   • No helper closures on the bag (lookupExpression / renderAST /
-//     hydrateInnerContent / hydrateInto). Authors reach renderer methods
-//     directly via the `renderer` bag field.
-//   • No makePlace (no place/match/clearOwnedSiblings closures). The
-//     Reaction body inlines the polymorphic write — primitive, unsafeHTML
-//     wrapper, or null — against the dispatch-local anchor/ownedNodes.
-//   • No safeRun wrapper. Tracing/recovery are not supported on value
-//     blocks; authors who need them should use the region path.
-//   • No notifyUpdate. Text-position expression writes never bubbled to
-//     the host's `updated` lifecycle in the pre-unification path; preserve
-//     that semantics here so coarsely-reactive subtemplates don't pay a
-//     microtask per inner-expression update.
-//   • No onDispose registration when there's no destroy hook. The Reaction
-//     stops via scope.dispose; the text node either dies with its parent
-//     (each-item removal, branch swap) or with the shadow root (unmount).
-//
-// What it preserves (so expression.js still reads like a defineBlock):
-//   • `compute({ node, data, self, renderer })` returns a primitive,
-//     `unsafeHTML(value)` wrapper, or null. Hook is called as
-//     `compute.call(config, bag)` so `this === config` and helpers on the
-//     config object are reachable as `this.helperName(...)`.
-//   • `hydrate(bag)` adopts server DOM and returns `{ anchor, ownedNodes,
-//     matched }`. `anchor` becomes the dispatch's reactive text node;
-//     `ownedNodes` populates the unsafeHTML payload tracking; `matched`
-//     primes lastContent so the first reactive re-fire dedups against it.
-//   • `create(ctx)` returns `self` — same contract.
-//   • `evaluateText` is forwarded for raw-text contexts (each / async fall
-//     through to expression's evaluator when nested in a raw-text element).
 // Module-level Reaction body for primitive value blocks. Shared across
 // every dispatch — V8 sees one function instance at the Reaction call
 // site for all primitive-shape value expressions, making the IC
@@ -311,10 +273,9 @@ function primitiveValueBody(state, comp) {
   state.anchor.data = state.compute(state) ?? '';
 }
 
-// Module-level Reaction body for unsafeHTML value blocks. Same shared-
-// function pattern as primitiveValueBody. Mutable per-dispatch fields
-// (ownedNodes, endAnchor) live on the state object so the body can update
-// them across re-fires.
+// Companion to primitiveValueBody for unsafeHTML payloads. Mutable
+// fields (ownedNodes, endAnchor) live on state so re-fires can update
+// them.
 function unsafeHTMLValueBody(state, comp) {
   if (comp.firstRun && state.hydrating) {
     state.compute(state);
@@ -325,28 +286,70 @@ function unsafeHTMLValueBody(state, comp) {
     for (let i = 0; i < state.ownedNodes.length; i++) { state.ownedNodes[i].remove(); }
   }
   state.ownedNodes = null;
-  if (state.anchor.data !== '') { state.anchor.data = ''; }
   const html = value == null || value[UNSAFE_HTML] == null
     ? ''
     : String(value[UNSAFE_HTML]);
   if (html) {
     const parsed = state.renderer.parseHTML(html);
     const nodes = [...parsed.childNodes];
-    state.anchor.after(parsed);
-    state.ownedNodes = nodes;
-    if (!state.endAnchor) { state.endAnchor = document.createTextNode(''); }
-    nodes[nodes.length - 1].after(state.endAnchor);
+    // Doctype/comment-only inputs strip to an empty fragment when parsed
+    // into a <template>. Skip the insert + endAnchor wiring rather than
+    // dereferencing nodes[-1].
+    if (nodes.length) {
+      state.anchor.after(parsed);
+      state.ownedNodes = nodes;
+      if (!state.endAnchor) { state.endAnchor = document.createTextNode(''); }
+      nodes[nodes.length - 1].after(state.endAnchor);
+      return;
+    }
   }
-  else if (state.endAnchor) {
+  if (state.endAnchor) {
     state.endAnchor.remove();
     state.endAnchor = null;
   }
 }
 
+// Lean dispatch for `type: 'value'` blocks (currently: expression). A
+// value-block's compute returns a primitive, an `unsafeHTML(value)`
+// wrapper, or null; the dispatch owns a single anchor text node plus
+// (for unsafeHTML) an ownedNodes list. The renderer reads
+// `dispatch.type === 'value'` and skips DynamicRegion allocation.
+//
+// What this path elides vs. the region dispatch:
+//   • No DynamicRegion — anchor IS the value text node in the
+//     primitive case.
+//   • No helper closures on a bag — blocks reach renderer methods
+//     directly via state.renderer.
+//   • No makePlace. The Reaction body inlines the write against
+//     dispatch-local anchor / ownedNodes.
+//   • No safeRun. Tracing/recovery aren't supported on value blocks.
+//   • No notifyUpdate on update — text-position writes don't bubble
+//     to `updated`, so coarsely reactive subtemplates don't pay a
+//     microtask per inner write.
+//   • No onDispose when the block has no destroy hook. The Reaction
+//     stops via scope.dispose; the text node dies with its parent.
+//
+// What value-blocks declare:
+//   • compute(state) — Called as state.compute(state) on every fire
+//     (no `this` binding). state = { compute, node, data, renderer,
+//     anchor, hydrating, self, ownedNodes, endAnchor }. Return a
+//     primitive, an `unsafeHTML(value)` wrapper, or null.
+//   • hydrate(state) — Called as hydrate.call(config, state) once at
+//     mount. `this === config`, so authors reach config helpers via
+//     `this.X(...)`. state adds a `comment` field for the adoption
+//     logic. Return { anchor, ownedNodes }.
+//   • create(ctx) — Returns `self`, reachable as state.self.
+//   • evaluateText — Forwarded for raw-text contexts (each/async
+//     nested in a raw-text element fall through to expression's
+//     evaluator).
+//   • static(node) — Optional predicate. Return true when a node-level
+//     flag guarantees no reactive dependencies; the dispatch skips
+//     Reaction wiring entirely and writes anchor.data once at mount.
 function makeValueDispatch(config) {
   const create = config.create;
   const compute = config.compute;
   const hydrate = config.hydrate;
+  const isStatic = config.static;
 
   function valueDispatch(ctx) {
     const { comment, node, data, scope, renderer, hydrating } = ctx;
@@ -355,14 +358,15 @@ function makeValueDispatch(config) {
     // allocation. Authors who do declare `create` get its return value
     // through `state.self` (compute reads state directly).
     const self = create ? (create.call(config, ctx) || null) : null;
+    const staticValue = isStatic ? isStatic(node) : false;
 
     let anchor;
     let ownedNodes = null;
 
     if (hydrating && hydrate) {
-      // Hydrate uses the same state shape compute will see at fire time,
-      // plus a `comment` field for the adoption logic. `this === config`
-      // inside the hook so authors can call helpers via `this.X(...)`.
+      // Hydrate gets its own state with a `comment` field for the
+      // adoption logic. `this === config` inside the hook so authors
+      // reach config helpers via `this.X(...)`.
       const hydrateState = {
         compute,
         node,
@@ -384,12 +388,9 @@ function makeValueDispatch(config) {
       comment.parentNode.replaceChild(anchor, comment);
     }
 
-    // Per-dispatch state — replaces both the per-dispatch bag object AND
-    // the per-dispatch Reaction-body closure that the bag pattern would
-    // need. Same hidden-class shape across primitive and unsafeHTML
-    // variants (V8 keeps a single hidden class for all kind:'value'
-    // dispatches; the body functions destructure / access only the fields
-    // they need).
+    // Per-dispatch state. Same hidden-class shape across primitive and
+    // unsafeHTML variants — the body functions destructure / access
+    // only the fields they need.
     const state = {
       compute,
       node,
@@ -402,11 +403,21 @@ function makeValueDispatch(config) {
       endAnchor: null,
     };
 
+    // Static dispatches skip Reaction wiring — the value is fixed for
+    // the lifetime of the dispatch, so there's no reactive surface to
+    // track. Hydration is a no-op because the adopted text node already
+    // carries the server-rendered value.
+    if (staticValue) {
+      if (!hydrating) {
+        anchor.data = String(compute(state) ?? '');
+      }
+      return;
+    }
+
     // Inline the isConnected guard rather than going through
-    // scope.reaction — that route would allocate an additional wrapper
-    // closure around the user body. The body itself (primitiveValueBody /
-    // unsafeHTMLValueBody) is module-level, so we save one closure
-    // allocation per dispatch compared to the closure-capture pattern.
+    // scope.reaction (which would wrap the body in another closure per
+    // dispatch). The body itself is module-level — see
+    // primitiveValueBody / unsafeHTMLValueBody above.
     const body = node.unsafeHTML ? unsafeHTMLValueBody : primitiveValueBody;
     scope.track(Reaction.create((comp) => {
       if (!comp.firstRun && !anchor.isConnected) {
@@ -421,6 +432,6 @@ function makeValueDispatch(config) {
     valueDispatch.evaluateText = (bag) => config.evaluateText(bag);
   }
   valueDispatch.definition = config;
-  valueDispatch.shape = 'value';
+  valueDispatch.type = 'value';
   return valueDispatch;
 }

--- a/packages/renderer/src/engines/native/define-block.js
+++ b/packages/renderer/src/engines/native/define-block.js
@@ -150,7 +150,11 @@ export function defineBlock(config) {
       err: null,
     };
 
-    const onSuccess = () => {
+    // notifyUpdate signals "post-mount reactive DOM change" to the host —
+    // initial render uses the `rendered` lifecycle and shouldn't fire it.
+    // Pass suppressNotify on the firstRun call sites to skip.
+    const onSuccess = (suppressNotify) => {
+      if (suppressNotify) { return; }
       if (typeof renderer.notifyUpdate === 'function') {
         renderer.notifyUpdate();
       }
@@ -162,10 +166,10 @@ export function defineBlock(config) {
     // hook decides what to render. With recovery alone (global flag, no
     // hook): default-isolate via region.clear() + reaction stop.
     const safeRun = wantsRecovery
-      ? (hookName, fn, comp) => {
+      ? (hookName, fn, comp, suppressNotify) => {
         try {
           fn();
-          onSuccess();
+          onSuccess(suppressNotify);
         }
         catch (err) {
           reportBlockError({ name, syntax: syntax?.(node), hook: hookName, err });
@@ -190,9 +194,9 @@ export function defineBlock(config) {
           }
         }
       }
-      : (_hookName, fn) => {
+      : (_hookName, fn, _comp, suppressNotify) => {
         fn();
-        onSuccess();
+        onSuccess(suppressNotify);
       };
 
     const reactionAnchor = region.anchor;
@@ -200,22 +204,27 @@ export function defineBlock(config) {
     scope.reaction(reactionAnchor, (comp) => {
       if (comp.firstRun) {
         const isHydrating = hydrating && hydrate;
-        safeRun(isHydrating ? 'hydrate' : 'render', () => {
-          if (isHydrating) {
-            // hydrate returns the AST that matches the server-rendered
-            // DOM (when applicable). Records the match on `place` so the
-            // first compute-driven update tick dedups instead of
-            // re-rendering over server bytes. Returning undefined is the
-            // backward-compatible no-op for blocks (each, async, etc.)
-            // that don't use compute / don't need the match hook.
-            const matched = hydrate(bag);
-            if (matched !== undefined) { matchPlace(matched); }
-          }
-          else { render(bag); }
-        }, comp);
+        safeRun(
+          isHydrating ? 'hydrate' : 'render',
+          () => {
+            if (isHydrating) {
+              // hydrate returns the AST that matches the server-rendered
+              // DOM (when applicable). Records the match on `place` so the
+              // first compute-driven update tick dedups instead of
+              // re-rendering over server bytes. Returning undefined is the
+              // backward-compatible no-op for blocks (each, async, etc.)
+              // that don't use compute / don't need the match hook.
+              const matched = hydrate(bag);
+              if (matched !== undefined) { matchPlace(matched); }
+            }
+            else { render(bag); }
+          },
+          comp,
+          /* suppressNotify */ true,
+        );
       }
       else if (update) {
-        safeRun('update', () => update(bag), comp);
+        safeRun('update', () => update(bag), comp, /* suppressNotify */ false);
       }
     }, {
       message: `${name}:${node.type}`,

--- a/packages/renderer/src/engines/native/renderer.js
+++ b/packages/renderer/src/engines/native/renderer.js
@@ -268,21 +268,18 @@ export class Renderer {
       if (type === 'expression' && processedAttrIDs.has(markerID)) { continue; }
       const entry = entries[markerID];
 
-      if (type === 'expression') {
-        // Dispatch via registry — text-position expression routes through
-        // blocks/expression.js, which delegates to bindTextExpression for
-        // now. Future cleanup may inline the binding logic into the block
-        // file and retire the legacy method.
-        getBlock('expression')?.({ comment, entry, data, scope, renderer: this });
+      if (type === 'expression' || type === 'block') {
+        // Both go through the same defineBlock-style dispatch via
+        // bindBlock. For 'expression', bindBlock looks up the
+        // 'expression' block in the registry; entry.node.type IS
+        // 'expression', so the lookup resolves the same way.
+        this.bindBlock(comment, entry, data, scope);
       }
       else if (type === 'rawText') {
-        // Dispatch via registry — the raw-text block self-registers from
-        // blocks/raw-text.js. Equivalent to the legacy bindRawTextContent
-        // raw-text walker; no legacy code path remains.
+        // Raw-text dispatch — plain function (no region, no lifecycle
+        // separation). Stays separate from defineBlock since it modifies
+        // a sibling element's textContent rather than managing a region.
         getBlock('rawText')?.({ comment, entry, data, scope, renderer: this });
-      }
-      else if (type === 'block') {
-        this.bindBlock(comment, entry, data, scope);
       }
     }
   }
@@ -380,9 +377,25 @@ export class Renderer {
       if (!entry) { continue; }
 
       if (type === 'expression') {
-        // Registry dispatch with hydrating: true routes to the same
-        // expression block; the block delegates to hydrateTextExpression.
-        getBlock('expression')?.({ comment, entry, data, scope, renderer: this, hydrating: true });
+        // Expression entries are dispatched via defineBlock just like
+        // block entries — the marker is single, so the region is
+        // constructed here (no close marker / serverMeta to parse). The
+        // expression block's hydrate hook adopts the server-emitted
+        // value text node (or unsafeHTML siblings) into region.ownedNodes
+        // before returning the matched content to prime place.
+        const block = getBlock(entry.node.type);
+        if (block) {
+          const region = new DynamicRegion(comment.parentNode, comment);
+          block({
+            node: entry.node,
+            data,
+            scope,
+            region,
+            renderer: this,
+            isSVG: entry.isSVG,
+            hydrating: true,
+          });
+        }
       }
       else if (type === 'block') {
         this.hydrateBlock(comment, entry, data, scope);

--- a/packages/renderer/src/engines/native/renderer.js
+++ b/packages/renderer/src/engines/native/renderer.js
@@ -321,8 +321,8 @@ export class Renderer {
     const { node, isSVG } = entry;
     const block = getBlock(node.type);
     if (!block) { return; }
-    if (block.shape === 'value') {
-      // Value-shape blocks (e.g. expression) manage their own anchor and
+    if (block.type === 'value') {
+      // type:'value' blocks (e.g. expression) manage their own anchor and
       // ownedNodes — DR allocation would be discarded by the lean path.
       block({ comment, node, data, scope, renderer: this, isSVG, hydrating: false });
       return;
@@ -383,29 +383,16 @@ export class Renderer {
       if (!entry) { continue; }
 
       if (type === 'expression') {
-        // Expression entries are dispatched via the registry. Value-shape
-        // blocks adopt server DOM directly from the comment marker — no
-        // DR pre-allocation. The lean dispatch reports back the reactive
-        // anchor identity from its hydrate hook.
+        // Expression dispatch adopts server DOM directly from the comment
+        // marker (no DR pre-allocation). The hydrate hook reports back
+        // the reactive anchor identity.
         const block = getBlock(entry.node.type);
-        if (block?.shape === 'value') {
+        if (block) {
           block({
             comment,
             node: entry.node,
             data,
             scope,
-            renderer: this,
-            isSVG: entry.isSVG,
-            hydrating: true,
-          });
-        }
-        else if (block) {
-          const region = new DynamicRegion(comment.parentNode, comment);
-          block({
-            node: entry.node,
-            data,
-            scope,
-            region,
             renderer: this,
             isSVG: entry.isSVG,
             hydrating: true,

--- a/packages/renderer/src/engines/native/renderer.js
+++ b/packages/renderer/src/engines/native/renderer.js
@@ -321,6 +321,12 @@ export class Renderer {
     const { node, isSVG } = entry;
     const block = getBlock(node.type);
     if (!block) { return; }
+    if (block.shape === 'value') {
+      // Value-shape blocks (e.g. expression) manage their own anchor and
+      // ownedNodes — DR allocation would be discarded by the lean path.
+      block({ comment, node, data, scope, renderer: this, isSVG, hydrating: false });
+      return;
+    }
     const region = new DynamicRegion(comment.parentNode, comment);
     block({ node, data, scope, region, renderer: this, isSVG, hydrating: false });
   }
@@ -377,14 +383,23 @@ export class Renderer {
       if (!entry) { continue; }
 
       if (type === 'expression') {
-        // Expression entries are dispatched via defineBlock just like
-        // block entries — the marker is single, so the region is
-        // constructed here (no close marker / serverMeta to parse). The
-        // expression block's hydrate hook adopts the server-emitted
-        // value text node (or unsafeHTML siblings) into region.ownedNodes
-        // before returning the matched content to prime place.
+        // Expression entries are dispatched via the registry. Value-shape
+        // blocks adopt server DOM directly from the comment marker — no
+        // DR pre-allocation. The lean dispatch reports back the reactive
+        // anchor identity from its hydrate hook.
         const block = getBlock(entry.node.type);
-        if (block) {
+        if (block?.shape === 'value') {
+          block({
+            comment,
+            node: entry.node,
+            data,
+            scope,
+            renderer: this,
+            isSVG: entry.isSVG,
+            hydrating: true,
+          });
+        }
+        else if (block) {
           const region = new DynamicRegion(comment.parentNode, comment);
           block({
             node: entry.node,

--- a/packages/renderer/test/browser/node-types.test.js
+++ b/packages/renderer/test/browser/node-types.test.js
@@ -75,6 +75,28 @@ RENDERING_ENGINES.forEach(engine => {
       expect(el.shadowRoot.querySelector('b')).not.toBeNull();
       expect(el.shadowRoot.querySelector('em')).toBeNull();
     });
+
+    it('should not crash when unsafeHTML content parses to zero child nodes', async () => {
+      const tag = uniqueTag();
+      defineComponent({
+        tagName: tag,
+        renderingEngine: engine,
+        template: '<div>{#html doctype}</div>',
+        createComponent: () => ({
+          // Doctype declarations are document-level — a <template> strips
+          // them, leaving template.content with zero child nodes. The
+          // unsafeHTML payload writer must tolerate this without crashing.
+          doctype: '<!DOCTYPE html>',
+        }),
+      });
+      const el = document.createElement(tag);
+      document.body.appendChild(el);
+      await el.rendered;
+
+      const div = el.shadowRoot.querySelector('div');
+      expect(div).not.toBeNull();
+      expect(div.textContent).toBe('');
+    });
   });
 
   /*******************************


### PR DESCRIPTION
### Summary

This creates a new type of block `type: 'value'` that has a different set of arguments and produces a text node. 

This unifies the block architecture between so `expression` and `rawText` now share a similar shape.

### Risk
- Largest risk is performance regressions around expression evaluation. This does add ceremony over the more pure expression evaluation in previous versions, but also improves clarity and uniformity.