### PR TITLE
Bench: Collect on teardown so each krausest op starts on a freed heap

### DIFF
--- a/packages/component/bench/tachometer/bench-krausest.js
+++ b/packages/component/bench/tachometer/bench-krausest.js
@@ -200,6 +200,17 @@ async function mount() {
 
 function destroy() {
   container.innerHTML = '';
+  // Collect on teardown so each op measures on a freed heap, not the old-space
+  // the previous op grew. Runs after every performance.measure, never inside a
+  // measured region.
+  if (globalThis.gc) {
+    try {
+      globalThis.gc({ type: 'major', execution: 'sync', flavor: 'last-resort' });
+    }
+    catch {
+      globalThis.gc();
+    }
+  }
 }
 
 function getRows(el) {

--- a/packages/component/bench/tachometer/tachometer-ci-krausest.json
+++ b/packages/component/bench/tachometer/tachometer-ci-krausest.json
@@ -8,7 +8,7 @@
     {
       "name": "this-change",
       "url": "ci-current-krausest.html",
-      "browser": { "name": "chrome", "headless": true },
+      "browser": { "name": "chrome", "headless": true, "addArguments": ["--js-flags=--expose-gc"] },
       "measurement": [
         { "mode": "performance", "entryName": "create-1k" },
         { "mode": "performance", "entryName": "create-10k" },
@@ -26,7 +26,7 @@
     {
       "name": "tip-of-tree",
       "url": "ci-baseline-krausest.html",
-      "browser": { "name": "chrome", "headless": true },
+      "browser": { "name": "chrome", "headless": true, "addArguments": ["--js-flags=--expose-gc"] },
       "measurement": [
         { "mode": "performance", "entryName": "create-1k" },
         { "mode": "performance", "entryName": "create-10k" },


### PR DESCRIPTION
Validates collect-on-teardown on krausest before generalizing it to the other suites.