### PR TITLE
Bench: Add clean-heap and forced-GC krausest update probes

### DIFF
--- a/packages/component/bench/tachometer/bench-krausest.js
+++ b/packages/component/bench/tachometer/bench-krausest.js
@@ -207,6 +207,36 @@ function getRows(el) {
 }
 
 /*******************************
+      Update (clean heap)
+      Same workload as update-10th-50 but run first, before the
+      create-heavy ops, so the measured region starts on a clean heap.
+      The delta against update-10th-50 isolates suite-ordering GC cost.
+*******************************/
+
+// Warm render / reconcile / update so the first-op cold JIT doesn't
+// skew the isolated measure.
+const elWarm = await mount();
+elWarm.component.run(1000);
+await flush();
+for (let i = 0; i < 10; i++) {
+  elWarm.component.update();
+  flushWork();
+}
+destroy();
+
+const elIso = await mount();
+elIso.component.run(1000);
+await flush();
+// purpose: Same update workload as update-10th-50 but on a clean heap with no create-heavy ops before it. Pairs with update-10th-50 to isolate suite-ordering GC pressure.
+performance.mark(startMark('update-isolated-50'));
+for (let i = 0; i < 50; i++) {
+  elIso.component.update();
+  flushWork();
+}
+performance.measure('update-isolated-50', startMark('update-isolated-50'));
+destroy();
+
+/*******************************
       Create
       (krausest 01_run, 02b_runlots)
 *******************************/
@@ -277,6 +307,31 @@ for (let i = 0; i < 50; i++) {
   flushWork();
 }
 performance.measure('update-10th-50', startMark('update-10th-50'));
+destroy();
+
+/*******************************
+      Update (forced GC)
+      update-10th workload with a full GC before the measured region.
+      If the update-10th-50 delta vanishes here, the carried-in cost is
+      reclaimable GC pressure from the create-heavy ops above.
+*******************************/
+
+const el5b = await mount();
+el5b.component.run(1000);
+await flush();
+// gc() exists only under --js-flags=--expose-gc (set in tachometer-ci-krausest.json).
+// Settle after collecting so the measured region starts on a post-GC heap.
+if (globalThis.gc) {
+  globalThis.gc();
+  await flush();
+}
+// purpose: update-10th workload with a forced GC before the measured region. If the update-10th-50 regression vanishes here it is reclaimable GC pressure.
+performance.mark(startMark('update-gc-50'));
+for (let i = 0; i < 50; i++) {
+  el5b.component.update();
+  flushWork();
+}
+performance.measure('update-gc-50', startMark('update-gc-50'));
 destroy();
 
 /*******************************

--- a/packages/component/bench/tachometer/tachometer-ci-krausest.json
+++ b/packages/component/bench/tachometer/tachometer-ci-krausest.json
@@ -8,13 +8,15 @@
     {
       "name": "this-change",
       "url": "ci-current-krausest.html",
-      "browser": { "name": "chrome", "headless": true },
+      "browser": { "name": "chrome", "headless": true, "addArguments": ["--js-flags=--expose-gc"] },
       "measurement": [
         { "mode": "performance", "entryName": "create-1k" },
         { "mode": "performance", "entryName": "create-10k" },
         { "mode": "performance", "entryName": "replace-1k" },
         { "mode": "performance", "entryName": "append-1k" },
         { "mode": "performance", "entryName": "update-10th-50" },
+        { "mode": "performance", "entryName": "update-isolated-50" },
+        { "mode": "performance", "entryName": "update-gc-50" },
         { "mode": "performance", "entryName": "select-40" },
         { "mode": "performance", "entryName": "swap-rows-20" },
         { "mode": "performance", "entryName": "remove-row-front-20" },
@@ -26,13 +28,15 @@
     {
       "name": "tip-of-tree",
       "url": "ci-baseline-krausest.html",
-      "browser": { "name": "chrome", "headless": true },
+      "browser": { "name": "chrome", "headless": true, "addArguments": ["--js-flags=--expose-gc"] },
       "measurement": [
         { "mode": "performance", "entryName": "create-1k" },
         { "mode": "performance", "entryName": "create-10k" },
         { "mode": "performance", "entryName": "replace-1k" },
         { "mode": "performance", "entryName": "append-1k" },
         { "mode": "performance", "entryName": "update-10th-50" },
+        { "mode": "performance", "entryName": "update-isolated-50" },
+        { "mode": "performance", "entryName": "update-gc-50" },
         { "mode": "performance", "entryName": "select-40" },
         { "mode": "performance", "entryName": "swap-rows-20" },
         { "mode": "performance", "entryName": "remove-row-front-20" },


### PR DESCRIPTION
Temporary diagnostic for #223. That PR's per-AST binding-plan cache regresses `update-10th-50` by +45% on krausest across two runs, yet the changed code never executes during that op. The leading explanation is suite-ordering GC pressure: `update-10th-50` runs after create-1k / create-10k / replace-1k / append-1k in one page load, and the cache shifts the heap trajectory those create-heavy ops leave behind.

Two probes pin it down. Both are read from the same single page run tachometer already does, so no extra config.

- `update-isolated-50` runs the identical update workload first, on a clean heap with no create-heavy ops before it.
- `update-gc-50` runs it in place but forces a full GC right before the measure. Needs `--js-flags=--expose-gc`, added to the krausest config.

The read on #223's bench run: if `update-10th-50` regresses while `update-isolated-50` and `update-gc-50` stay flat, the cost is reclaimable GC pressure from op ordering, not a per-user regression.

Reverted once #223's run has read these. Bench harness is pinned from main, so #223 picks these up automatically on its next run.