### PR TITLE
Feat: Signal Safety Presets

### DIFF
--- a/packages/reactivity/src/signal.js
+++ b/packages/reactivity/src/signal.js
@@ -16,6 +16,12 @@ import { captureStack, isStackCapture, isTracing, setStackCapture, setTracing } 
 import { Reaction } from './reaction.js';
 
 const IS_SIGNAL = Symbol.for('semantic-ui/Signal');
+const noEqualityFn = () => false;
+
+function freezeValue(value) {
+  if (value === null || typeof value !== 'object') { return value; }
+  return deepFreeze(value);
+}
 
 export class Signal {
   get [IS_SIGNAL]() {
@@ -25,37 +31,38 @@ export class Signal {
     return !!instance?.[IS_SIGNAL];
   }
 
-  constructor(initialValue, { context, equalityFunction, allowClone = true, cloneFunction, safety } = {}) {
-    // pass in some metadata for debugging
+  constructor(initialValue, options = {}) {
+    const { context, equalityFunction, allowClone = true, cloneFunction, safety } = options;
+    const effectiveSafety = safety ?? (allowClone === false ? 'reference' : 'clone');
+
+    // Dispatch non-clone modes to specialized subclasses so the hot setter
+    // body in each mode stays byte-tight enough for V8 to inline transitively
+    // through `signal.set()`. new.target gate skips when subclasses call super().
+    if (new.target === Signal && effectiveSafety !== 'clone') {
+      if (effectiveSafety === 'freeze') { return new FreezeSignal(initialValue, options); }
+      if (effectiveSafety === 'none') { return new NoneSignal(initialValue, options); }
+      return new ReferenceSignal(initialValue, options);
+    }
+
     this.dependency = new Dependency({
       firstRun: true,
       value: initialValue,
     });
 
-    // allow user to opt out of value cloning
     this.allowClone = allowClone;
-    this.safety = safety ?? (allowClone === false ? 'reference' : 'clone');
+    this.safety = effectiveSafety;
 
-    // allow custom equality function
     this.equalityFunction = (equalityFunction)
       ? wrapFunction(equalityFunction)
-      : Signal.equalityFunction;
+      : (effectiveSafety === 'none' ? noEqualityFn : Signal.equalityFunction);
 
-    // allow custom clone function
     this.clone = (cloneFunction)
       ? wrapFunction(cloneFunction)
       : Signal.cloneFunction;
 
-    this.currentValue = this.protect(initialValue);
+    this.currentValue = this.maybeClone(initialValue);
 
-    // allow debugging context to be set
     this.setContext(context);
-  }
-
-  protect(value) {
-    if (this.safety === 'freeze') { return deepFreeze(value); }
-    if (this.safety === 'clone') { return this.maybeClone(value); }
-    return value;
   }
 
   // set debugging context for signal removing any present context
@@ -126,7 +133,7 @@ export class Signal {
 
   set value(newValue) {
     if (!this.equalityFunction(this.currentValue, newValue)) {
-      this.currentValue = this.protect(newValue);
+      this.currentValue = this.maybeClone(newValue);
       this.notify();
     }
   }
@@ -375,3 +382,51 @@ export class Signal {
     return this.removeIndex(this.getItemIndex(id));
   }
 }
+
+class FreezeSignal extends Signal {
+  constructor(initialValue, options) {
+    super(initialValue, options);
+    this.currentValue = freezeValue(initialValue);
+  }
+
+  get value() {
+    this.depend();
+    return this.currentValue;
+  }
+
+  set value(newValue) {
+    if (!this.equalityFunction(this.currentValue, newValue)) {
+      this.currentValue = freezeValue(newValue);
+      this.notify();
+    }
+  }
+
+  peek() {
+    return this.currentValue;
+  }
+}
+
+class ReferenceSignal extends Signal {
+  constructor(initialValue, options) {
+    super(initialValue, options);
+    this.currentValue = initialValue;
+  }
+
+  get value() {
+    this.depend();
+    return this.currentValue;
+  }
+
+  set value(newValue) {
+    if (!this.equalityFunction(this.currentValue, newValue)) {
+      this.currentValue = newValue;
+      this.notify();
+    }
+  }
+
+  peek() {
+    return this.currentValue;
+  }
+}
+
+class NoneSignal extends ReferenceSignal {}

--- a/packages/reactivity/src/signal.js
+++ b/packages/reactivity/src/signal.js
@@ -1,5 +1,6 @@
 import {
   clone,
+  deepFreeze,
   isArray,
   isClassInstance,
   isDevelopment,
@@ -52,7 +53,10 @@ export class Signal {
   }
 
   protect(value) {
-    return this.maybeClone(value);
+    if (value === null || typeof value !== 'object') { return value; }
+    if (this.safety === 'freeze') { return deepFreeze(value); }
+    if (this.safety === 'clone') { return this.maybeClone(value); }
+    return value;
   }
 
   // set debugging context for signal removing any present context

--- a/packages/reactivity/src/signal.js
+++ b/packages/reactivity/src/signal.js
@@ -125,11 +125,10 @@ export class Signal {
   }
 
   set value(newValue) {
-    if (this.equalityFunction(this.currentValue, newValue)) { return; }
-    this.currentValue = (newValue === null || typeof newValue !== 'object')
-      ? newValue
-      : this.protect(newValue);
-    this.notify();
+    if (!this.equalityFunction(this.currentValue, newValue)) {
+      this.currentValue = this.protect(newValue);
+      this.notify();
+    }
   }
 
   get({ clone = true } = {}) {

--- a/packages/reactivity/src/signal.js
+++ b/packages/reactivity/src/signal.js
@@ -53,7 +53,6 @@ export class Signal {
   }
 
   protect(value) {
-    if (value === null || typeof value !== 'object') { return value; }
     if (this.safety === 'freeze') { return deepFreeze(value); }
     if (this.safety === 'clone') { return this.maybeClone(value); }
     return value;
@@ -126,10 +125,11 @@ export class Signal {
   }
 
   set value(newValue) {
-    if (!this.equalityFunction(this.currentValue, newValue)) {
-      this.currentValue = this.protect(newValue);
-      this.notify();
-    }
+    if (this.equalityFunction(this.currentValue, newValue)) { return; }
+    this.currentValue = (newValue === null || typeof newValue !== 'object')
+      ? newValue
+      : this.protect(newValue);
+    this.notify();
   }
 
   get({ clone = true } = {}) {

--- a/packages/reactivity/src/signal.js
+++ b/packages/reactivity/src/signal.js
@@ -24,7 +24,7 @@ export class Signal {
     return !!instance?.[IS_SIGNAL];
   }
 
-  constructor(initialValue, { context, equalityFunction, allowClone = true, cloneFunction } = {}) {
+  constructor(initialValue, { context, equalityFunction, allowClone = true, cloneFunction, safety } = {}) {
     // pass in some metadata for debugging
     this.dependency = new Dependency({
       firstRun: true,
@@ -33,8 +33,7 @@ export class Signal {
 
     // allow user to opt out of value cloning
     this.allowClone = allowClone;
-    // unused this commit — establishes hidden class slot for the safety preset
-    this.safety = 'clone';
+    this.safety = safety ?? (allowClone === false ? 'reference' : 'clone');
 
     // allow custom equality function
     this.equalityFunction = (equalityFunction)

--- a/packages/reactivity/src/signal.js
+++ b/packages/reactivity/src/signal.js
@@ -33,6 +33,8 @@ export class Signal {
 
     // allow user to opt out of value cloning
     this.allowClone = allowClone;
+    // unused this commit — establishes hidden class slot for the safety preset
+    this.safety = 'clone';
 
     // allow custom equality function
     this.equalityFunction = (equalityFunction)

--- a/packages/reactivity/src/signal.js
+++ b/packages/reactivity/src/signal.js
@@ -45,10 +45,14 @@ export class Signal {
       ? wrapFunction(cloneFunction)
       : Signal.cloneFunction;
 
-    this.currentValue = this.maybeClone(initialValue);
+    this.currentValue = this.protect(initialValue);
 
     // allow debugging context to be set
     this.setContext(context);
+  }
+
+  protect(value) {
+    return this.maybeClone(value);
   }
 
   // set debugging context for signal removing any present context
@@ -119,7 +123,7 @@ export class Signal {
 
   set value(newValue) {
     if (!this.equalityFunction(this.currentValue, newValue)) {
-      this.currentValue = this.maybeClone(newValue);
+      this.currentValue = this.protect(newValue);
       this.notify();
     }
   }

--- a/packages/renderer/src/engines/lit/renderer.js
+++ b/packages/renderer/src/engines/lit/renderer.js
@@ -57,7 +57,7 @@ export class LitRenderer {
     this.inheritsData = inheritsData; // for subtrees lets us know if this needs to have data updates downstream
     this.protectedKeys = protectedKeys; // keys scoped to this subtree (loop vars, async results) that parent updates cannot overwrite
     this.id = LitRenderer.getID({ ast, data, isSVG });
-    this.dataVersion = new Signal(0, { allowClone: false, equalityFunction: () => false });
+    this.dataVersion = new Signal(0, { safety: 'none', equalityFunction: () => false });
 
     // Delegate expression evaluation
     this.evaluator = new ExpressionEvaluator({

--- a/packages/templating/src/template.js
+++ b/packages/templating/src/template.js
@@ -1001,7 +1001,7 @@ export const Template = class Template {
         if (property in target) {
           let signal = template.settingsVars.get(property);
           if (!signal) {
-            signal = new Signal(target[property], { allowClone: false });
+            signal = new Signal(target[property], { safety: 'reference' });
             template.settingsVars.set(property, signal);
           }
           signal.get(); // track dependency
@@ -1019,7 +1019,7 @@ export const Template = class Template {
           signal.set(value);
         }
         else {
-          signal = new Signal(value, { allowClone: false });
+          signal = new Signal(value, { safety: 'reference' });
           template.settingsVars.set(property, signal);
         }
         return true;

--- a/tools/benchmark/src/main.js
+++ b/tools/benchmark/src/main.js
@@ -5,8 +5,8 @@ import { buildData } from './store.js';
 import ast from './template.html?ast';
 
 const defaultState = {
-  rows: { value: [], options: { allowClone: false, equalityFunction: () => false } },
-  selected: { value: 0, options: { allowClone: false, equalityFunction: () => false } },
+  rows: { value: [], options: { safety: 'none', equalityFunction: () => false } },
+  selected: { value: 0, options: { safety: 'none', equalityFunction: () => false } },
 };
 
 const createComponent = ({ state }) => ({


### PR DESCRIPTION
Existing signals safety PR #148 #150 have too many confounding performance issues with baseline signals implementation which has been separately optimized. This PR intends to reimplement safety presets with a careful look at performance tradeoffs for all hotpaths from the increased overhead of `protect()`. 

This PR will help decide whether we ship TC39 reference safety (none), freeze, or the ultra safe clone based on real world bench.