### PR TITLE
Bench: Shim collection-helper renames

### DIFF
--- a/packages/component/bench/tachometer/bench-todo.js
+++ b/packages/component/bench/tachometer/bench-todo.js
@@ -110,7 +110,7 @@ defineComponent({
       },
       toggleAll() {
         const allDone = state.todos.get().every(t => t.completed);
-        state.todos.setArrayProperty('completed', !allDone);
+        state.todos.setProperty('completed', !allDone);
       },
       deleteTodo(id) {
         state.todos.removeItem(id);
@@ -126,10 +126,10 @@ defineComponent({
       },
       saveTodo(id, title) {
         state.editingId.set(null);
-        state.todos.setProperty(id, 'title', title);
+        state.todos.setItemProperty(id, 'title', title);
       },
       renameTodo(id, title) {
-        state.todos.setProperty(id, 'title', title);
+        state.todos.setItemProperty(id, 'title', title);
       },
     };
   },

--- a/packages/reactivity/bench/tachometer/bench-signal.js
+++ b/packages/reactivity/bench/tachometer/bench-signal.js
@@ -265,7 +265,7 @@ let sink = null;
   // purpose: Finds an item by id and updates one field in a 1000-item list signal across 200 alternating updates.
   performance.mark(startMark('reactive-set-property-by-id-200'));
   for (let i = 0; i < 200; i++) {
-    sig.setProperty(ids[i], 'active', i % 2 === 0);
+    sig.setItemProperty(ids[i], 'active', i % 2 === 0);
     flush();
   }
   performance.measure('reactive-set-property-by-id-200', startMark('reactive-set-property-by-id-200'));

--- a/packages/reactivity/src/signal.js
+++ b/packages/reactivity/src/signal.js
@@ -289,6 +289,10 @@ export class Signal {
   }
   setProperty(idOrProperty, property, value) {
     if (isArray(this.currentValue)) {
+      // a 2-arg call sets the field on every item
+      if (arguments.length < 3) {
+        return this.setArrayProperty(idOrProperty, property);
+      }
       const id = idOrProperty;
       const index = this.getItemIndex(id);
       return this.setArrayProperty(index, property, value);
@@ -302,6 +306,10 @@ export class Signal {
       this.currentValue[property] = value;
       this.notify();
     }
+  }
+
+  setItemProperty(id, property, value) {
+    return this.setArrayProperty(this.getItemIndex(id), property, value);
   }
   replaceItem(id, item) {
     const index = this.getItemIndex(id);

--- a/packages/reactivity/test/unit/signal-helpers.test.js
+++ b/packages/reactivity/test/unit/signal-helpers.test.js
@@ -543,6 +543,53 @@ SAFETY_MODES.forEach((safety) => {
       });
     });
 
+    describe('setItemProperty', () => {
+      it('sets a property on the item matching the id', () => {
+        const sig = new Signal(
+          [{ id: 'a', title: 'one' }, { id: 'b', title: 'two' }],
+          { safety },
+        );
+        sig.setItemProperty('b', 'title', 'TWO');
+        expect(sig.raw().find(i => i.id === 'b').title).toBe('TWO');
+        expect(sig.raw().find(i => i.id === 'a').title).toBe('one');
+      });
+
+      it('is a no-op when no item matches the id', () => {
+        const sig = new Signal(
+          [{ id: 'a', title: 'one' }, { id: 'b', title: 'two' }],
+          { safety },
+        );
+        const sub = subscribe(sig);
+        sig.setItemProperty('missing', 'title', 'X');
+        flush();
+        expect(sub.count).toBe(0);
+        sub.stop();
+      });
+    });
+
+    describe('setProperty (array form, all items)', () => {
+      it('sets the field on every item', () => {
+        const sig = new Signal(
+          [{ id: 'a', done: false }, { id: 'b', done: false }],
+          { safety },
+        );
+        sig.setProperty('done', true);
+        expect(sig.raw().every(item => item.done === true)).toBe(true);
+      });
+
+      it('fires reactivity once', () => {
+        const sig = new Signal(
+          [{ id: 'a', done: false }, { id: 'b', done: false }],
+          { safety },
+        );
+        const sub = subscribe(sig);
+        sig.setProperty('done', true);
+        flush();
+        expect(sub.count).toBe(1);
+        sub.stop();
+      });
+    });
+
     describe('setProperty (object form)', () => {
       it('sets a property on the stored object', () => {
         const sig = new Signal({ name: 'a', count: 0 }, { safety });


### PR DESCRIPTION
This shims the bench to allow us to refactor signal mutation helpers and get clean results against baseline.