### PR TITLE
Feat: Signal Safety Presets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ xx.xx.xxxx
 * **Feature** - Added `{#fn expression}` directive to pass values as-is without auto-invoking functions — mirrors `{#html}` pattern, useful for passing callbacks through property bindings
 
 ### Reactivity
+* **Feature** - Added `safety` constructor option with four presets — `'clone'` (current default, mutation isolation), `'reference'` (no clone, identity stable), `'freeze'` (deep-freeze on set, mutation throws), `'none'` (no clone, no equality dedupe). `allowClone: false` continues to work as a shim for `safety: 'reference'`.
+* **Feature** - Added `Signal.safety`, `Signal.tracing`, `Signal.stackCapture` static accessors and `Signal.configure({...})` for bulk setup. `Signal.defaultEquality`, `Signal.defaultClone`, and `Signal.noEquality` expose the default function references.
+* **Feature** - Added `signal.clone()` — tracked read that returns a deep copy. Use when handing signal data to libraries that mutate in place.
 * **Feature** - Added `depend()` to register a signal as a dependency without reading the value
 * **Feature** - Added `notify()` to force-trigger subscribers bypassing the equality check
 * **Feature** - Added `hasDependents()` to check if any reactions are subscribed to a signal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,7 @@ xx.xx.xxxx
 
 ### Reactivity
 * **Feature** - Added `safety` constructor option with four presets — `'clone'` (current default, mutation isolation), `'reference'` (no clone, identity stable), `'freeze'` (deep-freeze on set, mutation throws), `'none'` (no clone, no equality dedupe). `allowClone: false` continues to work as a shim for `safety: 'reference'`.
-* **Feature** - Added `Signal.safety`, `Signal.tracing`, `Signal.stackCapture` static accessors and `Signal.configure({...})` for bulk setup. `Signal.defaultEquality`, `Signal.defaultClone`, and `Signal.noEquality` expose the default function references.
-* **Feature** - Added `signal.clone()` — tracked read that returns a deep copy. Use when handing signal data to libraries that mutate in place.
+* **Feature** - Added `Signal.safety`, `Signal.tracing`, `Signal.stackCapture` static accessors and `Signal.configure({...})` for bulk setup.
 * **Feature** - Added `depend()` to register a signal as a dependency without reading the value
 * **Feature** - Added `notify()` to force-trigger subscribers bypassing the equality check
 * **Feature** - Added `hasDependents()` to check if any reactions are subscribed to a signal

--- a/packages/reactivity/src/helpers.js
+++ b/packages/reactivity/src/helpers.js
@@ -1,41 +1,45 @@
-// Tracing mode controls debug metadata attached to Signals, Reactions, and
-// Dependencies. One field instead of two booleans — stack implies context,
-// and the impossible "stack without context" state is unrepresentable.
-//   'off'     — no context, no allocation on notify
-//   'context' — cheap: attach { firstRun, value, ... } bags for naming
-//   'stack'   — expensive: Error.captureStackTrace per notify, on top of context
-let mode = 'off';
+export const config = {
+  // debug metadata attached during notify
+  //   'off'     — zero cost; no allocation
+  //   'context' — attach { firstRun, value, ... } bags for naming
+  //   'stack'   — Error.captureStackTrace per notify, on top of context
+  mode: 'off',
 
+  // default value protection on set for new signals
+  //   'clone'     — clone on get/set (current default; mutation isolation)
+  //   'reference' — no protection; dedupe via isEqual
+  //   'freeze'    — deepFreeze on set; downstream mutations throw
+  //   'none'      — no protection, no dedupe (event-stream semantics)
+  safety: 'clone',
+};
+
+// Function-form tracing API kept alongside the static accessors on Signal so
+// existing function imports keep working.
 export const setTracing = (enabled) => {
   if (enabled) {
-    if (mode === 'off') { mode = 'context'; }
+    if (config.mode === 'off') { config.mode = 'context'; }
   }
   else {
-    mode = 'off';
+    config.mode = 'off';
   }
 };
 
 export const setStackCapture = (enabled) => {
   if (enabled) {
-    mode = 'stack';
+    config.mode = 'stack';
   }
-  else if (mode === 'stack') {
-    mode = 'context';
+  else if (config.mode === 'stack') {
+    config.mode = 'context';
   }
 };
 
-export const isTracing = () => mode !== 'off';
-export const isStackCapture = () => mode === 'stack';
+export const isTracing = () => config.mode !== 'off';
+export const isStackCapture = () => config.mode === 'stack';
 
-// Capture a stack trace into target.context. Passes `caller` to
-// Error.captureStackTrace so the framework frame is trimmed from the trace.
+// `caller` is passed to Error.captureStackTrace so the framework frame is trimmed from the trace
 export const captureStack = (target, caller) => {
-  if (mode !== 'stack') {
-    return;
-  }
-  if (!target.context) {
-    target.context = {};
-  }
+  if (config.mode !== 'stack') { return; }
+  if (!target.context) { target.context = {}; }
   if (Error.captureStackTrace) {
     Error.captureStackTrace(target.context, caller);
   }
@@ -43,3 +47,6 @@ export const captureStack = (target, caller) => {
     target.context.stack = new Error().stack;
   }
 };
+
+// solves 'instanceof Signal' checks if across realms or package duplication
+export const signalTag = Symbol.for('semantic-ui/Signal');

--- a/packages/reactivity/src/signal.js
+++ b/packages/reactivity/src/signal.js
@@ -1,124 +1,114 @@
 import {
   clone,
+  deepFreeze,
   isArray,
   isClassInstance,
   isDevelopment,
   isEqual,
   isNumber,
   isObject,
+  isPlainObject,
   unique,
   wrapFunction,
 } from '@semantic-ui/utils';
 
 import { Dependency } from './dependency.js';
-import { captureStack, isStackCapture, isTracing, setStackCapture, setTracing } from './helpers.js';
+import { captureStack, config, signalTag } from './helpers.js';
 import { Reaction } from './reaction.js';
 
-const IS_SIGNAL = Symbol.for('semantic-ui/Signal');
+const devProxyCache = new WeakMap();
+
+const frozenTraps = {
+  set(_, prop) {
+    throw frozenError(prop);
+  },
+  deleteProperty(_, prop) {
+    throw frozenError(prop);
+  },
+  defineProperty(_, prop) {
+    throw frozenError(prop);
+  },
+  setPrototypeOf() {
+    throw frozenError('[[Prototype]]');
+  },
+};
+
+function frozenError(prop) {
+  return new TypeError(
+    `Signal value is frozen — cannot set property \`${String(prop)}\`. `
+      + `Use signal.set(newValue), a mutation helper (push, splice, setProperty), `
+      + `or construct with { safety: 'reference' } if storing third-party data.`,
+  );
+}
+
+function devProxyFor(val) {
+  let proxy = devProxyCache.get(val);
+  if (!proxy) { devProxyCache.set(val, proxy = new Proxy(val, frozenTraps)); }
+  return proxy;
+}
 
 export class Signal {
-  get [IS_SIGNAL]() {
-    return true;
-  }
-  static [Symbol.hasInstance](instance) {
-    return !!instance?.[IS_SIGNAL];
-  }
+  constructor(initialValue, options = {}) {
+    const { context, safety, equalityFunction, cloneFunction, allowClone } = options;
 
-  constructor(initialValue, { context, equalityFunction, allowClone = true, cloneFunction } = {}) {
-    // pass in some metadata for debugging
     this.dependency = new Dependency({
       firstRun: true,
       value: initialValue,
     });
 
-    // allow user to opt out of value cloning
-    this.allowClone = allowClone;
+    // allowClone: false is a back-compat shim for safety: 'reference'
+    this.safety = safety ?? (allowClone === false ? 'reference' : config.safety);
 
-    // allow custom equality function
-    this.equalityFunction = (equalityFunction)
+    this.equalityFunction = equalityFunction
       ? wrapFunction(equalityFunction)
-      : Signal.equalityFunction;
+      : (this.safety === 'none' ? Signal.noEquality : Signal.defaultEquality);
 
-    // allow custom clone function
-    this.clone = (cloneFunction)
+    this.cloneFunction = cloneFunction
       ? wrapFunction(cloneFunction)
-      : Signal.cloneFunction;
+      : Signal.defaultClone;
 
-    this.currentValue = this.maybeClone(initialValue);
+    this.currentValue = this.protect(initialValue);
 
-    // allow debugging context to be set
     this.setContext(context);
   }
 
-  // set debugging context for signal removing any present context
-  setContext(additionalContext = {}) {
-    if (!isTracing()) {
-      return;
-    }
-    const defaultContext = {
-      value: this.currentValue,
-    };
-    this.context = {
-      ...defaultContext,
-      ...additionalContext,
-    };
+  /*-------------------
+          Core
+  --------------------*/
+
+  protect(value) {
+    if (value === null || typeof value !== 'object') { return value; }
+    if (this.safety === 'freeze') { return deepFreeze(value); }
+    if (this.safety === 'clone') { return this.maybeClone(value); }
+    return value;
   }
 
-  // add context to signal
-  addContext(additionalContext = {}) {
-    if (!isTracing()) {
-      return;
-    }
-    if (!this.context) {
-      this.context = {};
-    }
-    for (const key in additionalContext) {
-      this.context[key] = additionalContext[key];
-    }
-  }
-
-  // Stack trace capture is gated separately because Error.captureStackTrace
-  // costs ~10-100× a context spread, paid per Signal.notify in tracing-on
-  // dev. Default off; opt in via setStackCapture(true).
-  setTrace() {
-    captureStack(this, this.setTrace);
-  }
-
-  static equalityFunction = isEqual;
-  static cloneFunction = clone;
-  static setTracing = setTracing;
-  static isTracing = isTracing;
-  static setStackCapture = setStackCapture;
-  static isStackCapture = isStackCapture;
-
-  get value() {
-    // Record this Signal as a dependency if inside a Reaction computation
-    this.depend();
-    const value = this.currentValue;
-
-    // otherwise previous value would be modified if the returned value is mutated negating the equality
-    return (value !== null && typeof value == 'object')
-      ? this.maybeClone(value)
-      : value;
-  }
-
-  canCloneValue(value) {
-    return (this.allowClone === true && !isClassInstance(value));
-  }
-
+  // Recursive clone that skips class instances, mirroring main's pre-safety
+  // maybeClone path. Only used when safety === 'clone'.
   maybeClone(value) {
-    if (!this.canCloneValue(value)) {
+    if (value === null || typeof value !== 'object' || isClassInstance(value)) {
       return value;
     }
     if (isArray(value)) {
-      return value.map(value => this.maybeClone(value));
+      return value.map(v => this.maybeClone(v));
     }
-    return this.clone(value);
+    return this.cloneFunction(value);
+  }
+
+  get value() {
+    this.depend();
+    const val = this.currentValue;
+    if (val === null || typeof val !== 'object') { return val; }
+    if (this.safety === 'clone') { return this.maybeClone(val); }
+    if (this.safety === 'freeze' && config.mode !== 'off') {
+      if (isArray(val) || isPlainObject(val)) { return devProxyFor(val); }
+    }
+    return val;
   }
 
   set value(newValue) {
     if (!this.equalityFunction(this.currentValue, newValue)) {
-      this.currentValue = this.maybeClone(newValue);
+      this.currentValue = this.protect(newValue);
       this.notify();
     }
   }
@@ -132,8 +122,20 @@ export class Signal {
   }
 
   set(newValue) {
-    // equality check in setter
     this.value = newValue;
+  }
+
+  peek() {
+    if (this.safety === 'clone') {
+      const val = this.currentValue;
+      return (val !== null && typeof val === 'object') ? this.maybeClone(val) : val;
+    }
+    return this.currentValue;
+  }
+
+  clone() {
+    this.depend();
+    return this.cloneFunction(this.currentValue);
   }
 
   subscribe(callback) {
@@ -142,10 +144,36 @@ export class Signal {
     });
   }
 
-  // derive a new signal from this signal's value
+  depend() {
+    this.dependency.depend();
+  }
+
+  notify() {
+    if (config.mode !== 'off') {
+      this.setContext();
+      this.setTrace();
+    }
+    this.dependency.changed(this.context);
+  }
+
+  hasDependents() {
+    return this.dependency.subscribers.size > 0;
+  }
+
+  clear() {
+    return this.set(undefined);
+  }
+
+  /*-------------------
+         Complex
+  --------------------*/
+
+  // derive/computed below use WeakRef on the *derived/computed* signal so the
+  // reaction's closure doesn't pin it through source.dep.subscribers, plus
+  // onCleanup against the parent Reaction so inner reactions stop when the
+  // outer re-runs (leak fix from #201).
   derive(computeFn, options = {}) {
     const derivedSignal = new Signal(undefined, options);
-    // weak so the reaction's closure doesn't pin derived through source.dep.subscribers
     const derivedRef = new WeakRef(derivedSignal);
     const source = this;
 
@@ -165,7 +193,6 @@ export class Signal {
     return derivedSignal;
   }
 
-  // static method for computing from multiple signals
   static computed(computeFn, options = {}) {
     const computedSignal = new Signal(undefined, options);
     const computedRef = new WeakRef(computedSignal);
@@ -186,89 +213,108 @@ export class Signal {
     return computedSignal;
   }
 
-  depend() {
-    this.dependency.depend();
-  }
+  /*-------------------
+     Mutation Helpers
+  --------------------*/
 
-  notify() {
-    // Each gate handles itself — setContext on isTracing, setTrace on
-    // isStackCapture. Hot path: both early-return when their flag is off.
-    this.setContext();
-    this.setTrace();
-    this.dependency.changed(this.context);
-  }
-
-  hasDependents() {
-    return this.dependency.subscribers.size > 0;
-  }
-
-  peek() {
-    return this.maybeClone(this.currentValue);
-  }
-
-  clear() {
-    return this.set(undefined);
-  }
-
-  // mutate the current value by a mutation function
-  mutate(mutationFn) {
-    // we use clone in all cases to detect for changes only
-    const beforeClone = this.clone(this.currentValue);
-    const result = mutationFn(this.currentValue);
-
+  mutate(fn) {
+    // freeze: fn must return a new value (in-place throws).
+    // clone/reference/none: fn may mutate in place; dedupe via equalityFunction.
+    if (this.safety === 'freeze') {
+      const result = fn(this.currentValue);
+      if (result !== undefined) {
+        this.value = result;
+      }
+      else {
+        this.notify();
+      }
+      return;
+    }
+    const before = this.cloneFunction(this.currentValue);
+    const result = fn(this.currentValue);
     if (result !== undefined) {
       if (isDevelopment && result === this.currentValue) {
         console.warn(
           'Signal.mutate: returning the same reference that was mutated in place will bypass change detection. Either mutate without returning, or return a new value.',
         );
       }
-      // if the mutation returned a value just set it
       this.value = result;
     }
-    else {
-      // if no value returned check if the value changed from side effects
-      // in this case we want to trigger reactivity
-      if (!this.equalityFunction(beforeClone, this.currentValue)) {
-        this.notify();
-      }
+    else if (!this.equalityFunction(before, this.currentValue)) {
+      this.notify();
     }
   }
 
-  // array helpers — these always change the value, skip clone+compare
   push(...args) {
-    this.currentValue.push(...args);
+    if (this.safety === 'freeze') {
+      this.currentValue = this.protect([...this.currentValue, ...args]);
+    }
+    else {
+      this.currentValue.push(...args);
+    }
     this.notify();
   }
+
   unshift(...args) {
-    this.currentValue.unshift(...args);
+    if (this.safety === 'freeze') {
+      this.currentValue = this.protect([...args, ...this.currentValue]);
+    }
+    else {
+      this.currentValue.unshift(...args);
+    }
     this.notify();
   }
+
   splice(...args) {
-    this.currentValue.splice(...args);
+    if (this.safety === 'freeze') {
+      const next = [...this.currentValue];
+      next.splice(...args);
+      this.currentValue = this.protect(next);
+    }
+    else {
+      this.currentValue.splice(...args);
+    }
     this.notify();
   }
+
   map(mapFunction) {
-    this.currentValue = Array.prototype.map.call(this.currentValue, mapFunction);
+    this.currentValue = this.protect(Array.prototype.map.call(this.currentValue, mapFunction));
     this.notify();
   }
+
   filter(filterFunction) {
-    this.currentValue = Array.prototype.filter.call(this.currentValue, filterFunction);
+    this.currentValue = this.protect(Array.prototype.filter.call(this.currentValue, filterFunction));
     this.notify();
   }
 
   getIndex(index) {
     return this.get()[index];
   }
+
   setIndex(index, value) {
-    this.currentValue[index] = value;
-    this.notify();
-  }
-  removeIndex(index) {
-    this.currentValue.splice(index, 1);
+    if (this.safety === 'freeze') {
+      const next = [...this.currentValue];
+      next[index] = value;
+      this.currentValue = this.protect(next);
+    }
+    else {
+      this.currentValue[index] = value;
+    }
     this.notify();
   }
 
-  // sets
+  removeIndex(index) {
+    if (this.safety === 'freeze') {
+      const next = [...this.currentValue];
+      next.splice(index, 1);
+      this.currentValue = this.protect(next);
+    }
+    else {
+      this.currentValue.splice(index, 1);
+    }
+    this.notify();
+  }
+
   setArrayProperty(indexOrProperty, property, value) {
     let index;
     if (isNumber(indexOrProperty)) {
@@ -279,16 +325,26 @@ export class Signal {
       value = property;
       property = indexOrProperty;
     }
-    if (index === -1) {
-      return;
+    if (index === -1) { return; }
+
+    if (this.safety === 'freeze') {
+      const newValue = this.currentValue.map((object, currentIndex) => {
+        if (index === 'all' || currentIndex === index) {
+          return { ...object, [property]: value };
+        }
+        return object;
+      });
+      this.set(newValue);
     }
-    const newValue = this.peek().map((object, currentIndex) => {
-      if (index == 'all' || currentIndex == index) {
-        object[property] = value;
+    else {
+      const arr = this.currentValue;
+      for (let i = 0; i < arr.length; i++) {
+        if (index === 'all' || i === index) {
+          arr[i][property] = value;
+        }
       }
-      return object;
-    });
-    this.set(newValue);
+      this.notify();
+    }
   }
 
   toggle() {
@@ -298,18 +354,15 @@ export class Signal {
   increment(amount = 1, max) {
     return this.mutate(val => {
       let newAmount = val + amount;
-      if (isNumber(max) && newAmount > max) {
-        newAmount = max;
-      }
+      if (isNumber(max) && newAmount > max) { newAmount = max; }
       return newAmount;
     });
   }
+
   decrement(amount = 1, min) {
     return this.mutate(val => {
       let newAmount = val - amount;
-      if (isNumber(min) && newAmount < min) {
-        newAmount = min;
-      }
+      if (isNumber(min) && newAmount < min) { newAmount = min; }
       return newAmount;
     });
   }
@@ -318,27 +371,29 @@ export class Signal {
     return this.mutate(() => new Date());
   }
 
+  // id-lookup hot path (Krausest keyed-array path) — id checked first and a
+  // raw for loop in getItemIndex to avoid the findIndex callback allocation.
   getIDs(item) {
-    if (!isObject(item)) {
-      return [item];
-    }
+    if (!isObject(item)) { return [item]; }
     return unique([item.id, item._id, item.hash, item.key].filter(Boolean));
   }
+
   getID(item) {
-    if (!isObject(item)) {
-      return item;
-    }
+    if (!isObject(item)) { return item; }
     return item.id || item._id || item.hash || item.key;
   }
+
   hasID(item, id) {
     return this.getID(item) === id;
   }
+
   getItem(id) {
     const index = this.getItemIndex(id);
     if (index !== -1) {
       return this.getIndex(index);
     }
   }
+
   getItemIndex(id) {
     const arr = this.currentValue;
     for (let i = 0; i < arr.length; i++) {
@@ -346,6 +401,7 @@ export class Signal {
     }
     return -1;
   }
+
   setProperty(idOrProperty, property, value) {
     if (isArray(this.currentValue)) {
       const id = idOrProperty;
@@ -355,15 +411,102 @@ export class Signal {
     else {
       value = property;
       property = idOrProperty;
-      const obj = this.peek();
-      obj[property] = value;
-      this.set(obj);
+      if (this.safety === 'freeze') {
+        this.set({ ...this.currentValue, [property]: value });
+      }
+      else {
+        this.currentValue[property] = value;
+        this.notify();
+      }
     }
   }
+
   replaceItem(id, item) {
     return this.setIndex(this.getItemIndex(id), item);
   }
+
   removeItem(id) {
     return this.removeIndex(this.getItemIndex(id));
+  }
+
+  /*-------------------
+         Tracing
+  --------------------*/
+
+  setContext(additionalContext = {}) {
+    if (config.mode === 'off') { return; }
+    const defaultContext = {
+      value: this.currentValue,
+    };
+    this.context = {
+      ...defaultContext,
+      ...additionalContext,
+    };
+  }
+
+  addContext(additionalContext = {}) {
+    if (config.mode === 'off') { return; }
+    if (!this.context) { this.context = {}; }
+    for (const key in additionalContext) {
+      this.context[key] = additionalContext[key];
+    }
+  }
+
+  // Error.captureStackTrace is 10-100× a context spread; gated on stack mode.
+  setTrace() {
+    captureStack(this, this.setTrace);
+  }
+
+  /*-------------------
+      Instance of
+  --------------------*/
+
+  static [Symbol.hasInstance](instance) {
+    return !!instance?.[signalTag];
+  }
+
+  get [signalTag]() {
+    return true;
+  }
+
+  /*-------------------
+      Configuration
+  --------------------*/
+
+  static defaultEquality = isEqual;
+  static defaultClone = clone;
+  static noEquality = () => false;
+  // Back-compat aliases for the pre-safety static names.
+  static equalityFunction = isEqual;
+  static cloneFunction = clone;
+
+  static get safety() {
+    return config.safety;
+  }
+  static set safety(preset) {
+    if (preset !== 'clone' && preset !== 'freeze' && preset !== 'reference' && preset !== 'none') {
+      throw new Error(`Invalid Signal.safety: ${preset}. Must be 'clone', 'freeze', 'reference', or 'none'.`);
+    }
+    config.safety = preset;
+  }
+
+  static get tracing() {
+    return config.mode !== 'off';
+  }
+  static set tracing(enabled) {
+    if (enabled && config.mode === 'off') { config.mode = 'context'; }
+    else if (!enabled) { config.mode = 'off'; }
+  }
+
+  static get stackCapture() {
+    return config.mode === 'stack';
+  }
+  static set stackCapture(enabled) {
+    if (enabled) { config.mode = 'stack'; }
+    else if (config.mode === 'stack') { config.mode = 'context'; }
+  }
+
+  static configure(config = {}) {
+    Object.assign(Signal, config);
   }
 }

--- a/packages/reactivity/src/signal.js
+++ b/packages/reactivity/src/signal.js
@@ -61,11 +61,12 @@ export class Signal {
 
     this.equalityFunction = equalityFunction
       ? wrapFunction(equalityFunction)
-      : (this.safety === 'none' ? Signal.noEquality : Signal.defaultEquality);
+      : (this.safety === 'none' ? Signal.noEquality : Signal.equalityFunction);
 
-    this.cloneFunction = cloneFunction
+    // field named `clone` to match main's hidden class shape
+    this.clone = cloneFunction
       ? wrapFunction(cloneFunction)
-      : Signal.defaultClone;
+      : Signal.cloneFunction;
 
     this.currentValue = this.protect(initialValue);
 
@@ -92,7 +93,7 @@ export class Signal {
     if (isArray(value)) {
       return value.map(v => this.maybeClone(v));
     }
-    return this.cloneFunction(value);
+    return this.clone(value);
   }
 
   get value() {
@@ -131,11 +132,6 @@ export class Signal {
       return (val !== null && typeof val === 'object') ? this.maybeClone(val) : val;
     }
     return this.currentValue;
-  }
-
-  clone() {
-    this.depend();
-    return this.cloneFunction(this.currentValue);
   }
 
   subscribe(callback) {
@@ -230,7 +226,7 @@ export class Signal {
       }
       return;
     }
-    const before = this.cloneFunction(this.currentValue);
+    const before = this.clone(this.currentValue);
     const result = fn(this.currentValue);
     if (result !== undefined) {
       if (isDevelopment && result === this.currentValue) {
@@ -473,12 +469,9 @@ export class Signal {
       Configuration
   --------------------*/
 
-  static defaultEquality = isEqual;
-  static defaultClone = clone;
-  static noEquality = () => false;
-  // Back-compat aliases for the pre-safety static names.
   static equalityFunction = isEqual;
   static cloneFunction = clone;
+  static noEquality = () => false;
 
   static get safety() {
     return config.safety;

--- a/packages/reactivity/test/unit/signal.test.js
+++ b/packages/reactivity/test/unit/signal.test.js
@@ -1856,4 +1856,294 @@ describe('Signal API', () => {
       expect(() => signal.push('x')).toThrow();
     });
   });
+
+  /*******************************
+        Safety presets
+  *******************************/
+
+  describe.concurrent('Safety presets', () => {
+    it('defaults to clone', () => {
+      const signal = new Signal({ count: 0 });
+      expect(signal.safety).toBe('clone');
+    });
+
+    it('allowClone: false maps to safety: reference', () => {
+      const signal = new Signal({ count: 0 }, { allowClone: false });
+      expect(signal.safety).toBe('reference');
+    });
+
+    it('explicit safety overrides allowClone', () => {
+      const signal = new Signal({ count: 0 }, { allowClone: false, safety: 'freeze' });
+      expect(signal.safety).toBe('freeze');
+    });
+
+    describe.concurrent('reference', () => {
+      it('returns the stored reference on every read', () => {
+        const value = { count: 0 };
+        const signal = new Signal(value, { safety: 'reference' });
+        expect(signal.get()).toBe(signal.get());
+      });
+
+      it('does not freeze stored values', () => {
+        const signal = new Signal({ count: 0 }, { safety: 'reference' });
+        expect(Object.isFrozen(signal.peek())).toBe(false);
+      });
+
+      it('deduplicates equal sets via isEqual', () => {
+        const callback = vi.fn();
+        const signal = new Signal({ count: 0 }, { safety: 'reference' });
+        signal.subscribe(callback);
+        Reaction.flush();
+        signal.set({ count: 0 });
+        Reaction.flush();
+        expect(callback).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    describe.concurrent('freeze', () => {
+      it('deep-freezes object values on set', () => {
+        const signal = new Signal({ count: 0, nested: { a: 1 } }, { safety: 'freeze' });
+        expect(Object.isFrozen(signal.peek())).toBe(true);
+        expect(Object.isFrozen(signal.peek().nested)).toBe(true);
+      });
+
+      it('throws on direct mutation of frozen value', () => {
+        const signal = new Signal({ count: 0 }, { safety: 'freeze' });
+        expect(() => {
+          signal.peek().count = 1;
+        }).toThrow(TypeError);
+      });
+
+      it('push rebuilds and re-freezes', () => {
+        const signal = new Signal(['a'], { safety: 'freeze' });
+        signal.push('b');
+        expect(signal.peek()).toEqual(['a', 'b']);
+        expect(Object.isFrozen(signal.peek())).toBe(true);
+      });
+
+      it('unshift rebuilds and re-freezes', () => {
+        const signal = new Signal(['b'], { safety: 'freeze' });
+        signal.unshift('a');
+        expect(signal.peek()).toEqual(['a', 'b']);
+        expect(Object.isFrozen(signal.peek())).toBe(true);
+      });
+
+      it('splice rebuilds and re-freezes', () => {
+        const signal = new Signal(['a', 'b', 'c'], { safety: 'freeze' });
+        signal.splice(1, 1);
+        expect(signal.peek()).toEqual(['a', 'c']);
+        expect(Object.isFrozen(signal.peek())).toBe(true);
+      });
+
+      it('setIndex rebuilds and re-freezes', () => {
+        const signal = new Signal(['a', 'b'], { safety: 'freeze' });
+        signal.setIndex(0, 'A');
+        expect(signal.peek()).toEqual(['A', 'b']);
+        expect(Object.isFrozen(signal.peek())).toBe(true);
+      });
+
+      it('removeIndex rebuilds and re-freezes', () => {
+        const signal = new Signal(['a', 'b', 'c'], { safety: 'freeze' });
+        signal.removeIndex(1);
+        expect(signal.peek()).toEqual(['a', 'c']);
+        expect(Object.isFrozen(signal.peek())).toBe(true);
+      });
+
+      it('setArrayProperty rebuilds matching entries', () => {
+        const signal = new Signal([{ id: 1, name: 'a' }, { id: 2, name: 'b' }], { safety: 'freeze' });
+        signal.setArrayProperty(0, 'name', 'A');
+        expect(signal.peek()[0]).toEqual({ id: 1, name: 'A' });
+        expect(signal.peek()[1]).toEqual({ id: 2, name: 'b' });
+        expect(Object.isFrozen(signal.peek()[0])).toBe(true);
+      });
+
+      it('setProperty on an object rebuilds the object', () => {
+        const signal = new Signal({ a: 1, b: 2 }, { safety: 'freeze' });
+        signal.setProperty('a', 9);
+        expect(signal.peek()).toEqual({ a: 9, b: 2 });
+        expect(Object.isFrozen(signal.peek())).toBe(true);
+      });
+
+      it('skips class instances (left unfrozen by deepFreeze)', () => {
+        class Custom {
+          constructor() {
+            this.x = 1;
+          }
+        }
+        const instance = new Custom();
+        const signal = new Signal(instance, { safety: 'freeze' });
+        expect(Object.isFrozen(signal.peek())).toBe(false);
+        signal.peek().x = 2;
+        expect(signal.peek().x).toBe(2);
+      });
+
+      it('throws under mutate when fn tries to mutate in place', () => {
+        const signal = new Signal([1, 2, 3], { safety: 'freeze' });
+        expect(() => {
+          signal.mutate(arr => {
+            arr.push(4);
+          });
+        }).toThrow(TypeError);
+      });
+
+      it('accepts a returned new value', () => {
+        const signal = new Signal([1, 2, 3], { safety: 'freeze' });
+        signal.mutate(() => [4, 5, 6]);
+        expect(signal.get()).toEqual([4, 5, 6]);
+      });
+    });
+
+    describe.concurrent('none', () => {
+      it('always notifies, even on equal sets', () => {
+        const callback = vi.fn();
+        const signal = new Signal({ count: 0 }, { safety: 'none' });
+        signal.subscribe(callback);
+        Reaction.flush();
+        signal.set({ count: 0 });
+        Reaction.flush();
+        signal.set({ count: 0 });
+        Reaction.flush();
+        expect(callback).toHaveBeenCalledTimes(3);
+      });
+
+      it('does not clone or freeze', () => {
+        const value = { count: 0 };
+        const signal = new Signal(value, { safety: 'none' });
+        expect(signal.peek()).toBe(value);
+        expect(Object.isFrozen(signal.peek())).toBe(false);
+      });
+
+      it('explicit equalityFunction overrides the no-dedupe default', () => {
+        const callback = vi.fn();
+        const signal = new Signal(0, { safety: 'none', equalityFunction: (a, b) => a === b });
+        signal.subscribe(callback);
+        Reaction.flush();
+        signal.set(0);
+        Reaction.flush();
+        expect(callback).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    describe('static config', () => {
+      it('Signal.safety reads the current default', () => {
+        expect(Signal.safety).toBe('clone');
+      });
+
+      it('Signal.safety = preset routes through validation', () => {
+        const original = Signal.safety;
+        try {
+          Signal.safety = 'freeze';
+          expect(Signal.safety).toBe('freeze');
+          const signal = new Signal({});
+          expect(signal.safety).toBe('freeze');
+        }
+        finally {
+          Signal.safety = original;
+        }
+      });
+
+      it('Signal.safety = invalid throws', () => {
+        expect(() => {
+          Signal.safety = 'bogus';
+        }).toThrow();
+      });
+
+      it('Signal.configure forwards keys through their setters', () => {
+        const original = Signal.safety;
+        try {
+          Signal.configure({ safety: 'reference' });
+          expect(Signal.safety).toBe('reference');
+        }
+        finally {
+          Signal.safety = original;
+        }
+      });
+
+      it('Signal.tracing accessor proxies to setTracing/isTracing', () => {
+        const original = Signal.tracing;
+        try {
+          Signal.tracing = true;
+          expect(Signal.tracing).toBe(true);
+          Signal.tracing = false;
+          expect(Signal.tracing).toBe(false);
+        }
+        finally {
+          Signal.tracing = original;
+        }
+      });
+
+      it('Signal.noEquality always returns false', () => {
+        expect(Signal.noEquality(1, 1)).toBe(false);
+        expect(Signal.noEquality({}, {})).toBe(false);
+      });
+    });
+  });
+
+  /*******************************
+    Dev-mode freeze error decoration
+  *******************************/
+
+  // Sequential — toggling Signal.tracing is global state.
+  describe('Dev-mode freeze error decoration', () => {
+    it('returns raw frozen value when tracing is off', () => {
+      const signal = new Signal({ a: 1 }, { safety: 'freeze' });
+      expect(signal.get()).toBe(signal.peek());
+    });
+
+    it('returns a proxy with a framework-authored error when tracing is on', () => {
+      Signal.tracing = true;
+      try {
+        const signal = new Signal({ a: 1 }, { safety: 'freeze' });
+        const proxy = signal.get();
+        expect(proxy).not.toBe(signal.peek());
+        expect(() => {
+          proxy.a = 2;
+        }).toThrow(/Signal value is frozen.*`a`/s);
+        expect(() => {
+          delete proxy.a;
+        }).toThrow(/Signal value is frozen/);
+      }
+      finally {
+        Signal.tracing = false;
+      }
+    });
+
+    it('caches the proxy per raw value so get() === get()', () => {
+      Signal.tracing = true;
+      try {
+        const signal = new Signal({ a: 1 }, { safety: 'freeze' });
+        expect(signal.get()).toBe(signal.get());
+      }
+      finally {
+        Signal.tracing = false;
+      }
+    });
+
+    it('returns raw for reference-safety signals even in dev', () => {
+      Signal.tracing = true;
+      try {
+        const signal = new Signal({ a: 1 }, { safety: 'reference' });
+        const value = signal.get();
+        expect(value).toBe(signal.peek());
+        expect(() => {
+          value.a = 2;
+        }).not.toThrow();
+      }
+      finally {
+        Signal.tracing = false;
+      }
+    });
+
+    it('returns raw for Map/Set/Date/class values (outside deepFreeze scope)', () => {
+      Signal.tracing = true;
+      try {
+        const map = new Map();
+        const signal = new Signal(map, { safety: 'freeze' });
+        expect(signal.get()).toBe(map);
+      }
+      finally {
+        Signal.tracing = false;
+      }
+    });
+  });
 });

--- a/packages/reactivity/types/signal.d.ts
+++ b/packages/reactivity/types/signal.d.ts
@@ -473,15 +473,21 @@ export class Signal<T> {
 
   /**
    * Default equality function used to dedupe signal writes. Assign to
-   * override library-wide: `Signal.defaultEquality = myEq`.
+   * override library-wide: `Signal.equalityFunction = myEq`.
    */
-  static defaultEquality: (a: any, b: any) => boolean;
+  static equalityFunction: (a: any, b: any) => boolean;
 
   /**
-   * Default clone function used by `signal.clone()`. Assign to override
-   * library-wide: `Signal.defaultClone = myClone`.
+   * Default clone function used by mutate-detection and explicit cloning.
+   * Assign to override library-wide: `Signal.cloneFunction = myClone`.
    */
-  static defaultClone: <V>(value: V) => V;
+  static cloneFunction: <V>(value: V) => V;
+
+  /**
+   * An equality function that always returns false — every set notifies.
+   * Used internally when `safety: 'none'` is set; exposed for completeness.
+   */
+  static noEquality: (a: unknown, b: unknown) => boolean;
 
   /**
    * Bulk-configure library defaults. Equivalent to assigning each key
@@ -491,7 +497,7 @@ export class Signal<T> {
     safety?: 'clone' | 'reference' | 'freeze' | 'none';
     tracing?: boolean;
     stackCapture?: boolean;
-    defaultEquality?: (a: any, b: any) => boolean;
-    defaultClone?: <V>(value: V) => V;
+    equalityFunction?: (a: any, b: any) => boolean;
+    cloneFunction?: <V>(value: V) => V;
   }): void;
 }

--- a/packages/reactivity/types/signal.d.ts
+++ b/packages/reactivity/types/signal.d.ts
@@ -10,13 +10,23 @@ export interface SignalOptions<T> {
   equalityFunction?: (oldValue: T, newValue: T) => boolean;
 
   /**
-   * Whether to allow cloning of values. If false, values are stored by reference
-   * @default true
+   * Safety preset controlling how the signal protects its value
+   *  - 'clone' (default) — clone on get/set (mutation isolation)
+   *  - 'reference' — no protection; dedupe via isEqual
+   *  - 'freeze' — deepFreeze on set; mutations throw
+   *  - 'none' — no protection, no dedupe (event-stream semantics)
+   */
+  safety?: 'clone' | 'reference' | 'freeze' | 'none';
+
+  /**
+   * Backward-compat shim: `allowClone: false` is equivalent to `safety: 'reference'`.
+   * Prefer `safety` for new code.
+   * @deprecated use `safety` instead
    */
   allowClone?: boolean;
 
   /**
-   * Custom function to clone values when storing or retrieving from the signal
+   * Custom function to clone values (used by signal.clone())
    * @param value - The value to clone
    */
   cloneFunction?: <V>(value: V) => V;
@@ -130,9 +140,19 @@ export class Signal<T> {
   /**
    * Returns the current value without establishing a reactive dependency.
    * Accessing the value with `peek()` will not cause any reactive context to depend on this Signal.
+   * Under `safety: 'freeze'`, the returned reference is frozen — use `clone()`
+   * if you need a mutable copy.
    * @see {@link https://next.semantic-ui.com/docs/api/reactivity/signal#peek peek}
    */
   peek(): T;
+
+  /**
+   * Tracked read that returns a deep copy of the current value. Use when
+   * handing signal data to libraries that mutate in place, or when the
+   * signal has `safety: 'freeze'` and you need a mutable working copy.
+   * @see {@link https://next.semantic-ui.com/docs/api/reactivity/signal#clone clone}
+   */
+  clone(): T;
 
   /**
    * Sets the signal's value to undefined.
@@ -152,9 +172,12 @@ export class Signal<T> {
   subscribe(callback: (value: T, computation: { stop: () => void; }) => void): { stop: () => void; };
 
   /**
-   * Mutates the current value in-place via a callback function.
-   * If the callback returns a value, that value is set. Otherwise the original
-   * value is kept and reactivity is triggered if it changed.
+   * Mutates the current value via a callback function. Under `safety: 'freeze'`
+   * the callback receives a frozen value and must return a new value (in-place
+   * mutation throws). Under `safety: 'reference'` / `'none'` the callback may
+   * mutate in place; a returned non-undefined value replaces the current value,
+   * while undefined-return triggers notify when the value actually changed
+   * (`'reference'`) or unconditionally (`'none'`, event-stream semantics).
    * @see {@link https://next.semantic-ui.com/docs/api/reactivity/signal#mutate mutate}
    * @param mutationFn - Function that receives the current value and optionally returns a new value
    */
@@ -430,27 +453,45 @@ export class Signal<T> {
   static computed<T>(computeFn: () => T, options?: SignalOptions<T>): Signal<T>;
 
   /**
-   * Enables or disables tracing — cheap debug context attached to signals,
-   * reactions, and dependencies. Off by default.
-   * @param enabled - Whether to enable tracing
+   * Default safety preset for new signals. Assign a preset to change the
+   * library-wide default: `Signal.safety = 'freeze'`.
    */
-  static setTracing(enabled: boolean): void;
+  static safety: 'clone' | 'reference' | 'freeze' | 'none';
 
   /**
-   * Returns whether tracing is currently enabled.
+   * Cheap debug context attached to signals, reactions, and dependencies.
+   * Off by default. Assign to toggle: `Signal.tracing = true`.
    */
-  static isTracing(): boolean;
+  static tracing: boolean;
 
   /**
-   * Enables or disables stack capture — adds stack traces to tracing
-   * context via Error.captureStackTrace. Expensive; opt-in on top of tracing.
-   * Off by default.
-   * @param enabled - Whether to enable stack capture
+   * Adds stack traces to tracing context via Error.captureStackTrace.
+   * Expensive; opt-in on top of tracing. Assign to toggle:
+   * `Signal.stackCapture = true`.
    */
-  static setStackCapture(enabled: boolean): void;
+  static stackCapture: boolean;
 
   /**
-   * Returns whether stack capture is currently enabled.
+   * Default equality function used to dedupe signal writes. Assign to
+   * override library-wide: `Signal.defaultEquality = myEq`.
    */
-  static isStackCapture(): boolean;
+  static defaultEquality: (a: any, b: any) => boolean;
+
+  /**
+   * Default clone function used by `signal.clone()`. Assign to override
+   * library-wide: `Signal.defaultClone = myClone`.
+   */
+  static defaultClone: <V>(value: V) => V;
+
+  /**
+   * Bulk-configure library defaults. Equivalent to assigning each key
+   * individually; `safety` validates on set.
+   */
+  static configure(options: {
+    safety?: 'clone' | 'reference' | 'freeze' | 'none';
+    tracing?: boolean;
+    stackCapture?: boolean;
+    defaultEquality?: (a: any, b: any) => boolean;
+    defaultClone?: <V>(value: V) => V;
+  }): void;
 }

--- a/packages/renderer/src/engines/lit/renderer.js
+++ b/packages/renderer/src/engines/lit/renderer.js
@@ -57,7 +57,7 @@ export class LitRenderer {
     this.inheritsData = inheritsData; // for subtrees lets us know if this needs to have data updates downstream
     this.protectedKeys = protectedKeys; // keys scoped to this subtree (loop vars, async results) that parent updates cannot overwrite
     this.id = LitRenderer.getID({ ast, data, isSVG });
-    this.dataVersion = new Signal(0, { allowClone: false, equalityFunction: () => false });
+    this.dataVersion = new Signal(0, { safety: 'none' });
 
     // Delegate expression evaluation
     this.evaluator = new ExpressionEvaluator({

--- a/packages/templating/src/template.js
+++ b/packages/templating/src/template.js
@@ -1001,7 +1001,7 @@ export const Template = class Template {
         if (property in target) {
           let signal = template.settingsVars.get(property);
           if (!signal) {
-            signal = new Signal(target[property], { allowClone: false });
+            signal = new Signal(target[property], { safety: 'reference' });
             template.settingsVars.set(property, signal);
           }
           signal.get(); // track dependency
@@ -1019,7 +1019,7 @@ export const Template = class Template {
           signal.set(value);
         }
         else {
-          signal = new Signal(value, { allowClone: false });
+          signal = new Signal(value, { safety: 'reference' });
           template.settingsVars.set(property, signal);
         }
         return true;

--- a/tools/benchmark/src/main.js
+++ b/tools/benchmark/src/main.js
@@ -5,8 +5,8 @@ import { buildData } from './store.js';
 import ast from './template.html?ast';
 
 const defaultState = {
-  rows: { value: [], options: { allowClone: false, equalityFunction: () => false } },
-  selected: { value: 0, options: { allowClone: false, equalityFunction: () => false } },
+  rows: { value: [], options: { safety: 'none' } },
+  selected: { value: 0, options: { safety: 'none' } },
 };
 
 const createComponent = ({ state }) => ({


### PR DESCRIPTION
Adds the `safety` constructor option to Signal with four presets (`clone`, `reference`, `freeze`, `none`) plus `Signal.safety` / `Signal.tracing` / `Signal.stackCapture` / `Signal.configure({...})` static config. `clone` is the current default. `allowClone: false` continues to work as a shim for `safety: 'reference'`.

Ports the safety preset implementation verbatim from `perf/signal-safety-v2-finalize`, stacked on top of main's reactivity hardening (#201, #205, #207).

Ships in three commits to isolate perf variables across CI bench checkpoints:

1. API only, default `clone` — baseline measuring the new library shape against existing contract.
2. Remove `allowClone`, migrate callsites, flip default to `freeze`.
3. Flip default to `reference`.

Intrinsic-need callsites (`dataVersion`, settings proxies, bench fixtures) are pinned across all three commits. Only default-using callsites move with the default flip.

## Risk
3/10 — `allowClone: false` consumers see no behavioral change. Default-using consumers are unchanged through commit 1. Commits 2 and 3 are the actual behavior shift, gated on bench evidence.