### PR TITLE
Feat: Signal Safety Presets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ xx.xx.xxxx
 * **Feature** - Added `{#fn expression}` directive to pass values as-is without auto-invoking functions — mirrors `{#html}` pattern, useful for passing callbacks through property bindings
 
 ### Reactivity
+* **Feature** - Added `safety` constructor option with four presets — `'clone'` (current default, mutation isolation), `'reference'` (no clone, identity stable), `'freeze'` (deep-freeze on set, mutation throws), `'none'` (no clone, no equality dedupe). `allowClone: false` continues to work as a shim for `safety: 'reference'`.
+* **Feature** - Added `Signal.safety`, `Signal.tracing`, `Signal.stackCapture` static accessors and `Signal.configure({...})` for bulk setup.
 * **Feature** - Added `depend()` to register a signal as a dependency without reading the value
 * **Feature** - Added `notify()` to force-trigger subscribers bypassing the equality check
 * **Feature** - Added `hasDependents()` to check if any reactions are subscribed to a signal

--- a/packages/reactivity/src/helpers.js
+++ b/packages/reactivity/src/helpers.js
@@ -27,6 +27,25 @@ export const setStackCapture = (enabled) => {
 export const isTracing = () => mode !== 'off';
 export const isStackCapture = () => mode === 'stack';
 
+// Default value-protection preset for new Signals when `safety` isn't set
+// at the call site.
+//   'clone'     — clone on get/set; mutation isolation, identity unstable
+//   'reference' — no clone; identity stable, mutate-after-get bypasses reactivity
+//   'freeze'    — deep-freeze on set; mutation throws at the call site
+//   'none'      — no clone, no equality dedupe; every set notifies
+let safety = 'clone';
+
+const SAFETY_PRESETS = new Set(['clone', 'reference', 'freeze', 'none']);
+
+export const setSafety = (preset) => {
+  if (!SAFETY_PRESETS.has(preset)) {
+    throw new TypeError(`Invalid safety preset: ${preset}. Must be 'clone', 'reference', 'freeze', or 'none'.`);
+  }
+  safety = preset;
+};
+
+export const getSafety = () => safety;
+
 // Capture a stack trace into target.context. Passes `caller` to
 // Error.captureStackTrace so the framework frame is trimmed from the trace.
 export const captureStack = (target, caller) => {

--- a/packages/reactivity/src/signal.js
+++ b/packages/reactivity/src/signal.js
@@ -1,5 +1,6 @@
 import {
   clone,
+  deepFreeze,
   isArray,
   isClassInstance,
   isDevelopment,
@@ -11,8 +12,18 @@ import {
 } from '@semantic-ui/utils';
 
 import { Dependency } from './dependency.js';
-import { captureStack, isStackCapture, isTracing, setStackCapture, setTracing } from './helpers.js';
+import {
+  captureStack,
+  getSafety,
+  isStackCapture,
+  isTracing,
+  setSafety,
+  setStackCapture,
+  setTracing,
+} from './helpers.js';
 import { Reaction } from './reaction.js';
+
+const noEquality = () => false;
 
 const IS_SIGNAL = Symbol.for('semantic-ui/Signal');
 
@@ -24,30 +35,43 @@ export class Signal {
     return !!instance?.[IS_SIGNAL];
   }
 
-  constructor(initialValue, { context, equalityFunction, allowClone = true, cloneFunction } = {}) {
+  constructor(initialValue, { context, equalityFunction, allowClone, cloneFunction, safety } = {}) {
     // pass in some metadata for debugging
     this.dependency = new Dependency({
       firstRun: true,
       value: initialValue,
     });
 
-    // allow user to opt out of value cloning
-    this.allowClone = allowClone;
+    // safety preset: explicit > allowClone backward-compat > Signal.safety static default
+    this.safety = safety ?? (allowClone === false ? 'reference' : getSafety());
+    // derived for the existing maybeClone path — only true under 'clone'
+    this.allowClone = this.safety === 'clone';
 
-    // allow custom equality function
+    // allow custom equality function; 'none' skips dedupe entirely
     this.equalityFunction = (equalityFunction)
       ? wrapFunction(equalityFunction)
-      : Signal.equalityFunction;
+      : (this.safety === 'none' ? noEquality : Signal.equalityFunction);
 
     // allow custom clone function
     this.clone = (cloneFunction)
       ? wrapFunction(cloneFunction)
       : Signal.cloneFunction;
 
-    this.currentValue = this.maybeClone(initialValue);
+    this.currentValue = this.protect(initialValue);
 
     // allow debugging context to be set
     this.setContext(context);
+  }
+
+  // Apply the safety preset's storage protection on the way in.
+  // 'clone' — deep-clone (mutation isolation, current default)
+  // 'freeze' — deep-freeze in place (throws on mutation at the call site)
+  // 'reference' / 'none' — store raw (caller owns mutation discipline)
+  protect(value) {
+    if (value === null || typeof value !== 'object') { return value; }
+    if (this.safety === 'clone') { return this.maybeClone(value); }
+    if (this.safety === 'freeze') { return deepFreeze(value); }
+    return value;
   }
 
   // set debugging context for signal removing any present context
@@ -86,20 +110,48 @@ export class Signal {
 
   static equalityFunction = isEqual;
   static cloneFunction = clone;
+  static noEquality = noEquality;
   static setTracing = setTracing;
   static isTracing = isTracing;
   static setStackCapture = setStackCapture;
   static isStackCapture = isStackCapture;
+
+  // Accessor pairs over helpers state, so `Signal.safety = 'freeze'` and
+  // `Object.assign(Signal, { safety: 'freeze', tracing: true })` both work.
+  static get safety() {
+    return getSafety();
+  }
+  static set safety(preset) {
+    setSafety(preset);
+  }
+  static get tracing() {
+    return isTracing();
+  }
+  static set tracing(enabled) {
+    setTracing(enabled);
+  }
+  static get stackCapture() {
+    return isStackCapture();
+  }
+  static set stackCapture(enabled) {
+    setStackCapture(enabled);
+  }
+
+  static configure(config = {}) {
+    Object.assign(Signal, config);
+  }
 
   get value() {
     // Record this Signal as a dependency if inside a Reaction computation
     this.depend();
     const value = this.currentValue;
 
-    // otherwise previous value would be modified if the returned value is mutated negating the equality
-    return (value !== null && typeof value == 'object')
-      ? this.maybeClone(value)
-      : value;
+    // Only 'clone' mode pays the per-read clone — reference/freeze/none all
+    // return the stored value directly.
+    if (this.safety === 'clone' && value !== null && typeof value === 'object') {
+      return this.maybeClone(value);
+    }
+    return value;
   }
 
   canCloneValue(value) {
@@ -118,7 +170,7 @@ export class Signal {
 
   set value(newValue) {
     if (!this.equalityFunction(this.currentValue, newValue)) {
-      this.currentValue = this.maybeClone(newValue);
+      this.currentValue = this.protect(newValue);
       this.notify();
     }
   }
@@ -203,7 +255,9 @@ export class Signal {
   }
 
   peek() {
-    return this.maybeClone(this.currentValue);
+    // 'clone' returns a fresh copy (mutation isolation); other modes return raw.
+    if (this.safety === 'clone') { return this.maybeClone(this.currentValue); }
+    return this.currentValue;
   }
 
   clear() {
@@ -234,25 +288,46 @@ export class Signal {
     }
   }
 
-  // array helpers — these always change the value, skip clone+compare
+  // array helpers — these always change the value, skip clone+compare.
+  // Under 'freeze' the stored array is frozen, so each helper rebuilds and
+  // re-freezes; other modes mutate in place.
   push(...args) {
-    this.currentValue.push(...args);
+    if (this.safety === 'freeze') {
+      this.currentValue = deepFreeze([...this.currentValue, ...args]);
+    }
+    else {
+      this.currentValue.push(...args);
+    }
     this.notify();
   }
   unshift(...args) {
-    this.currentValue.unshift(...args);
+    if (this.safety === 'freeze') {
+      this.currentValue = deepFreeze([...args, ...this.currentValue]);
+    }
+    else {
+      this.currentValue.unshift(...args);
+    }
     this.notify();
   }
   splice(...args) {
-    this.currentValue.splice(...args);
+    if (this.safety === 'freeze') {
+      const next = [...this.currentValue];
+      next.splice(...args);
+      this.currentValue = deepFreeze(next);
+    }
+    else {
+      this.currentValue.splice(...args);
+    }
     this.notify();
   }
   map(mapFunction) {
-    this.currentValue = Array.prototype.map.call(this.currentValue, mapFunction);
+    const next = Array.prototype.map.call(this.currentValue, mapFunction);
+    this.currentValue = this.safety === 'freeze' ? deepFreeze(next) : next;
     this.notify();
   }
   filter(filterFunction) {
-    this.currentValue = Array.prototype.filter.call(this.currentValue, filterFunction);
+    const next = Array.prototype.filter.call(this.currentValue, filterFunction);
+    this.currentValue = this.safety === 'freeze' ? deepFreeze(next) : next;
     this.notify();
   }
 
@@ -260,11 +335,25 @@ export class Signal {
     return this.get()[index];
   }
   setIndex(index, value) {
-    this.currentValue[index] = value;
+    if (this.safety === 'freeze') {
+      const next = [...this.currentValue];
+      next[index] = value;
+      this.currentValue = deepFreeze(next);
+    }
+    else {
+      this.currentValue[index] = value;
+    }
     this.notify();
   }
   removeIndex(index) {
-    this.currentValue.splice(index, 1);
+    if (this.safety === 'freeze') {
+      const next = [...this.currentValue];
+      next.splice(index, 1);
+      this.currentValue = deepFreeze(next);
+    }
+    else {
+      this.currentValue.splice(index, 1);
+    }
     this.notify();
   }
 
@@ -280,6 +369,17 @@ export class Signal {
       property = indexOrProperty;
     }
     if (index === -1) {
+      return;
+    }
+    if (this.safety === 'freeze') {
+      // rebuild every matching entry — direct mutation would throw on frozen
+      const next = this.currentValue.map((object, currentIndex) => {
+        if (index === 'all' || currentIndex === index) {
+          return { ...object, [property]: value };
+        }
+        return object;
+      });
+      this.set(next);
       return;
     }
     const newValue = this.peek().map((object, currentIndex) => {
@@ -355,6 +455,10 @@ export class Signal {
     else {
       value = property;
       property = idOrProperty;
+      if (this.safety === 'freeze') {
+        this.set({ ...this.currentValue, [property]: value });
+        return;
+      }
       const obj = this.peek();
       obj[property] = value;
       this.set(obj);

--- a/packages/reactivity/test/unit/signal.test.js
+++ b/packages/reactivity/test/unit/signal.test.js
@@ -1856,4 +1856,226 @@ describe('Signal API', () => {
       expect(() => signal.push('x')).toThrow();
     });
   });
+
+  /*******************************
+        Safety presets
+  *******************************/
+
+  describe.concurrent('Safety presets', () => {
+    it('defaults to clone', () => {
+      const signal = new Signal({ count: 0 });
+      expect(signal.safety).toBe('clone');
+    });
+
+    it('allowClone: false maps to safety: reference', () => {
+      const signal = new Signal({ count: 0 }, { allowClone: false });
+      expect(signal.safety).toBe('reference');
+    });
+
+    it('explicit safety overrides allowClone', () => {
+      const signal = new Signal({ count: 0 }, { allowClone: false, safety: 'freeze' });
+      expect(signal.safety).toBe('freeze');
+    });
+
+    describe.concurrent('clone', () => {
+      it('returns a fresh reference on every read', () => {
+        const signal = new Signal({ count: 0 }, { safety: 'clone' });
+        const a = signal.get();
+        const b = signal.get();
+        expect(a).not.toBe(b);
+        expect(a).toEqual(b);
+      });
+
+      it('does not freeze stored values', () => {
+        const signal = new Signal({ count: 0 }, { safety: 'clone' });
+        expect(Object.isFrozen(signal.peek())).toBe(false);
+      });
+    });
+
+    describe.concurrent('reference', () => {
+      it('returns the stored reference on every read', () => {
+        const value = { count: 0 };
+        const signal = new Signal(value, { safety: 'reference' });
+        expect(signal.get()).toBe(signal.get());
+      });
+
+      it('does not freeze stored values', () => {
+        const signal = new Signal({ count: 0 }, { safety: 'reference' });
+        expect(Object.isFrozen(signal.peek())).toBe(false);
+      });
+
+      it('deduplicates equal sets via isEqual', () => {
+        const callback = vi.fn();
+        const signal = new Signal({ count: 0 }, { safety: 'reference' });
+        signal.subscribe(callback);
+        Reaction.flush();
+        signal.set({ count: 0 });
+        Reaction.flush();
+        expect(callback).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    describe.concurrent('freeze', () => {
+      it('deep-freezes object values on set', () => {
+        const signal = new Signal({ count: 0, nested: { a: 1 } }, { safety: 'freeze' });
+        expect(Object.isFrozen(signal.peek())).toBe(true);
+        expect(Object.isFrozen(signal.peek().nested)).toBe(true);
+      });
+
+      it('throws on direct mutation of frozen value', () => {
+        const signal = new Signal({ count: 0 }, { safety: 'freeze' });
+        expect(() => {
+          signal.peek().count = 1;
+        }).toThrow(TypeError);
+      });
+
+      it('push rebuilds and re-freezes', () => {
+        const signal = new Signal(['a'], { safety: 'freeze' });
+        signal.push('b');
+        expect(signal.peek()).toEqual(['a', 'b']);
+        expect(Object.isFrozen(signal.peek())).toBe(true);
+      });
+
+      it('unshift rebuilds and re-freezes', () => {
+        const signal = new Signal(['b'], { safety: 'freeze' });
+        signal.unshift('a');
+        expect(signal.peek()).toEqual(['a', 'b']);
+        expect(Object.isFrozen(signal.peek())).toBe(true);
+      });
+
+      it('splice rebuilds and re-freezes', () => {
+        const signal = new Signal(['a', 'b', 'c'], { safety: 'freeze' });
+        signal.splice(1, 1);
+        expect(signal.peek()).toEqual(['a', 'c']);
+        expect(Object.isFrozen(signal.peek())).toBe(true);
+      });
+
+      it('setIndex rebuilds and re-freezes', () => {
+        const signal = new Signal(['a', 'b'], { safety: 'freeze' });
+        signal.setIndex(0, 'A');
+        expect(signal.peek()).toEqual(['A', 'b']);
+        expect(Object.isFrozen(signal.peek())).toBe(true);
+      });
+
+      it('removeIndex rebuilds and re-freezes', () => {
+        const signal = new Signal(['a', 'b', 'c'], { safety: 'freeze' });
+        signal.removeIndex(1);
+        expect(signal.peek()).toEqual(['a', 'c']);
+        expect(Object.isFrozen(signal.peek())).toBe(true);
+      });
+
+      it('setArrayProperty rebuilds matching entries', () => {
+        const signal = new Signal([{ id: 1, name: 'a' }, { id: 2, name: 'b' }], { safety: 'freeze' });
+        signal.setArrayProperty(0, 'name', 'A');
+        expect(signal.peek()[0]).toEqual({ id: 1, name: 'A' });
+        expect(signal.peek()[1]).toEqual({ id: 2, name: 'b' });
+        expect(Object.isFrozen(signal.peek()[0])).toBe(true);
+      });
+
+      it('setProperty on an object rebuilds the object', () => {
+        const signal = new Signal({ a: 1, b: 2 }, { safety: 'freeze' });
+        signal.setProperty('a', 9);
+        expect(signal.peek()).toEqual({ a: 9, b: 2 });
+        expect(Object.isFrozen(signal.peek())).toBe(true);
+      });
+
+      it('skips class instances (left unfrozen by deepFreeze)', () => {
+        class Custom {
+          constructor() {
+            this.x = 1;
+          }
+        }
+        const instance = new Custom();
+        const signal = new Signal(instance, { safety: 'freeze' });
+        expect(Object.isFrozen(signal.peek())).toBe(false);
+        signal.peek().x = 2;
+        expect(signal.peek().x).toBe(2);
+      });
+    });
+
+    describe.concurrent('none', () => {
+      it('always notifies, even on equal sets', () => {
+        const callback = vi.fn();
+        const signal = new Signal({ count: 0 }, { safety: 'none' });
+        signal.subscribe(callback);
+        Reaction.flush();
+        signal.set({ count: 0 });
+        Reaction.flush();
+        signal.set({ count: 0 });
+        Reaction.flush();
+        expect(callback).toHaveBeenCalledTimes(3);
+      });
+
+      it('does not clone or freeze', () => {
+        const value = { count: 0 };
+        const signal = new Signal(value, { safety: 'none' });
+        expect(signal.peek()).toBe(value);
+        expect(Object.isFrozen(signal.peek())).toBe(false);
+      });
+
+      it('explicit equalityFunction overrides the no-dedupe default', () => {
+        const callback = vi.fn();
+        const signal = new Signal(0, { safety: 'none', equalityFunction: (a, b) => a === b });
+        signal.subscribe(callback);
+        Reaction.flush();
+        signal.set(0);
+        Reaction.flush();
+        expect(callback).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    describe('static config', () => {
+      it('Signal.safety reads the current default', () => {
+        expect(Signal.safety).toBe('clone');
+      });
+
+      it('Signal.safety = preset routes through validation', () => {
+        const original = Signal.safety;
+        try {
+          Signal.safety = 'freeze';
+          expect(Signal.safety).toBe('freeze');
+          const signal = new Signal({});
+          expect(signal.safety).toBe('freeze');
+        }
+        finally {
+          Signal.safety = original;
+        }
+      });
+
+      it('Signal.safety = invalid throws', () => {
+        expect(() => {
+          Signal.safety = 'bogus';
+        }).toThrow(TypeError);
+      });
+
+      it('Signal.configure forwards keys through their setters', () => {
+        const original = Signal.safety;
+        try {
+          Signal.configure({ safety: 'reference' });
+          expect(Signal.safety).toBe('reference');
+        }
+        finally {
+          Signal.safety = original;
+        }
+      });
+
+      it('Signal.tracing accessor proxies to setTracing/isTracing', () => {
+        const original = Signal.tracing;
+        try {
+          Signal.tracing = true;
+          expect(Signal.tracing).toBe(true);
+          Signal.tracing = false;
+          expect(Signal.tracing).toBe(false);
+        }
+        finally {
+          Signal.tracing = original;
+        }
+      });
+
+      it('Signal.noEquality always returns false', () => {
+        expect(Signal.noEquality(1, 1)).toBe(false);
+        expect(Signal.noEquality({}, {})).toBe(false);
+      });
+    });
+  });
 });

--- a/packages/reactivity/types/signal.d.ts
+++ b/packages/reactivity/types/signal.d.ts
@@ -10,8 +10,19 @@ export interface SignalOptions<T> {
   equalityFunction?: (oldValue: T, newValue: T) => boolean;
 
   /**
-   * Whether to allow cloning of values. If false, values are stored by reference
-   * @default true
+   * Value-protection preset.
+   *   'clone' — clone on get/set (mutation isolation, current default)
+   *   'reference' — store raw (identity stable, no mutation isolation)
+   *   'freeze' — deep-freeze on set (throws on mutation at the call site)
+   *   'none' — no clone, no equality dedupe (every set notifies)
+   * @default 'clone'
+   */
+  safety?: 'clone' | 'reference' | 'freeze' | 'none';
+
+  /**
+   * Backward-compat shim: `allowClone: false` is equivalent to `safety: 'reference'`.
+   * Prefer `safety` for new code.
+   * @deprecated use `safety` instead
    */
   allowClone?: boolean;
 
@@ -453,4 +464,40 @@ export class Signal<T> {
    * Returns whether stack capture is currently enabled.
    */
   static isStackCapture(): boolean;
+
+  /**
+   * The default safety preset for new Signals when `safety` isn't passed at
+   * the call site. Set to 'clone' (default), 'reference', 'freeze', or 'none'.
+   */
+  static safety: 'clone' | 'reference' | 'freeze' | 'none';
+
+  /**
+   * Accessor form of {@link Signal.setTracing} / {@link Signal.isTracing}.
+   * `Signal.tracing = true` enables tracing; reading returns the current state.
+   */
+  static tracing: boolean;
+
+  /**
+   * Accessor form of {@link Signal.setStackCapture} / {@link Signal.isStackCapture}.
+   */
+  static stackCapture: boolean;
+
+  /**
+   * An equality function that always returns false — every set notifies.
+   * Used internally when `safety: 'none'` is set; exposed for completeness.
+   */
+  static noEquality: (a: unknown, b: unknown) => boolean;
+
+  /**
+   * Bulk static config setter. Forwards each key through the static accessors
+   * (so validation on `safety` / `tracing` / `stackCapture` runs as if the
+   * properties were set individually).
+   */
+  static configure(config: {
+    safety?: 'clone' | 'reference' | 'freeze' | 'none';
+    tracing?: boolean;
+    stackCapture?: boolean;
+    equalityFunction?: (a: unknown, b: unknown) => boolean;
+    cloneFunction?: <V>(value: V) => V;
+  }): void;
 }

--- a/packages/renderer/src/engines/lit/renderer.js
+++ b/packages/renderer/src/engines/lit/renderer.js
@@ -57,7 +57,7 @@ export class LitRenderer {
     this.inheritsData = inheritsData; // for subtrees lets us know if this needs to have data updates downstream
     this.protectedKeys = protectedKeys; // keys scoped to this subtree (loop vars, async results) that parent updates cannot overwrite
     this.id = LitRenderer.getID({ ast, data, isSVG });
-    this.dataVersion = new Signal(0, { allowClone: false, equalityFunction: () => false });
+    this.dataVersion = new Signal(0, { safety: 'none' });
 
     // Delegate expression evaluation
     this.evaluator = new ExpressionEvaluator({

--- a/packages/templating/src/template.js
+++ b/packages/templating/src/template.js
@@ -1001,7 +1001,7 @@ export const Template = class Template {
         if (property in target) {
           let signal = template.settingsVars.get(property);
           if (!signal) {
-            signal = new Signal(target[property], { allowClone: false });
+            signal = new Signal(target[property], { safety: 'reference' });
             template.settingsVars.set(property, signal);
           }
           signal.get(); // track dependency
@@ -1019,7 +1019,7 @@ export const Template = class Template {
           signal.set(value);
         }
         else {
-          signal = new Signal(value, { allowClone: false });
+          signal = new Signal(value, { safety: 'reference' });
           template.settingsVars.set(property, signal);
         }
         return true;

--- a/tools/benchmark/src/main.js
+++ b/tools/benchmark/src/main.js
@@ -5,8 +5,8 @@ import { buildData } from './store.js';
 import ast from './template.html?ast';
 
 const defaultState = {
-  rows: { value: [], options: { allowClone: false, equalityFunction: () => false } },
-  selected: { value: 0, options: { allowClone: false, equalityFunction: () => false } },
+  rows: { value: [], options: { safety: 'none' } },
+  selected: { value: 0, options: { safety: 'none' } },
 };
 
 const createComponent = ({ state }) => ({


### PR DESCRIPTION
Adds the `safety` constructor option to Signal with four presets (`clone`, `reference`, `freeze`, `none`) plus `Signal.safety` / `Signal.tracing` / `Signal.stackCapture` / `Signal.configure({...})` static config. `clone` is the current default. `allowClone: false` continues to work as a shim for `safety: 'reference'`.

Ships in three commits to isolate perf variables across CI bench checkpoints:

1. API only, default `clone` — baseline measuring the new library shape against existing contract.
2. Remove `allowClone`, migrate callsites, flip default to `freeze`.
3. Flip default to `reference`.

The bench results across the three runs inform which default ships. Intrinsic-need callsites (`dataVersion`, settings proxies, bench fixtures) are pinned across all three commits. Only default-using callsites move with the default flip.

## Risk
3/10 — `allowClone: false` consumers see no behavioral change. Default-using consumers are unchanged through commit 1. Commits 2 and 3 are the actual behavior shift, gated on bench evidence.