### PR TITLE
Refactor: Modernize Utils Helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ xx.xx.xxxx
 * **Feature** - Added `includeMargin`, `includePadding`, and `includeBorder` options to `naturalWidth()` and `naturalHeight()` — allows measuring unconstrained intrinsic dimensions while preserving the element's box model.
 
 ### Utils
+* **BREAKING** - `noop` now returns `undefined` (truly no-op). Previously it returned its first argument (identity). Use the new `identity` export if you need the old behavior.
+* **Feature** - Added `identity` export — returns its first argument unchanged.
 * **Feature** - Added [`deepFreeze`](https://next.semantic-ui.com/docs/api/utils/cloning#deepfreeze) — recursively freezes a value in place and returns the same reference. Walks arrays and plain objects only, leaving `Date`, `Map`, `Set`, `RegExp`, DOM nodes, and custom class instances untouched so their internal slots keep working. Cycle-safe via an internal `WeakSet`; already-frozen inputs take a fast-path no-op.
 * **Feature** - Added [`createCache`](https://next.semantic-ui.com/docs/api/utils/cache) — a bounded, Map-like cache factory with pluggable eviction (`lru` default, `fifo`, `flush`) and an `onEvict` hook. Collapses ad-hoc `new Map()` + size-check patterns behind one named primitive.
 * **Feature** - Added `assignInPlace()` for syncing an object's contents to match a source without replacing the reference — supports `preserveExistingKeys` to skip deletion, `preserveGetters` to keep computed properties (own getter descriptors) intact across syncs, and `returnChanged` to detect modifications

--- a/ai/plans/ROADMAP.md
+++ b/ai/plans/ROADMAP.md
@@ -112,12 +112,10 @@ Behavioral changes and API contracts that downstream agents and consumers will t
 |---|------|-------|------|-------|-------|
 | 2a | [Signal Performance](active/signal-performance.md) | 4-5h + audit | pair | scoped | `safety` preset system (`freeze` / `reference` / `none`) replacing `allowClone`. Audit of `.get()` call sites for get-mutate-set patterns gates the default flip. |
 | 2a.1 | [Fine-Grained Reactivity](active/fine-grained-reactivity.md) | 6-8h | pair | initial | `ReactiveDataContext` — per-key Signal bag — at `{#each}` items, subtemplate `reactiveData`, snippet args. Eliminates the N×M coarse invalidation pattern. Lands after 2a. |
-| 2a.2 | [FGR — As-Mode Per-Field Isolation](active/fgr-as-mode-per-field-isolation.md) | 3-4h | pair | initial | Closes the per-FIELD gap in `{#each todo in todos}` where one field's mutation wakes every binding reading the item. Two `it.fails` contracts in `subtree-spurious` come off. Fast-follow to 2a.1. |
-| 2a.3 | [Reactivity Hardening](reactivity-hardening.md) | 6-8h (up to 16h) | pair | scoped | Council-flagged Reaction/Scheduler/Dependency cleanup — `afterFlush` scheduling, terminal `stop`, throw-safety, set-swap, lazy refcounted computed (audit-cleared), plus benchmarks gating a conditional dep-tracking rewrite. Parallel to `2a`, minimal file overlap. |
 | 2b | [Value Schema](value-schema.md) | 16-24h (2-3d) | pair | initial | Contract for ~20-30 form components. `value` setting + schema + `change` event. Gates form/form-field and the wrapper architecture. |
 | 2c | [State from Settings](state-from-settings.md) | 8h | pair | scoped | `{ default: 'all', from: 'setting' }` in `defaultState`. Eliminates manual shadowing for components that accept initial values from attributes but own them as state. |
 | 2d | [Subtemplate Settings](subtemplate-settings.md) | 8-12h | pair | initial | Reactive `defaultSettings` on subtemplates with merged proxy over parent web component settings. Same upgrade path: add `tagName` and the subtemplate becomes a web component with no API change. |
-| 2e | [Template Match Blocks](template-match-blocks.md) | 8-16h (1-2d) | pair | scoped | `{#match}`/`{is}`/`{else}` — value-based branching. Replaces verbose `{#if is x 'a'}...{else if is x 'b'}` chains. **Sequence after `P16`** so `{#match}` inherits attribute-position support; otherwise it ships with the same hidden regression `{#if}` carries today. |
+| 2e | [Template Match Blocks](template-match-blocks.md) | 8-16h (1-2d) | pair | scoped | `{#match}`/`{is}`/`{else}` — value-based branching. Replaces verbose `{#if is x 'a'}...{else if is x 'b'}` chains. |
 | 2f | [Internationalization](i18n.md) | TBD | pair | initial | i18n as a built-in framework primitive — locale, formatters, RTL, language switching. Lands before Phase 4 to avoid retrofitting 60+ components. Pair session needed to scope. |
 
 ---
@@ -158,8 +156,8 @@ An agent needs eyes and tooling to work in isolation. Phase 4 has two gates befo
 
 Wrappers are the adoption surface for the majority of consumers — React/Vue/Svelte developers using `@semantic-ui/react` etc. rather than registering web components manually. Architecture defines the generation pipeline; per-framework packages are the artifacts. Blocked on Value Schema (2b); iterates alongside Phase 4 primitive generation. Sequenced ahead of authored documentation because adoption needs the wrappers — docs alone don't convert most users.
 
-| # | Plan | Hours | Mode | Scope | Notes |
-|---|------|-------|------|-------|-------|
+| # | What | Hours | Mode | Notes |
+|---|------|-------|------|-------|
 | 5a | [Wrapper Architecture](wrapper-architecture.md) | 40-56h (5-7d) | pair | initial | Generation pipeline for React/Vue/Svelte wrappers. Blocked on value schema. |
 | 5b | Wrapper Packages | 96-160h (12-20d) | pair | initial | `@semantic-ui/react`, `/vue`, `/svelte`. Blocked on wrapper architecture. |
 
@@ -202,9 +200,6 @@ Slot in wherever there's a gap; not phase-gated.
 | P12 | [Template Spread Syntax](template-spread-syntax.md) | 4-8h | pair | scoped | `{>card ...friend}` — object spread in data passing. Ship when component templates demonstrate need. |
 | P13 | [Template Content Projection](template-wrapper-snippets.md) | 12-16h (1.5-2d) | pair | scoped | `{>content}` — content projection for snippets + subtemplates. Ship when component templates demonstrate need. |
 | P14 | [Template Let Bindings](template-let-bindings.md) | 10-14h (1-2d) | pair | scoped | `{#let}...{/let}` — snippet-for-vars. Ship when component templates demonstrate need. |
-| P15 | [Native Renderer — Perf Wins](native-renderer-perf-wins.md) | 4-6h | pair | scoped | Three small renderer cleanups: cache collapse (Option A — keep string cache for unsafeHTML), module-scoped TreeWalker, unsafeHTML dirty-check (~10000× savings ratio at unchanged values). Item 3 ships standalone for clean bench attribution. |
-| P16 | [Block Dispatch Unification](block-dispatch-unification.md) | 20-30h (2.5-4d) | pair | scoped | Restore block-position introspection (regression: `{#if}` in attribute values renders literal comment text) and fold expression handling into the block model. Every AST node dispatches via `getBlock(type)(bag)`; every block receives `entry.classification` and renders position-appropriately, matching Lit's `partInfo` contract. Step 1 ships independently as the regression bugfix. **Should land before `2e Template Match Blocks`** so match inherits attribute-position support. |
-| P17 | [defineBlock — Mount-Cost Reduction](defineblock-mount-cost.md) | 4-6h | pair | scoped | Eliminate per-dispatch closure construction in `defineBlock`. Krausest `create-1000`/`create-10000` wins. **Blocked on `2a.2` (FGR — As-Mode Per-Field Isolation) merge** to avoid `each.js` conflicts. |
 
 ---
 

--- a/ai/plans/utils-modernization.md
+++ b/ai/plans/utils-modernization.md
@@ -1,0 +1,83 @@
+# Utils Modernization
+
+## Goal
+
+`@semantic-ui/utils` has accumulated a mix of principled next-gen design and lodash-parity leftovers. The library's instinct is right — when two functions exist, they should capture meaningfully distinct behaviors, not arg-shape variants. A few leftovers violate that, and a few modern patterns are missing.
+
+This plan captures the decisions needed to reconcile the library with that principle and stage the breaking changes behind a single release window.
+
+**Naming principle**: two exports earn their place when they express **distinct intent at the call site**, even if the implementations overlap. Two names for the same intent (`any = some`) is a wart; two names for distinct intents that happen to share a body (`wrapFunction` as defensive normalization vs `constant` as explicit factory) is a feature — the name is for the reader.
+
+## Design / Implementation
+
+### Removals (breaking)
+
+| Export | Issue | Proposed action |
+|--------|-------|-----------------|
+| `any` | Exact alias of `some` (`arrays.js:237`) — two names, one function | Delete. Document `some` as canonical (matches `Array.prototype.some`). |
+| `onlyKeys` | Same operation as `pick` but takes array instead of spread args | Pick one shape. Most callers pass an array today (from config/filters/`Object.keys`) — recommend standardizing on `pick(obj, keys)` taking an array, delete `onlyKeys`. |
+
+### Signature changes (breaking)
+
+| Export | Issue | Proposed action |
+|--------|-------|-----------------|
+| `first` / `last` | Return-type polymorphism: `first(arr)` returns element, `first(arr, 2)` returns array | Split: `first(arr)` always returns the element. Add `firstN(arr, n)` / `lastN(arr, n)` that always return arrays. |
+
+### Additions
+
+| Export | Rationale |
+|--------|-----------|
+| `returnsSelf`, `returnsNull`, `returnsTrue`, `returnsFalse`, `returnsUndefined` | Named, shared, reference-stable functions for the common constant returns. Ship the common cases as direct exports so every consumer dedupes to the same closure — enables reference-equality checks like `template.js`'s `this.onThemeChangedCallback !== noop` pattern to generalize across the codebase. |
+| `constant = wrapFunction` | Alias for the explicit-factory intent. Same body as `wrapFunction`, different semantic intent at the call site: `wrapFunction(x)` reads as defensive normalization ("value-or-function, normalize"); `constant(x)` reads as explicit factory ("function that returns this"). Covers the programmatic-value case (`constant(config.default)`) where a direct named export can't. |
+| `identity` → rename to `returnsSelf` | `identity` is brand-new in this release (from the noop/identity split). Rename to `returnsSelf` for consistency with the prefix family and to avoid FP jargon. Ship both renames together in this release window rather than churning twice. |
+| `pipe(...fns)(x)` | Functional composition is idiomatic in modern TS; lodash's `flow` is clunky. Small primitive, pairs well with existing polymorphic iterators. |
+| `attempt(fn, fallback)` or `safely(fn)` | Several sites in the codebase use `try { ... } catch { /* noop */ }` (see `browser.js:113,152,178,191`). A named helper makes intent greppable and documents the pattern. |
+| `tap(fn)` | Passes value through while running a side effect. Small, useful in pipes and reactive chains. |
+
+### Decisions needed
+
+- **Do `any` and `onlyKeys` get deprecation shims in this release, or hard-deleted?** Hard-delete is cleaner for a 1.0-era library; deprecation adds complexity for a short window. Recommend hard-delete + loud CHANGELOG entry + migration note.
+- **`first`/`last` strategy:** (a) always-scalar + new `firstN`/`lastN`, or (b) always-array (breaking for all current 1-arg callers)? Recommend (a) — smaller blast radius, clearer semantics at call site.
+- **`pick` arg shape final answer:** spread (`pick(obj, 'a', 'b')`) or array (`pick(obj, ['a', 'b'])`)? Recommend array — composes with `Object.keys`, filter results, config. Spread is 2014 ergonomics for hand-literal keys that rarely appear in modern code.
+- **`pipe` return style:** eager (`pipe(fns, x)`) or curried (`pipe(...fns)(x)`)? Curried composes better; eager is simpler.
+- **`attempt` vs `safely` naming:** `attempt(fn, fallback)` reads naturally ("attempt this, else fallback"). `safely(fn)` suggests "swallow errors" without the fallback value — less useful.
+- **Shape resolved.** Ship shared direct exports for the common constant returns (`returnsSelf`, `returnsNull`, `returnsTrue`, `returnsFalse`, `returnsUndefined`) — reference-stable across consumers, enables dedup and ref-equality checks. `constant` is an alias of `wrapFunction` covering the programmatic-value case. `identity` renames to `returnsSelf` in the same release window.
+  - Rejected names along the way: `always` (asserts continued truth when actual use is ephemeral-default), bare `returns(value)` / `constant(value)` as the *only* surface (works, but loses the dedup win from sharing primitive closures across the codebase).
+
+### Out of scope
+
+- Changes to `extend` / `deepExtend` / `assignInPlace` — the three merge variants already capture distinct contracts (shallow / recursive / sync-with-deletion). Leave as-is.
+- Rewriting `proxyObject`, `weightedObjectSearch`, `hashCode` — these are niche, principled, and earn their export.
+
+### Completed as one-line wins (not part of this plan)
+
+- `proxyObject` default swapped from `noop` to `() => ({})`. *Revisit:* `() => ({})` allocates a fresh closure on each defaulted call — once `always` lands, change to `always({})` for a shared reference.
+- `hasProperty` reduced to thin re-export of `Object.hasOwn` (ES2022).
+- `utility-functions.md` skill updated for `noop` / `identity` split.
+
+### Adoption once `always` lands
+
+Audit the codebase for `() => <literal>` patterns that are candidates to migrate:
+- `NO_EQUALITY = () => false` in `reactivity/src/signal.js` → `always(false)`
+- `filter: () => true` defaults (e.g. `docs/src/examples/templates/expressions-fn/filter-list.js:7`)
+- `proxyObject` default (above)
+- Any `defaultSettings` entries that use bare `() => x` closures
+
+## Open Questions
+
+See "Decisions needed" above. Five design calls, all quick — should fit in one pair session.
+
+Once decisions are made:
+- Codemod for `any` → `some`, `onlyKeys` → `pick` across `packages/`, `src/`, `docs/`, `tools/`.
+- Audit `first(arr, N)` / `last(arr, N)` call sites — all need rewrite to `firstN` / `lastN`.
+- CHANGELOG entries under **BREAKING** for each removal/signature change.
+- Type-file updates.
+- Skill doc (`ai/skills/authoring/utility-functions.md`) updates.
+
+## Dependencies
+
+None. Can land anytime — breaking changes batch naturally with other utils changes in a release window.
+
+## Status
+
+`initial` — design decisions pending. Created 2026-04-16 off the utils review following the signal-safety PR.

--- a/ai/skills/authoring/utility-functions.md
+++ b/ai/skills/authoring/utility-functions.md
@@ -367,11 +367,17 @@ truncate('こんにちは世界です', 8, { locale: 'ja' });          // 'こ�
 
 ### Core
 ```javascript
-import { noop, wrapFunction } from '@semantic-ui/utils';
+import { noop, identity, wrapFunction } from '@semantic-ui/utils';
 
-// Identity function — returns its argument
-noop(42);                              // 42
-noop('hello');                         // 'hello'
+// noop — swallows arguments, returns undefined. Use as a reusable empty
+// callback to avoid allocating fresh () => {} closures.
+noop();                                // undefined
+noop(42, 'ignored');                   // undefined
+
+// identity — returns its first argument unchanged. Use as a pass-through
+// default for transforms (e.g. `transform = mapFn ?? identity`).
+identity(42);                          // 42
+identity('hello');                     // 'hello'
 
 // Wraps non-functions into a function that returns the value
 const fn = wrapFunction('default');    // () => 'default'
@@ -827,7 +833,8 @@ const pattern = new RegExp(escapeRegExp('price ($5.00)'), 'i');
 ### Functions (functions.js)
 | Function | Signature | Returns |
 |----------|-----------|---------|
-| `noop` | `(v)` | `v` (identity function) |
+| `noop` | `()` | `undefined` — swallows args, reusable empty callback |
+| `identity` | `(v)` | `v` — returns first arg unchanged |
 | `wrapFunction` | `(x)` | `x` if function, else `() => x` |
 | `memoize` | `(fn, hashFn?)` | Memoized function |
 | `wait` | `(ms, opts?)` | Promise |

--- a/ai/skills/contributing/agent-lessons.md
+++ b/ai/skills/contributing/agent-lessons.md
@@ -68,14 +68,111 @@ This applies to naming functions (elicit usage patterns before picking names), c
 
 ---
 
-## Delegate to Fresh Perspectives
+## Quiet Code Over Ornamented Code
 
-When stuck in a solution direction, delegating to a fresh agent (or pair of agents) reading the problem from scratch produces better results than pushing harder yourself. Rules that worked:
+Training data pushes toward a particular visual dialect: `SCREAMING_CAPS` for module-level values, `_underscore` prefixes for "private" properties, dispatcher functions that route to shared refs via if-ladders, options objects where direct literals would do. Each is borrowed from a different language or era. None earn their weight in modern JS — they add visual ceremony that signals "I'm being rigorous" without conveying more information.
 
-- Describe the problem and symptoms, not the diagnosis
-- Give all relevant file paths — don't make them search
-- Let failing tests with correct expectations count as valid findings
-- Independent convergence on the same fix is the highest-confidence signal
+`MAX_RETRIES = 3` doesn't tell the reader more than `maxRetries = 3`; `const` already declares immutability. `_privateCache` doesn't tell the reader more than `privateCache`; JS has no language-level convention here. A `constant(value)` dispatcher that routes to `ALWAYS_TRUE`/`ALWAYS_FALSE` via an if-ladder doesn't tell the reader more than seven flat exports — `returnsTrue`, `returnsFalse`, `returnsNull`, `returnsSelf`, etc. — sitting next to each other. In each case the quiet form is strictly more legible: intent lives in the name, at the value level, not in a scaffolding layer above it.
+
+Specific tells to notice in your own output:
+
+- `SCREAMING_CAPS` module-level constants
+- `_underscore`-prefixed "private" names (not SUI convention — see `feedback_no_underscore_vars`)
+- Dispatcher functions that route to shared refs via if/switch — prefer N direct flat exports
+- Options objects for configuration that never varies
+- "Extensibility for the future" when the future isn't real
+- Factories that construct what could be literals
+
+The test: if this code had only one user and no hypothetical future callers, would it still have this shape? Usually the ornamented version collapses to something simpler. In the framework author's words, ornament "obscures the elegance and semantic intent."
+
+**Apply this as a review lens, not just a write-time check.** The quiet form is rarely what lands on the first pass — it's what emerges when you re-read the diff with "can this be quieter?" as the question. Example: a `Signal.configure` that ran a 5-line if-ladder to forward keys into setters survived the write pass; the review pass collapsed it to `Object.assign(Signal, config)` because bracket assignment already routes through setters. Before finalizing any changeset, re-read with the lens — the Object.assign instinct has to be yours by default, not the reviewer's.
+
+### Comments: the OSS bar
+
+The same discipline applies to comments, and this is a repeated failure point for AI defaults — both directions. On the first pass, agents tend to narrate (`// loop through items`, `// set the value`, `// Factory for signals computed from other signals`). On the review pass, agents tend to over-prune and strip load-bearing WHY notes alongside the narration. Both miss the target.
+
+**The bar**: a comment earns its place only if it documents something **non-obvious to someone who doesn't know the codebase** — a weird trick, a hidden constraint, a problem the code is defending against, a performance choice backed by numbers.
+
+Compare:
+
+❌ **Narration / internal rationale** (remove):
+```js
+// Module-local only because it's used as a computed class member key
+// (`[IS_SIGNAL]`), which is evaluated before static fields initialize.
+const IS_SIGNAL = Symbol.for('semantic-ui/Signal');
+```
+This explains the internal engineering decision (where it lives) to readers who weren't asking. Dead weight.
+
+✅ **Problem being solved** (keep):
+```js
+// solves 'instanceof Signal' checks if across realms or package duplication
+const IS_SIGNAL = Symbol.for('semantic-ui/Signal');
+```
+A reader sees `Symbol.for` + `[Symbol.hasInstance]` and wonders *why not just `instanceof`*. The comment answers that — points at the observable failure this technique defends against. That's the bar.
+
+Other load-bearing categories:
+- **Performance numbers**: `// Error.captureStackTrace is 10-100× a context spread; gated on stack mode`
+- **Behavioral variance by state**: the block above `Signal.prototype.mutate` explaining freeze vs. reference/none semantics
+- **Weird-trick explanations**: `// WeakRef lets the derived reaction self-stop when the source is GC'd`
+- **Config / enum value docs**: `// 'off' — zero cost; 'context' — attach bags; 'stack' — captureStackTrace per notify` inline on a config object. Readers using the config need the semantics somewhere, and the config site is where they look.
+
+What the above examples share: a future reader sees the code, asks a specific question, and the comment answers that question in one line. Never restate what the code does. Never announce internal plans ("replace with X when Y ships"). Never document API contracts that belong in JSDoc or types.
+
+**Section dividers are a separate case.** "No section labels" is the right instinct for single-declaration labels like `// DX pass throughs` above one static assignment. It's the wrong instinct for multi-method conceptual clusters in a large file — the SUI codebase uses a canonical three-level comment hierarchy for large CSS files, config files, and organized JS files (see the `code-formatting` skill). Level-2 dividers (`/*---  Core  ---*/`, `/*---  Mutation Helpers  ---*/`, `/*---  Configuration  ---*/`) are the correct tool for grouping ~10 related methods as navigation aids. Test: does the divider label a conceptual cluster a reader wants to scan past or jump to? Follow the three-level hierarchy. If it labels one thing the name already conveys, remove.
+
+---
+
+## You Are an Orchestrator, Not an Investigator
+
+The default failure mode for agents on hard diagnostic tasks is treating them as solo work — reading, hypothesizing, implementing, measuring, all in the main conversation. This is roughly an order of magnitude slower than it needs to be, and it accumulates anchoring bias as your own theories color each subsequent step.
+
+Reframe the role: **you deploy investigators; you don't investigate**. Diagnostic work is inherently parallelizable, and fresh subagents produce independent reads of evidence without carrying your prior theories.
+
+### Parallelize by default
+
+Any moment you catch yourself saying "let me go read X and figure out Y," check whether the read-and-figure-out could be done by a fresh agent with a self-contained brief. Usually it can. Common patterns where parallel agents dominate solo investigation:
+
+- **Branching hypotheses** — "Is the regression in path A or path B?" → one agent per path.
+- **Multi-angle investigation** — profile + diff + aggregate artifacts + call-chain audit + grep-for-callsites are five distinct angles on the same symptom, all suitable for parallel fresh agents.
+- **Unfamiliar code exploration** — "How does reconcile phase 3 work?" → dispatch an Explore agent with a narrow question, move on.
+- **Independent validation of a fix** — after a change, dispatch an agent to verify the fix resolves the original symptoms without regressing adjacent behavior.
+
+Five parallel agents at ~10 minutes each = 10 minutes of wall clock for 50 agent-minutes of work. The cost-benefit versus solo investigation is lopsided almost always.
+
+### Synthesis, not aggregation
+
+Your job when reports come back isn't to concatenate them. It's to:
+
+- **Identify convergence** — two independent agents reaching the same conclusion via different paths is the highest-confidence signal available. Stop hedging, move on.
+- **Identify divergence** — disagreement between agents flags ambiguous evidence. Next move: targeted third agent to resolve, or in-context examination of the specific disagreement point.
+- **Reject weak findings** — "X might be the issue but I'm not sure" is a hypothesis, not evidence. Treat it as a pointer to the next investigation, not a conclusion.
+
+### Briefing discipline
+
+Fresh agents start with zero context. Every brief must be self-contained:
+
+- **State the problem and symptoms** — not your diagnosis.
+- **List exact file paths** — line numbers if you have them. Don't make the agent search.
+- **Choose prescribed-hypothesis vs open-ended** with intent. Prescribing produces confirmation bias; open-ended produces independent judgment. Both are useful in different situations.
+- **Specify the deliverable** — report, profile output, code change, measurement. Include format ("under 300 words", "return the top 10 hot frames by tick count").
+- **Tell them whether to write code or only investigate.** Unclear here is a common churn source.
+
+See the `fresh-take` skill for the deeper bias-isolation technique when delegating a single careful evaluation (distinct from the parallel-investigation pattern here).
+
+### When NOT to parallelize
+
+In-context work is better when:
+
+- The task is mechanical and fast (reading one file, running one command).
+- The task requires accumulated conversation context (an in-progress refactor, iterative review).
+- The task requires user judgment mid-flight (design decisions, scope trade-offs).
+- The deliverable is a code change the user needs to diff-review before commit.
+
+Rule of thumb: if the work is **investigative** (reading, profiling, analyzing, summarizing), default to subagent. If the work is **productive or interactive** (writing production code, reviewing with user, navigating a tricky refactor), default to in-context.
+
+### The "let me think about this" tell
+
+More than ~60 seconds reasoning about a diagnostic problem without executing anything is almost always the moment to dispatch an agent instead. Solo reasoning on ambiguous diagnostic questions produces anchoring, not answers. Parallel fresh agents produce evidence.
 
 ---
 
@@ -96,8 +193,10 @@ Ask "what's the actual cost?" before investing energy in reducing it. The user w
 | Deferring work that should be finished now | Read the room — the user may see the full arc |
 | Applying training-data assumptions | Verify against actual codebase behavior |
 | Optimizing for hypothetical costs | Ask about the real cost model first |
-| Pushing harder when stuck | Delegate to a fresh perspective |
+| Investigating solo | Orchestrate — dispatch parallel fresh agents, synthesize findings |
+| Reasoning >60s without executing | Dispatch an agent instead of thinking harder |
 | Adding semantic abstraction early | Start literal, promote with evidence |
+| Decorating code with training-data visual conventions | Quiet form wins — flat direct names over SCREAMING_CAPS, underscores, dispatcher layers |
 
 ---
 
@@ -107,4 +206,5 @@ Ask "what's the actual cost?" before investing energy in reducing it. The user w
 |-------|---------|-------------|
 | **Mental Model** | `mental-model` | Understanding the framework's core concepts |
 | **Build System** | `build-system` | Working with the build pipeline |
+| **Fresh Take** | `fresh-take` | Careful bias-isolated delegation for a single deep evaluation (complements the parallel-orchestration pattern above) |
 | **Agent Guestbook** | `agent-guestbook` | Reading the full stories behind these lessons |

--- a/ai/skills/workflows/contributing/improve-performance.md
+++ b/ai/skills/workflows/contributing/improve-performance.md
@@ -174,6 +174,64 @@ Consequences:
 - **Don't tune thresholds to what you wish you could detect.** Tune to what the measurement actually supports. Asking for ±1% resolution on a 2ms bench means the metric is permanently "unsure" regardless of sampling time.
 - **The in-house reporter exposes this as a per-metric `Expected Noise`** column. When a metric shows Unsure with CI width similar to the expected-noise estimate, the bench is running at its physical floor — more samples don't help. When the CI width is wider than the estimate, the metric is genuinely variable beyond its duration's predicted floor and more samples may resolve it.
 
+### Recognizing the "Challenge the Tests" Failure Mode
+
+When perf investigation gets hard, agents reliably pivot from "diagnose the code" to "question the measurement." This section exists because the pivot happens in nearly every session that uses CI as a baseline, and because specific evidence against it is available.
+
+The failure shape:
+1. Investigation doesn't quickly yield a root cause.
+2. Agent reframes results as noise, bench design flaws, or measurement instability.
+3. Agent proposes changing the test harness rather than the code.
+
+Challenging the harness is sometimes correct. But it requires evidence. Here is the evidence this harness has already produced.
+
+#### "These confident regressions are probably noise"
+
+**The harness has been empirically validated against null changes.** Null PRs (build-tool polish, workflow YAML edits) produce exactly zero confident regressions:
+
+- PR #143 ([comment](https://github.com/Semantic-Org/Semantic-Next/pull/143#issuecomment-4253067182)) — "Build: Reporter polish" — reports `✅ 0 faster · ❌ 0 slower · 🔍 15 unsure · ⚪ 8 no change`
+- PR #149 ([bench comment](https://github.com/Semantic-Org/Semantic-Next/pull/149)) — "Build: Discover runs all benchmarkable packages" — reports `✅ 0 faster · ❌ 0 slower · 🔍 18 unsure · ⚪ 13 no change`
+
+Two independent null changes, two reports of zero-in-each-confident-bucket. The reporter's "Confidently slower" classification is not prone to false positives on this hardware at 50 samples.
+
+The reporter does acknowledge the noise floor separately — it has a "Too Fast to Measure Precisely" bucket with per-metric CI width and expected-noise columns. That's where noise-dominated benches land. If a metric is in the *confident* bucket, it has already passed that check.
+
+If a bench is confidently regressed, the regression is real signal regardless of absolute magnitude. Diagnose it.
+
+#### "The regressions keep rotating between benches — that's noise"
+
+Classification can rotate because the CI width straddles the 2% floor differently across runs. The underlying delta does not.
+
+Download `bench-report.json` artifacts for multiple runs:
+```bash
+gh run download <run_id> -R <owner>/<repo>
+```
+
+Compute per-bench means across runs (each artifact has `benchmarks[].samples[]` with 50+ measurements). Real noise produces random-signed deltas around zero. A real regression produces same-signed deltas with a stable central tendency.
+
+Example from PR #148 session: `toggle-middle` showed PR-slower by +11.2%, +8.9%, +11.3% across three consecutive runs. The confidence *classification* fluctuated between runs, but the underlying delta was a stable ~10%. Aggregating artifacts revealed it as real; reading summaries alone would have supported the "rotating noise" interpretation.
+
+This aggregation is minutes of work once the artifacts are downloaded. Do it before concluding the pattern is noise.
+
+#### "Main baseline is drifting between runs — the measurement is unreliable"
+
+Tip-of-tree absolute times often vary 20-100% across runs due to CI-host variance (thermal, noisy neighbors, JIT state). This does not invalidate anything.
+
+Tachometer computes delta within a single run on the same host with interleaved samples. The relevant quantity is `(PR_mean - tip_mean) / tip_mean` per run. Inter-run baseline drift is cancelled by this structure. That main runs 60% faster on Tuesday than Thursday says nothing about whether your PR is faster or slower than main on either day.
+
+#### "Let me scale the bench up to make the signal cleaner"
+
+Valid for some cases, not others:
+
+- **Valid**: A bench in the "Too Fast to Measure Precisely" bucket with ±15% expected noise can't resolve a 3% delta. Scaling 10x moves it into a regime where small real deltas resolve cleanly. Use scaling when you suspect a real small delta underneath high-noise measurement.
+- **Not a fix**: A bench in the confident-regressed bucket will remain confidently regressed at 10x scale — only the absolute ms delta grows. Scaling does not erase a real regression; it makes the regression harder to miss.
+
+When proposing a scale change, state up front: which bucket is the bench currently in, what resolution is needed, what the scaling should change. If you find yourself scaling a confident-bucket bench, stop and re-examine the motivation.
+
+#### The general principle
+
+When the harness starts feeling like the enemy, the move is to name the specific property you're challenging, produce evidence that contradicts it, and only then discuss harness changes. The default stance is: the harness is correct, the code has a regression, your job is to find it.
+
 ### Gotchas
 
 **Stale Chrome/chromedriver processes.** Tachometer launches chromedriver and Chrome headless. If a run is killed mid-flight, these processes persist and block the next run. Kill them before retrying:

--- a/docs/src/examples/utils/functions/utils-noop/index.js
+++ b/docs/src/examples/utils/functions/utils-noop/index.js
@@ -1,15 +1,14 @@
 import { noop } from '@semantic-ui/utils';
 
-const value = 'hello';
-const result = noop(value);
-console.log(result);
+// noop swallows arguments and returns undefined
+console.log(noop()); // undefined
+console.log(noop(1, 2, 3)); // undefined
 
-// common use case - default callback
+// common use case - default callback that is safe to invoke
 function processData(data, callback = noop) {
   const processed = data.toUpperCase();
   callback(processed);
   return processed;
 }
 
-const data = processData('test');
-console.log(data);
+console.log(processData('test')); // 'TEST'

--- a/internal-packages/esbuild-resolve-bare-imports/test/cdn-urls.test.js
+++ b/internal-packages/esbuild-resolve-bare-imports/test/cdn-urls.test.js
@@ -6,7 +6,7 @@ const ROOT = resolve(import.meta.dirname, '../../..');
 const CDN_ROOT = 'https://cdn.semantic-ui.com';
 
 const SUI_PACKAGES = readdirSync(join(ROOT, 'packages'), { withFileTypes: true })
-  .filter(d => d.isDirectory())
+  .filter(d => d.isDirectory() && !d.name.startsWith('.'))
   .map(d => d.name);
 
 // Collect declared subpath exports (e.g. "./template") from each package

--- a/packages/component/src/define-component.js
+++ b/packages/component/src/define-component.js
@@ -2,7 +2,7 @@ import { getEngine } from '@semantic-ui/renderer';
 import { TemplateCompiler } from '@semantic-ui/compiler';
 // direct import avoids circular chunk dependency between component ↔ templating
 import { Template } from '@semantic-ui/templating/template';
-import { adoptStylesheet, each, fatal, isClient, kebabToCamel, noop } from '@semantic-ui/utils';
+import { adoptStylesheet, each, fatal, identity, isClient, kebabToCamel, noop } from '@semantic-ui/utils';
 
 import { getProperties } from './component-helpers.js';
 import { registerComponent } from './component-registry.js';
@@ -16,7 +16,7 @@ export const defineComponent = ({
   delegatesFocus = false,
   templateName = kebabToCamel(tagName),
 
-  createComponent: createComponentFn = noop,
+  createComponent: createComponentFn = identity,
   events = {},
   keys = {},
 

--- a/packages/query/src/behavior.js
+++ b/packages/query/src/behavior.js
@@ -4,6 +4,7 @@ import {
   clone,
   each,
   extend,
+  identity,
   isClassInstance,
   isFunction,
   isPlainObject,
@@ -26,7 +27,7 @@ export class Behavior {
     namespace = name,
 
     // returns behavior instance
-    createBehavior = noop,
+    createBehavior = identity,
 
     // event object
     events = {},
@@ -57,7 +58,7 @@ export class Behavior {
     onDestroyed = noop,
 
     // custom invocation fallback
-    customInvocation = noop,
+    customInvocation = identity,
 
     // element index information
     elementIndex = 0,

--- a/packages/utils/src/functions.js
+++ b/packages/utils/src/functions.js
@@ -6,9 +6,14 @@ import { isFunction, isPlainObject, isPromise } from './types.js';
 --------------------*/
 
 /*
-  Efficient no operation func
+  No operation — swallows arguments, returns undefined
 */
-export const noop = (v) => v;
+export const noop = () => {};
+
+/*
+  Identity — returns its first argument unchanged
+*/
+export const identity = (v) => v;
 
 /*
   Call function even if its not defined

--- a/packages/utils/src/objects.js
+++ b/packages/utils/src/objects.js
@@ -1,5 +1,4 @@
 import { clone } from './cloning.js';
-import { noop } from './functions.js';
 import { each } from './loops.js';
 import { escapeRegExp } from './regexp.js';
 import { isArray, isObject, isPlainObject, isString } from './types.js';
@@ -38,19 +37,29 @@ export const mapObject = (obj, callback) => {
 };
 
 /*
-  Handles properly copying getter/setters
+  Shallow-merge sources into target. Preserves source accessors (unlike
+  Object.assign, which snapshots getter values) and preserves target
+  extensibility (a frozen/sealed source does not lock down target props).
 */
 export const extend = (obj, ...sources) => {
   sources.forEach((source) => {
-    let descriptor, prop;
     if (source) {
-      for (prop in source) {
-        descriptor = Object.getOwnPropertyDescriptor(source, prop);
-        if (descriptor === undefined) {
-          obj[prop] = source[prop];
+      for (const prop in source) {
+        const desc = Object.getOwnPropertyDescriptor(source, prop);
+        if (desc?.get || desc?.set) {
+          Object.defineProperty(obj, prop, desc);
+        }
+        else if (prop in obj) {
+          // Existing target prop may be accessor from a prior source
+          Object.defineProperty(obj, prop, {
+            value: source[prop],
+            writable: true,
+            enumerable: true,
+            configurable: true,
+          });
         }
         else {
-          Object.defineProperty(obj, prop, descriptor);
+          obj[prop] = source[prop];
         }
       }
     }
@@ -300,7 +309,7 @@ export const get = function(obj, path = '') {
 /* This is useful for callbacks or other scenarios where you want to avoid the
    values of a reference object becoming stale when a source object changes
 */
-export const proxyObject = (sourceObj = noop, referenceObj = {}) => {
+export const proxyObject = (sourceObj = () => ({}), referenceObj = {}) => {
   return new Proxy(referenceObj, {
     get: (target, property) => {
       const propKey = typeof property === 'symbol' ? property.toString() : property;
@@ -319,11 +328,10 @@ export const onlyKeys = (obj, keysToKeep) => {
 };
 
 /*
-  Return true if non-inherited property
+  Return true if non-inherited property. Thin re-export of Object.hasOwn
+  (ES2022) — safe on Object.create(null) and objects that shadow hasOwnProperty.
 */
-export const hasProperty = (obj, prop) => {
-  return Object.prototype.hasOwnProperty.call(obj, prop);
-};
+export const hasProperty = Object.hasOwn;
 
 /*
   Reverses a lookup object

--- a/packages/utils/src/strings.js
+++ b/packages/utils/src/strings.js
@@ -1,4 +1,4 @@
-import { noop } from './functions.js';
+import { identity } from './functions.js';
 import { isArray, isFunction, isString } from './types.js';
 
 /*-------------------
@@ -109,7 +109,7 @@ export const joinWords = (words, {
   lastSeparator = ' and ',
   oxford = true,
   quotes = false,
-  transform = noop,
+  transform = identity,
 } = {}) => {
   if (!isArray(words) || words.length === 0) {
     return '';

--- a/packages/utils/test/functions.test.js
+++ b/packages/utils/test/functions.test.js
@@ -1,12 +1,20 @@
-import { debounce, memoize, noop, throttle, wait, wrapFunction } from '@semantic-ui/utils';
+import { debounce, identity, memoize, noop, throttle, wait, wrapFunction } from '@semantic-ui/utils';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 describe('function utilities', () => {
-  it('noop should act as an identity function', () => {
-    expect(noop(42)).toBe(42);
-    expect(noop('hello')).toBe('hello');
+  it('noop returns undefined and swallows arguments', () => {
     expect(noop()).toBeUndefined();
+    expect(noop(42)).toBeUndefined();
+    expect(noop('hello', 'world')).toBeUndefined();
+  });
+
+  it('identity returns its first argument unchanged', () => {
+    expect(identity(42)).toBe(42);
+    expect(identity('hello')).toBe('hello');
+    const obj = { a: 1 };
+    expect(identity(obj)).toBe(obj);
+    expect(identity()).toBeUndefined();
   });
   it('wrapFunction should return the same function if a function is passed', () => {
     const func = () => 'test';
@@ -888,8 +896,12 @@ describe('function utilities', () => {
 });
 
 describe('debounce — options object overload', () => {
-  beforeEach(() => { vi.useFakeTimers(); });
-  afterEach(() => { vi.restoreAllMocks(); });
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
 
   it('should accept options object as second argument', async () => {
     const func = vi.fn(() => 'result');
@@ -905,8 +917,12 @@ describe('debounce — options object overload', () => {
 });
 
 describe('throttle — options object overload', () => {
-  beforeEach(() => { vi.useFakeTimers(); });
-  afterEach(() => { vi.restoreAllMocks(); });
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
 
   it('should accept options object as second argument', () => {
     const func = vi.fn(() => 'result');

--- a/packages/utils/types/functions.d.ts
+++ b/packages/utils/types/functions.d.ts
@@ -78,6 +78,18 @@ export interface ThrottledFunction<T extends (...args: any[]) => any> {
 export function noop(...args: any[]): void;
 
 /**
+ * Identity function — returns its first argument unchanged
+ * @see {@link https://next.semantic-ui.com/docs/api/utils/functions#identity identity}
+ *
+ * @example
+ * ```ts
+ * const transform = mapFn ?? identity;
+ * const mapped = items.map(transform);
+ * ```
+ */
+export function identity<T>(value: T): T;
+
+/**
  * Wraps a value in a function if it isn't already a function
  * @see {@link https://next.semantic-ui.com/docs/api/utils/functions#wrapfunction wrapFunction}
  *


### PR DESCRIPTION
Changed `noop` to now return `undefined` (like community expects) adds a new  `identity` that returns itself.

## Changes
- Split utils `noop`/`identity`
- `extend` no longer copies non-writable descriptors from source onto target
- `hasProperty` aliased to `Object.hasOwn`
- `proxyObject` default source returns `{}`

## Risk
2/10 — `noop` callers expecting the old identity return now get `undefined`. All in-repo callers migrated to `identity`.