### PR TITLE
Perf: keyed-list reorder, teardown, and lighter rows

### DIFF
--- a/packages/reactivity/src/reaction.js
+++ b/packages/reactivity/src/reaction.js
@@ -7,7 +7,7 @@ export class Reaction {
   static create(callback, options = {}) {
     const reaction = new Reaction(callback, options);
     if (options.firstRun !== false) {
-      reaction.boundRun();
+      reaction.run();
     }
     return reaction;
   }
@@ -15,26 +15,25 @@ export class Reaction {
   constructor(callback, { context } = {}) {
     this.callback = callback;
     this.dependencies = new Set();
-    this.cleanups = [];
+    this.cleanups = null; // lazy — most reactions register none
     this.firstRun = true;
     this.active = true;
     if (context && isTracing()) {
       this.setContext(context);
     }
-    this.boundRun = this.run.bind(this);
   }
 
   // callbacks fire before next run() and on stop. use to scope inner reactions to parent
   onCleanup(callback) {
-    this.cleanups.push(callback);
+    (this.cleanups ??= []).push(callback);
   }
 
   fireCleanups() {
-    if (this.cleanups.length === 0) {
+    if (this.cleanups === null) {
       return;
     }
     const callbacks = this.cleanups;
-    this.cleanups = [];
+    this.cleanups = null;
     for (let i = 0; i < callbacks.length; i++) {
       callbacks[i]();
     }

--- a/packages/renderer/src/engines/native/attribute-binding.js
+++ b/packages/renderer/src/engines/native/attribute-binding.js
@@ -72,19 +72,34 @@ export function bindAttribute({
   const isIfDefined = singleEntry?.node.ifDefined || singleEntry?.classification.type === 'boolean';
 
   if (isSingleExpr) {
+    // This reaction is the sole writer of the attribute, so we shadow the
+    // last value we wrote and diff in JS rather than reading it back with
+    // getAttribute (a Blink boundary call) on every re-run. undefined means
+    // "currently absent" — never written, or cleared by an ifDefined miss.
+    // The first run always applies, clearing the parsed marker attribute.
+    let lastWritten;
     scope.reaction(element, (comp) => {
       const value = singleIsBlock
         ? renderASTToString([singleEntry.node], data, renderer)
         : renderer.lookupExpression(singleEntry.node.value, data);
-      if (skipFirstWrite && comp.firstRun) { return; }
+      if (skipFirstWrite && comp.firstRun) {
+        // Server already rendered the attribute; seed the shadow so the first
+        // reactive re-run diffs honestly against what's in the DOM.
+        lastWritten = (isIfDefined && !value) ? undefined : stringifyAttrValue(value);
+        return;
+      }
 
       if (isIfDefined && !value) {
-        element.removeAttribute(attrName);
+        if (comp.firstRun || lastWritten !== undefined) {
+          element.removeAttribute(attrName);
+          lastWritten = undefined;
+        }
       }
       else {
         const strValue = stringifyAttrValue(value);
-        if (element.getAttribute(attrName) !== strValue) {
+        if (comp.firstRun || strValue !== lastWritten) {
           element.setAttribute(attrName, strValue);
+          lastWritten = strValue;
         }
       }
       if (attrName === 'checked' || attrName === 'selected') {

--- a/packages/renderer/src/engines/native/blocks/each.js
+++ b/packages/renderer/src/engines/native/blocks/each.js
@@ -1,6 +1,7 @@
 import { arrayFromObject, isArray, isEmpty } from '@semantic-ui/utils';
 import { isBlockClose, isBlockOpen, MARKER_VERSION } from '../../../build-html-string.js';
 import { decodeItemKey, getCollectionType, getEachData, getItemID } from '../../../shared/each.js';
+import { lisIndices } from '../../../shared/lis.js';
 import { defineBlock } from '../define-block.js';
 import { ReactiveDataContext } from '../reactive-context.js';
 import { registerBlock } from './registry.js';
@@ -186,6 +187,25 @@ function disposeRecord(record) {
   disposeRecordDOM(record);
 }
 
+// Survivors to leave untouched in Phase 2: the LIS of their old DOM positions.
+// Everything off it is the minimal move set. Fresh records (still carrying their
+// build fragment) are excluded — they always insert.
+function lisKeepSet(records) {
+  const positions = [];
+  const recordIndex = [];
+  for (let i = 0; i < records.length; i++) {
+    const record = records[i];
+    if (!record || record.fragment) { continue; }
+    positions.push(record.index);
+    recordIndex.push(i);
+  }
+  const keep = new Set();
+  for (const seqIndex of lisIndices(positions)) {
+    keep.add(recordIndex[seqIndex]);
+  }
+  return keep;
+}
+
 // Lit-style head/tail keyed reconcile (lit-html's repeat directive).
 // Walks both ends inward; lazily builds key→index maps only when forced
 // by non-contiguous changes. Common cases (head/tail unchanged, single
@@ -303,30 +323,32 @@ function reconcile({ records, items, collectionType, node, data, scope, region, 
     if (record !== null) { disposeRecord(record); }
   }
 
-  // Phase 2: linearize DOM order using markers.
-  //
-  // `cursor` is always a currently-attached node that we know the next
-  // item's startMarker should follow. It starts as region.anchor and
-  // advances to each placed record's endMarker. Markers are stable — they
-  // are the invariant that survives inner-block mutations.
-  //
-  // For each record:
-  //   - If the record's startMarker is already the cursor's nextSibling,
-  //     the record is already in the right place; skip insertion.
-  //   - Otherwise, extract its [startMarker .. content .. endMarker]
-  //     range into a fragment, then insert the fragment after the cursor.
-  //     Fresh records start with their content already in the fragment
-  //     we built in createRecord — insert it directly.
+  // Move only records off the LIS of their old DOM positions — minimal moves for
+  // any permutation (Vue `getSequence`, inferno). `record.index` still holds the
+  // *old* position here: Phase 1 never writes it, Phase 3 does afterward. Fresh
+  // records (still carrying their build fragment) always insert. Build the LIS
+  // only on a real reorder; otherwise survivors stay ascending and `cursor`'s
+  // in-place skip suffices.
   let cursor = region.anchor;
+  let reordered = false;
+  let lastOldIndex = -1;
   for (const record of newRecords) {
+    if (!record || record.fragment) { continue; }
+    if (record.index < lastOldIndex) {
+      reordered = true;
+      break;
+    }
+    lastOldIndex = record.index;
+  }
+  const keep = reordered ? lisKeepSet(newRecords) : null;
+  for (let i = 0; i < newRecords.length; i++) {
+    const record = newRecords[i];
     if (!record) { continue; }
     if (record.fragment) {
-      // Freshly created record — content and markers are in the fragment.
       cursor.after(record.fragment);
       record.fragment = null;
     }
-    else if (record.startMarker.previousSibling !== cursor) {
-      // Existing record in the wrong position — extract and reinsert.
+    else if (keep ? !keep.has(i) : record.startMarker.previousSibling !== cursor) {
       const fragment = document.createDocumentFragment();
       extractRangeToFragment(record.startMarker, record.endMarker, fragment);
       cursor.after(fragment);

--- a/packages/renderer/src/engines/native/reaction-scope.js
+++ b/packages/renderer/src/engines/native/reaction-scope.js
@@ -38,11 +38,11 @@ export class ReactionScope {
     return childScope;
   }
 
-  // `fromParent` is set when the parent is tearing down all its children: the
-  // child then skips the per-child parent-unlink (the parent clears its array
-  // once), turning bulk teardown from O(n²) into O(n) and avoiding a splice
-  // mid-iteration. Standalone dispose detaches via an O(1) swap-pop using the
-  // stored slot index instead of indexOf + splice.
+  // Detach in O(1): a standalone dispose swap-pops itself out of `parent.children`
+  // via its stored slot index instead of indexOf + splice, and `fromParent` lets a
+  // parent tearing down its whole subtree skip the per-child unlink (clearing the
+  // array once). Bulk teardown O(n²) → O(n), and no more splice-mid-iteration.
+  // (Vue's EffectScope: same fromParent + indexed swap-pop.)
   dispose(fromParent = false) {
     for (const child of this.children) { child.dispose(true); }
     this.children = [];

--- a/packages/renderer/src/engines/native/reaction-scope.js
+++ b/packages/renderer/src/engines/native/reaction-scope.js
@@ -5,6 +5,8 @@ export class ReactionScope {
     this.reactions = [];
     this.children = [];
     this.disposers = [];
+    this.parent = null;
+    this.index = -1; // this scope's slot in parent.children, for O(1) detach
   }
 
   track(reaction) {
@@ -32,22 +34,31 @@ export class ReactionScope {
   child() {
     const childScope = new ReactionScope();
     childScope.parent = this;
-    this.children.push(childScope);
+    childScope.index = this.children.push(childScope) - 1;
     return childScope;
   }
 
-  dispose() {
-    for (const child of this.children) { child.dispose(); }
+  // `fromParent` is set when the parent is tearing down all its children: the
+  // child then skips the per-child parent-unlink (the parent clears its array
+  // once), turning bulk teardown from O(n²) into O(n) and avoiding a splice
+  // mid-iteration. Standalone dispose detaches via an O(1) swap-pop using the
+  // stored slot index instead of indexOf + splice.
+  dispose(fromParent = false) {
+    for (const child of this.children) { child.dispose(true); }
     this.children = [];
     for (const reaction of this.reactions) { reaction.stop(); }
     this.reactions = [];
     for (const fn of this.disposers) { fn(); }
     this.disposers = [];
-    // Remove from parent to prevent accumulation across branch switches
-    if (this.parent) {
-      const idx = this.parent.children.indexOf(this);
-      if (idx !== -1) { this.parent.children.splice(idx, 1); }
-      this.parent = null;
+    if (!fromParent && this.parent) {
+      const siblings = this.parent.children;
+      const last = siblings.pop();
+      if (last && last !== this && this.index < siblings.length) {
+        siblings[this.index] = last;
+        last.index = this.index;
+      }
     }
+    this.parent = null;
+    this.index = -1;
   }
 }

--- a/packages/renderer/src/engines/native/reactive-context.js
+++ b/packages/renderer/src/engines/native/reactive-context.js
@@ -145,7 +145,7 @@ function trapGet(target, prop) {
     }
     return values[prop];
   }
-  if (!target.keysSealed) { target.keySetVersion.depend(); }
+  if (!target.keysSealed) { (target.keySetVersion ??= new Dependency()).depend(); }
   return target.parent[prop];
 }
 
@@ -269,7 +269,11 @@ export class ReactiveDataContext {
     // userland breaks Signal.equalityFunction after this RDC is live,
     // both Signal and RDC fail the same way; no divergence.
     this.equalityFunction = Signal.equalityFunction;
-    this.keySetVersion = new Dependency();
+    // Lazy: only a reader falling through on the unsealed path allocates it
+    // (spread-mode late keys). as-mode reads run post-seal, so it stays null —
+    // the per-row saving. A writer fires it only if a reader already created it
+    // (a changed() on a never-subscribed dep was always a no-op).
+    this.keySetVersion = null;
     this.proxy = new Proxy(this, HANDLER);
 
     if (registerItemContext) {
@@ -288,7 +292,7 @@ export class ReactiveDataContext {
       if (key !== this.asKey || value === null || typeof value !== 'object') {
         this.deps[key] = new Dependency();
       }
-      if (!this.keysSealed) { this.keySetVersion.changed(); }
+      if (!this.keysSealed && this.keySetVersion !== null) { this.keySetVersion.changed(); }
       return;
     }
     const old = this.values[key];

--- a/packages/renderer/src/shared/lis.js
+++ b/packages/renderer/src/shared/lis.js
@@ -1,0 +1,33 @@
+/*
+  Longest strictly-increasing subsequence — the move-minimization behind keyed
+  list reorders. Vue (`getSequence`), inferno, and ivi all use it to move only
+  the nodes genuinely out of order. Pure logic, no DOM.
+*/
+
+// Indices into `values` of a longest strictly-increasing subsequence
+// (O(n log n) patience sort with predecessor links).
+export function lisIndices(values) {
+  const predecessor = new Array(values.length);
+  const tails = [];
+  for (let i = 0; i < values.length; i++) {
+    const value = values[i];
+    let lo = 0;
+    let hi = tails.length;
+    while (lo < hi) {
+      const mid = (lo + hi) >> 1;
+      if (values[tails[mid]] < value) { lo = mid + 1; }
+      else { hi = mid; }
+    }
+    predecessor[i] = lo > 0 ? tails[lo - 1] : -1;
+    if (lo === tails.length) { tails.push(i); }
+    else { tails[lo] = i; }
+  }
+  const result = new Array(tails.length);
+  let k = tails.length;
+  let node = k > 0 ? tails[k - 1] : -1;
+  while (k > 0) {
+    result[--k] = node;
+    node = predecessor[node];
+  }
+  return result;
+}

--- a/packages/renderer/test/unit/lis.test.js
+++ b/packages/renderer/test/unit/lis.test.js
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { lisIndices } from '../../src/shared/lis.js';
+
+const pick = (values, idx) => idx.map((i) => values[i]);
+const strictlyIncreasing = (a) => a.every((v, i) => i === 0 || a[i - 1] < v);
+
+describe('lisIndices', () => {
+  it('is empty for empty input', () => {
+    expect(lisIndices([])).toEqual([]);
+  });
+
+  it('returns the lone index for a single element', () => {
+    expect(lisIndices([7])).toEqual([0]);
+  });
+
+  it('keeps every index when already ascending', () => {
+    expect(lisIndices([0, 1, 2, 3])).toEqual([0, 1, 2, 3]);
+  });
+
+  it('keeps a single index when strictly descending', () => {
+    expect(lisIndices([3, 2, 1, 0])).toHaveLength(1);
+  });
+
+  it('returns ascending indices selecting a strictly-increasing, maximal subsequence', () => {
+    const values = [2, 1, 5, 3, 4, 7, 6];
+    const idx = lisIndices(values);
+    expect(idx).toEqual([...idx].sort((a, b) => a - b));
+    expect(strictlyIncreasing(pick(values, idx))).toBe(true);
+    expect(idx).toHaveLength(4); // e.g. values 1,3,4,6
+  });
+});


### PR DESCRIPTION
Three performance wins on the keyed-list path:

- **swap / reorder** — move only the rows that actually moved (longest-increasing-subsequence), instead of cascading through the whole list. Fixes the big outlier.
- **clear / replace / remove** — detach scopes in O(1) rather than O(n²), plus a latent cleanup-skip fix in subtree teardown.
- **lighter per-row reactive footprint** — drop dead/eager allocations.

Numbers land via the benchmark run.