### PR TITLE
Bug: Assorted Component Bugs / LSP

### DIFF
--- a/src/components/mobile-menu/mobile-menu.js
+++ b/src/components/mobile-menu/mobile-menu.js
@@ -100,16 +100,13 @@ const createComponent = ({ tpl, settings, $, state, flush, afterFlush, dispatchE
 
   // add -> icon if the menu has a sub menu
   addNavIcons(menu) {
-    if (!settings.navIcon) {
+    if (!settings.navIcon || !menu?.menu) {
       return menu;
     }
-    (menu?.menu || []).map(item => {
-      if (item.menu) {
-        item.navIcon = settings.navIcon;
-      }
-      return item;
-    });
-    return menu;
+    return {
+      ...menu,
+      menu: menu.menu.map(item => item.menu ? { ...item, navIcon: settings.navIcon } : item),
+    };
   },
   addTrailingSlash(url) {
     return (url.substr(-1) === '/')

--- a/src/components/nav-menu/nav-menu.js
+++ b/src/components/nav-menu/nav-menu.js
@@ -1,5 +1,5 @@
 import { defineComponent } from '@semantic-ui/component';
-import { any, clone, isArray, isFunction, isString, openLink } from '@semantic-ui/utils';
+import { any, isArray, isFunction, isString, openLink } from '@semantic-ui/utils';
 import { Icon } from '../../primitives/index.js';
 import css from './nav-menu.css?raw';
 import template from './nav-menu.html?raw';
@@ -43,8 +43,7 @@ const createComponent = ({ $, el, self, settings, state, reaction, isRendered })
         menu = [];
       }
     }
-    menu = clone(menu) || [];
-    menu = self.filterVisibleSections(menu);
+    menu = self.filterVisibleSections(menu || []);
     if (self.isSearching()) {
       menu = self.filterBySearchTerm(menu);
     }
@@ -147,26 +146,25 @@ const createComponent = ({ $, el, self, settings, state, reaction, isRendered })
     let firstMatch = false;
     const searchTermChanged = self.lastSearchTerm !== searchTerm;
     const addSelectedIndex = (item) => {
-      if (item?.url) {
-        selectedIndex++;
-        item.selectedIndex = selectedIndex;
+      if (!item?.url) {
+        return item;
       }
+      selectedIndex++;
       // reset selected index only when search term changes
-      if (searchTermChanged && !firstMatch && item.highlight && item?.url) {
+      if (searchTermChanged && !firstMatch && item.highlight) {
         state.selectedIndex.set(selectedIndex);
         firstMatch = true;
       }
-      return item;
+      return { ...item, selectedIndex };
     };
-    // add selected index for each menu, pages and subpages (3 deep max)
-    menu = menu.map(currentMenu => {
-      currentMenu = addSelectedIndex(currentMenu);
-      (currentMenu?.pages || []).map(page => {
-        page = addSelectedIndex(page);
-        (page?.pages || []).map(subPage => addSelectedIndex(subPage));
-      });
-      return currentMenu;
-    });
+    // recursively add the selected index to each item and its nested pages
+    const enrich = (item) => {
+      const withIndex = addSelectedIndex(item);
+      return withIndex?.pages
+        ? { ...withIndex, pages: withIndex.pages.map(enrich) }
+        : withIndex;
+    };
+    menu = menu.map(enrich);
     self.lastSearchTerm = searchTerm;
     state.maxIndex.set(selectedIndex);
     return menu;

--- a/tools/lsp/src/component-analyzer.js
+++ b/tools/lsp/src/component-analyzer.js
@@ -224,6 +224,8 @@ function findReturnExpression(block) {
 
 /*
   Extracts keys and inferred types from an object literal node.
+  State may be a raw value or a `{ value, options }` signal config.
+  Configs unwrap to the inner `value` so the type reflects the default.
 */
 function extractObjectFields(node) {
   const fields = [];
@@ -234,14 +236,29 @@ function extractObjectFields(node) {
     const name = getPropertyName(prop);
     if (!name) { continue; }
 
+    const valueNode = unwrapSignalConfig(prop.value);
     fields.push({
       name,
-      inferredType: inferTypeFromValue(prop.value),
-      defaultValue: getLiteralValue(prop.value),
+      inferredType: inferTypeFromValue(valueNode),
+      defaultValue: getLiteralValue(valueNode),
     });
   }
 
   return fields;
+}
+
+/*
+  Unwraps a `{ value, options }` signal config to its inner `value` node.
+  Requires both keys so it can't misfire on plain state that happens to
+  carry a `value` field.
+*/
+function unwrapSignalConfig(node) {
+  if (!node || node.type !== 'ObjectExpression') { return node; }
+  const props = node.properties.filter(prop => prop.type === 'Property');
+  const keys = props.map(getPropertyName);
+  if (!keys.includes('value') || !keys.includes('options')) { return node; }
+  const valueProp = props.find(prop => getPropertyName(prop) === 'value');
+  return valueProp?.value ?? node;
 }
 
 function extractEventKeys(node) {

--- a/tools/lsp/test/component-analyzer.test.js
+++ b/tools/lsp/test/component-analyzer.test.js
@@ -359,6 +359,52 @@ describe('ComponentAnalyzer', () => {
   });
 
   /*******************************
+      Signal-config state shape
+  *******************************/
+
+  describe('signal-config state ({ value, options })', () => {
+    const source = `
+      import { defineComponent } from '@semantic-ui/component';
+      const Comp = defineComponent({
+        tagName: 'config-state',
+        defaultState: {
+          rows: { value: [], options: { equality: 'deep' } },
+          count: { value: 0, options: {} },
+          valueOnly: { value: 7 },
+          plain: { nested: true },
+          flag: false,
+        },
+      });
+    `;
+    const model = analyzeComponent(source, '/virtual/config-state.js');
+
+    it('infers type from the inner value of a { value, options } config', () => {
+      const rows = model.state.find(s => s.name === 'rows');
+      expect(rows.inferredType).toBe('array');
+      expect(rows.defaultValue).toEqual([]);
+
+      const count = model.state.find(s => s.name === 'count');
+      expect(count.inferredType).toBe('number');
+      expect(count.defaultValue).toBe(0);
+    });
+
+    it('leaves plain objects untouched', () => {
+      // value without options is ambiguous, treat as a plain object
+      const valueOnly = model.state.find(s => s.name === 'valueOnly');
+      expect(valueOnly.inferredType).toBe('object');
+
+      const plain = model.state.find(s => s.name === 'plain');
+      expect(plain.inferredType).toBe('object');
+    });
+
+    it('still infers raw values alongside configs', () => {
+      const flag = model.state.find(s => s.name === 'flag');
+      expect(flag.inferredType).toBe('boolean');
+      expect(flag.defaultValue).toBe(false);
+    });
+  });
+
+  /*******************************
       Edge Cases
   *******************************/
 


### PR DESCRIPTION
This PR handles adding a grab bag of fixes that were in the abandoned Freeze Signal PR #150. 

## Changes
- Fixed mutation bug in `mobile-menu` 
- `nav-menu` no longer uses an unneeded clone
- Fixed issue with LSP for state using advanced {value, options} syntax

## Risk
2/10. 

First-party components and LSP tooling only

`nav-menu` now recurses to any menu depth (was 3). Confirm selected-item highlighting in the rendered menu.
