### PR TITLE
Perf: Krausest hot paths

### DIFF
--- a/packages/reactivity/src/signal.js
+++ b/packages/reactivity/src/signal.js
@@ -1,7 +1,5 @@
 import {
   clone,
-  findIndex,
-  firstMatch,
   isArray,
   isClassInstance,
   isDevelopment,
@@ -88,7 +86,6 @@ export class Signal {
 
   static equalityFunction = isEqual;
   static cloneFunction = clone;
-  static idFields = ['id', '_id', 'hash', 'key'];
   static setTracing = setTracing;
   static isTracing = isTracing;
   static setStackCapture = setStackCapture;
@@ -333,14 +330,13 @@ export class Signal {
     if (!isObject(item)) {
       return [item];
     }
-    return unique(Signal.idFields.map(f => item[f]).filter(Boolean));
+    return unique([item.id, item._id, item.hash, item.key].filter(Boolean));
   }
   getID(item) {
     if (!isObject(item)) {
       return item;
     }
-    const field = firstMatch(Signal.idFields, f => item[f]);
-    return field === undefined ? undefined : item[field];
+    return item.id || item._id || item.hash || item.key;
   }
   hasID(item, id) {
     return this.getID(item) === id;
@@ -352,7 +348,11 @@ export class Signal {
     }
   }
   getItemIndex(id) {
-    return findIndex(this.currentValue, item => this.hasID(item, id));
+    const arr = this.currentValue;
+    for (let i = 0; i < arr.length; i++) {
+      if (this.hasID(arr[i], id)) { return i; }
+    }
+    return -1;
   }
   setProperty(idOrProperty, property, value) {
     if (isArray(this.currentValue)) {

--- a/packages/reactivity/src/signal.js
+++ b/packages/reactivity/src/signal.js
@@ -1,6 +1,7 @@
 import {
   clone,
   findIndex,
+  firstMatch,
   isArray,
   isClassInstance,
   isDevelopment,
@@ -87,6 +88,7 @@ export class Signal {
 
   static equalityFunction = isEqual;
   static cloneFunction = clone;
+  static idFields = ['id', '_id', 'hash', 'key'];
   static setTracing = setTracing;
   static isTracing = isTracing;
   static setStackCapture = setStackCapture;
@@ -328,13 +330,17 @@ export class Signal {
   }
 
   getIDs(item) {
-    if (isObject(item)) {
-      return unique([item?._id, item?.id, item?.hash, item?.key].filter(Boolean));
+    if (!isObject(item)) {
+      return [item];
     }
-    return [item];
+    return unique(Signal.idFields.map(f => item[f]).filter(Boolean));
   }
   getID(item) {
-    return this.getIDs(item).filter(Boolean)[0];
+    if (!isObject(item)) {
+      return item;
+    }
+    const field = firstMatch(Signal.idFields, f => item[f]);
+    return field === undefined ? undefined : item[field];
   }
   hasID(item, id) {
     return this.getID(item) === id;

--- a/packages/renderer/src/engines/native/blocks/each.js
+++ b/packages/renderer/src/engines/native/blocks/each.js
@@ -205,7 +205,9 @@ function reconcile({ records, items, collectionType, node, data, scope, region, 
   const oldRecords = records.slice();
   const oldKeys = oldRecords.map((record) => record.key);
   const newKeys = items.map((item, i) => getItemID(item, i, collectionType));
-  const newRecords = new Array(items.length);
+  // .fill(null) promotes HOLEY_SMI → PACKED; matches the null sentinel
+  // the reconcile uses for reused slots.
+  const newRecords = new Array(items.length).fill(null);
 
   let oldHead = 0;
   let oldTail = oldRecords.length - 1;

--- a/packages/renderer/src/engines/native/blocks/each.js
+++ b/packages/renderer/src/engines/native/blocks/each.js
@@ -205,9 +205,7 @@ function reconcile({ records, items, collectionType, node, data, scope, region, 
   const oldRecords = records.slice();
   const oldKeys = oldRecords.map((record) => record.key);
   const newKeys = items.map((item, i) => getItemID(item, i, collectionType));
-  // .fill(null) promotes HOLEY_SMI → PACKED; matches the null sentinel
-  // the reconcile uses for reused slots.
-  const newRecords = new Array(items.length).fill(null);
+  const newRecords = new Array(items.length);
 
   let oldHead = 0;
   let oldTail = oldRecords.length - 1;

--- a/packages/renderer/src/engines/native/blocks/each.js
+++ b/packages/renderer/src/engines/native/blocks/each.js
@@ -203,7 +203,6 @@ function disposeRecord(record) {
 //          mutated.
 function reconcile({ records, items, collectionType, node, data, scope, region, renderAST, isSVG }) {
   const oldRecords = records.slice();
-  const oldKeys = oldRecords.map((record) => record.key);
   const newKeys = items.map((item, i) => getItemID(item, i, collectionType));
   const newRecords = new Array(items.length);
 
@@ -215,39 +214,48 @@ function reconcile({ records, items, collectionType, node, data, scope, region, 
   let newKeySet;
 
   while (oldHead <= oldTail && newHead <= newTail) {
-    if (oldRecords[oldHead] === null) {
+    const oldHeadRec = oldRecords[oldHead];
+    if (oldHeadRec === null) {
       oldHead++;
       continue;
     }
-    if (oldRecords[oldTail] === null) {
+    const oldTailRec = oldRecords[oldTail];
+    if (oldTailRec === null) {
       oldTail--;
       continue;
     }
-    if (oldKeys[oldHead] === newKeys[newHead]) {
-      newRecords[newHead++] = oldRecords[oldHead++];
+    if (oldHeadRec.key === newKeys[newHead]) {
+      newRecords[newHead++] = oldHeadRec;
+      oldHead++;
     }
-    else if (oldKeys[oldTail] === newKeys[newTail]) {
-      newRecords[newTail--] = oldRecords[oldTail--];
+    else if (oldTailRec.key === newKeys[newTail]) {
+      newRecords[newTail--] = oldTailRec;
+      oldTail--;
     }
-    else if (oldKeys[oldHead] === newKeys[newTail]) {
-      newRecords[newTail--] = oldRecords[oldHead++];
+    else if (oldHeadRec.key === newKeys[newTail]) {
+      newRecords[newTail--] = oldHeadRec;
+      oldHead++;
     }
-    else if (oldKeys[oldTail] === newKeys[newHead]) {
-      newRecords[newHead++] = oldRecords[oldTail--];
+    else if (oldTailRec.key === newKeys[newHead]) {
+      newRecords[newHead++] = oldTailRec;
+      oldTail--;
     }
     else {
       if (!oldKeyToIdx) {
         oldKeyToIdx = new Map();
-        for (let i = oldHead; i <= oldTail; i++) { oldKeyToIdx.set(oldKeys[i], i); }
+        for (let i = oldHead; i <= oldTail; i++) {
+          const rec = oldRecords[i];
+          if (rec !== null) { oldKeyToIdx.set(rec.key, i); }
+        }
         newKeySet = new Set();
         for (let i = newHead; i <= newTail; i++) { newKeySet.add(newKeys[i]); }
       }
-      if (!newKeySet.has(oldKeys[oldHead])) {
-        disposeRecord(oldRecords[oldHead]);
+      if (!newKeySet.has(oldHeadRec.key)) {
+        disposeRecord(oldHeadRec);
         oldHead++;
       }
-      else if (!newKeySet.has(oldKeys[oldTail])) {
-        disposeRecord(oldRecords[oldTail]);
+      else if (!newKeySet.has(oldTailRec.key)) {
+        disposeRecord(oldTailRec);
         oldTail--;
       }
       else {

--- a/packages/renderer/src/engines/native/reactive-context.js
+++ b/packages/renderer/src/engines/native/reactive-context.js
@@ -137,7 +137,7 @@ function trapGet(target, prop) {
       // here would attach a Reaction-side dep that cleans up and
       // re-attaches per cycle without ever invalidating.
       if (target.itemProxy === null) {
-        target.itemProxy = new Proxy({}, target.itemHandler);
+        target.itemProxy = new Proxy({ rdc: target }, ITEM_HANDLER);
       }
       return target.itemProxy;
     }
@@ -150,60 +150,61 @@ function trapGet(target, prop) {
   return target.parent[prop];
 }
 
-// Per-RDC handler for the item proxy. Target is a per-RDC placeholder
-// `{}` (so devtools display reads "Proxy(Object) {…}" — clean for
-// stack-trace debugging — without binding the proxy's identity to a
-// specific item ref). Every trap delegates to rdc.values[rdc.asKey],
-// the RDC's current item, so the proxy is stable across item-ref
-// changes (cloning Signals issue fresh refs every reconcile pass; we
-// don't want to invalidate per-cache-holder).
-function createItemHandler(rdc) {
-  return {
-    get(_, prop) {
-      const item = rdc.values[rdc.asKey];
-      if (prop === UNWRAP) {
-        if (Scheduler.current) {
-          let dep = rdc.fieldDeps[BARE_ITEM_DEP];
-          if (dep === undefined) {
-            dep = rdc.fieldDeps[BARE_ITEM_DEP] = new Dependency();
-          }
-          dep.depend();
-        }
-        return item;
-      }
-      if (typeof prop === 'symbol') {
-        return item == null ? undefined : item[prop];
-      }
+// Module-level handler shared across every RDC's item proxy. The proxy's
+// target carries the RDC reference (`{ rdc }`) so traps reach the current
+// values[asKey] without per-instance closures. Per-RDC factories allocated
+// five closures (one per trap) at every record creation — measurable on
+// large each-block mounts.
+const ITEM_HANDLER = {
+  get(target, prop) {
+    const rdc = target.rdc;
+    const item = rdc.values[rdc.asKey];
+    if (prop === UNWRAP) {
       if (Scheduler.current) {
-        let dep = rdc.fieldDeps[prop];
+        let dep = rdc.fieldDeps[BARE_ITEM_DEP];
         if (dep === undefined) {
-          dep = rdc.fieldDeps[prop] = new Dependency();
+          dep = rdc.fieldDeps[BARE_ITEM_DEP] = new Dependency();
         }
         dep.depend();
       }
+      return item;
+    }
+    if (typeof prop === 'symbol') {
       return item == null ? undefined : item[prop];
-    },
-    has(_, prop) {
-      const item = rdc.values[rdc.asKey];
-      return item != null && (prop in item);
-    },
-    ownKeys() {
-      const item = rdc.values[rdc.asKey];
-      return item == null ? [] : Reflect.ownKeys(item);
-    },
-    getOwnPropertyDescriptor(_, prop) {
-      const item = rdc.values[rdc.asKey];
-      if (item == null) { return undefined; }
-      const desc = Object.getOwnPropertyDescriptor(item, prop);
-      if (desc !== undefined) { desc.configurable = true; }
-      return desc;
-    },
-    getPrototypeOf() {
-      const item = rdc.values[rdc.asKey];
-      return item == null ? null : Object.getPrototypeOf(item);
-    },
-  };
-}
+    }
+    if (Scheduler.current) {
+      let dep = rdc.fieldDeps[prop];
+      if (dep === undefined) {
+        dep = rdc.fieldDeps[prop] = new Dependency();
+      }
+      dep.depend();
+    }
+    return item == null ? undefined : item[prop];
+  },
+  has(target, prop) {
+    const rdc = target.rdc;
+    const item = rdc.values[rdc.asKey];
+    return item != null && (prop in item);
+  },
+  ownKeys(target) {
+    const rdc = target.rdc;
+    const item = rdc.values[rdc.asKey];
+    return item == null ? [] : Reflect.ownKeys(item);
+  },
+  getOwnPropertyDescriptor(target, prop) {
+    const rdc = target.rdc;
+    const item = rdc.values[rdc.asKey];
+    if (item == null) { return undefined; }
+    const desc = Object.getOwnPropertyDescriptor(item, prop);
+    if (desc !== undefined) { desc.configurable = true; }
+    return desc;
+  },
+  getPrototypeOf(target) {
+    const rdc = target.rdc;
+    const item = rdc.values[rdc.asKey];
+    return item == null ? null : Object.getPrototypeOf(item);
+  },
+};
 
 function trapHas(target, prop) {
   return (prop in target.values) || (prop in target.parent);
@@ -260,10 +261,8 @@ export class ReactiveDataContext {
     // access of the as-key.
     this.fieldDeps = null;
     this.itemProxy = null;
-    this.itemHandler = null;
     if (asKey !== null) {
       this.fieldDeps = Object.create(null);
-      this.itemHandler = createItemHandler(this);
     }
     // Snapshot Signal.equalityFunction at construction. Mirrors Signal's
     // own per-instance snapshot semantics — late overrides of the static

--- a/packages/renderer/src/expression-evaluator.js
+++ b/packages/renderer/src/expression-evaluator.js
@@ -41,6 +41,10 @@ export class ExpressionEvaluator {
   // getExpressionArray is deterministic for a given expression string
   static parseCache = createCache({ maxSize: 5000, eviction: 'flush' });
 
+  // Pre-split segments for dotted paths. getDeepDataValue is called per
+  // expression read; caching avoids the per-call substring + intern cost.
+  static pathSegmentsCache = createCache({ maxSize: 5000, eviction: 'flush' });
+
   constructor({ data, helpers, dataVersion } = {}) {
     this.data = data;
     this.helpers = helpers || {};
@@ -310,11 +314,19 @@ export class ExpressionEvaluator {
     }
   }
 
-  getDeepDataValue(obj, path) {
-    let dot = path.indexOf('.');
+  getPathSegments(path) {
+    let segments = ExpressionEvaluator.pathSegmentsCache.get(path);
+    if (segments !== undefined) {
+      return segments;
+    }
+    segments = path.split('.');
+    ExpressionEvaluator.pathSegmentsCache.set(path, segments);
+    return segments;
+  }
 
+  getDeepDataValue(obj, path) {
     // Fast path: simple identifier (no dots)
-    if (dot === -1) {
+    if (path.indexOf('.') === -1) {
       const value = obj[path];
       if (value instanceof Signal) {
         return value.get();
@@ -322,11 +334,9 @@ export class ExpressionEvaluator {
       return value;
     }
 
-    // Walk segments via indexOf to avoid split() array allocation on hot path
+    const segments = this.getPathSegments(path);
     let current = obj;
-    let start = 0;
-    let end = dot;
-    while (start < path.length) {
+    for (let i = 0; i < segments.length; i++) {
       if (current instanceof Signal) {
         current = current.get();
       }
@@ -336,12 +346,7 @@ export class ExpressionEvaluator {
       if (current == null) {
         return undefined;
       }
-      current = current[path.substring(start, end)];
-      start = end + 1;
-      end = path.indexOf('.', start);
-      if (end === -1) {
-        end = path.length;
-      }
+      current = current[segments[i]];
     }
     return current;
   }

--- a/packages/renderer/src/expression-evaluator.js
+++ b/packages/renderer/src/expression-evaluator.js
@@ -228,9 +228,8 @@ export class ExpressionEvaluator {
     }
 
     const len = expressionArray.length;
-    // .fill promotes the HOLEY_SMI allocation to PACKED so reverse-fill
-    // assignments don't pin the array on the holey codegen path.
-    const results = new Array(len).fill(undefined);
+    // Pre-allocate results array at the right size instead of per-iteration unshift
+    const results = new Array(len);
 
     let index = len;
     while (index--) {
@@ -250,9 +249,9 @@ export class ExpressionEvaluator {
           // keys, or internal-slot method calls.
           let argCount = len - index - 1;
           if (argCount > 0) {
-            const args = [];
+            const args = new Array(argCount);
             for (let a = 0; a < argCount; a++) {
-              args.push(unwrap(results[index + 1 + a]));
+              args[a] = unwrap(results[index + 1 + a]);
             }
             result = tokenValue(...args);
           }

--- a/packages/renderer/src/expression-evaluator.js
+++ b/packages/renderer/src/expression-evaluator.js
@@ -228,8 +228,9 @@ export class ExpressionEvaluator {
     }
 
     const len = expressionArray.length;
-    // Pre-allocate results array at the right size instead of per-iteration unshift
-    const results = new Array(len);
+    // .fill promotes the HOLEY_SMI allocation to PACKED so reverse-fill
+    // assignments don't pin the array on the holey codegen path.
+    const results = new Array(len).fill(undefined);
 
     let index = len;
     while (index--) {
@@ -249,9 +250,9 @@ export class ExpressionEvaluator {
           // keys, or internal-slot method calls.
           let argCount = len - index - 1;
           if (argCount > 0) {
-            const args = new Array(argCount);
+            const args = [];
             for (let a = 0; a < argCount; a++) {
-              args[a] = unwrap(results[index + 1 + a]);
+              args.push(unwrap(results[index + 1 + a]));
             }
             result = tokenValue(...args);
           }

--- a/packages/utils/src/arrays.js
+++ b/packages/utils/src/arrays.js
@@ -62,6 +62,13 @@ export const firstMatch = (array = [], callbackOrValue) => {
     ? callbackOrValue
     : (val) => isEqual(val, callbackOrValue);
 
+  if (Array.isArray(array)) {
+    for (let i = 0; i < array.length; i++) {
+      if (callback(array[i], i, array)) { return array[i]; }
+    }
+    return;
+  }
+
   let result;
   each(array, (value, index) => {
     if (callback(value, index, array)) {
@@ -79,6 +86,13 @@ export const findIndex = (array = [], callbackOrValue) => {
   const callback = isFunction(callbackOrValue)
     ? callbackOrValue
     : (val) => isEqual(val, callbackOrValue);
+
+  if (Array.isArray(array)) {
+    for (let i = 0; i < array.length; i++) {
+      if (callback(array[i], i, array)) { return i; }
+    }
+    return -1;
+  }
 
   let matchedIndex = -1;
   each(array, (value, index) => {


### PR DESCRIPTION
V8-backed perf passes on the hot paths driving krausest. 

## Changes

- Improved hot path for id lookup in Signals which is hotpath for keyed arrays
- Swapped `id` to be accessed before `_id` for fuzzy id lookup 
- Added fast path for `firstMatch` / `findIndex` utils that avoids `each`
- Added cache to `ExpressionEvaluator` for repeated dot path lookups
- Item-proxy handler in `ReactiveDataContext` is now module-level and uses less closures
- Tweak `each` reconciliation to improve v8 performance

## Risk

3/10 

Test suite has good coverage on change sites, code nearly identical, just rewritten to improve performance.