### PR TITLE
Build: Add restore-keys fallback to Playwright cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,8 @@ jobs:
         uses: actions/cache@v5
         with:
           key: ${{ runner.os }}-playwright-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-
           path: ~/.cache/ms-playwright
 
       - name: Install Playwright
@@ -154,6 +156,8 @@ jobs:
         uses: actions/cache@v5
         with:
           key: ${{ runner.os }}-playwright-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-
           path: ~/.cache/ms-playwright
 
       - name: Install Playwright


### PR DESCRIPTION
Fixes bug where playwright hangs in yauzl zip extraction (microsoft/playwright#40724). 

Using restore-keys falls back to any prior cache.