### PR TITLE
Bench: Collect on teardown in todo and template suites

### DIFF
--- a/packages/component/bench/tachometer/bench-template.js
+++ b/packages/component/bench/tachometer/bench-template.js
@@ -30,6 +30,17 @@ document.body.appendChild(container);
 
 function destroy() {
   container.innerHTML = '';
+  // Collect on teardown so each op measures on a freed heap, not the old-space
+  // the previous op grew. Runs after every performance.measure, never inside a
+  // measured region.
+  if (globalThis.gc) {
+    try {
+      globalThis.gc({ type: 'major', execution: 'sync', flavor: 'last-resort' });
+    }
+    catch {
+      globalThis.gc();
+    }
+  }
 }
 
 /*******************************

--- a/packages/component/bench/tachometer/bench-todo.js
+++ b/packages/component/bench/tachometer/bench-todo.js
@@ -161,6 +161,17 @@ async function mount() {
 
 function destroy() {
   container.innerHTML = '';
+  // Collect on teardown so each op measures on a freed heap, not the old-space
+  // the previous op grew. Runs after every performance.measure, never inside a
+  // measured region.
+  if (globalThis.gc) {
+    try {
+      globalThis.gc({ type: 'major', execution: 'sync', flavor: 'last-resort' });
+    }
+    catch {
+      globalThis.gc();
+    }
+  }
 }
 
 function getTodos(el) {

--- a/packages/component/bench/tachometer/tachometer-ci-template.json
+++ b/packages/component/bench/tachometer/tachometer-ci-template.json
@@ -8,7 +8,7 @@
     {
       "name": "this-change",
       "url": "ci-current-template.html",
-      "browser": { "name": "chrome", "headless": true },
+      "browser": { "name": "chrome", "headless": true, "addArguments": ["--js-flags=--expose-gc"] },
       "measurement": [
         { "mode": "performance", "entryName": "subtemplate-reactive-data-100x500" },
         { "mode": "performance", "entryName": "subtemplate-shorthand-props-100x500" },
@@ -26,7 +26,7 @@
     {
       "name": "tip-of-tree",
       "url": "ci-baseline-template.html",
-      "browser": { "name": "chrome", "headless": true },
+      "browser": { "name": "chrome", "headless": true, "addArguments": ["--js-flags=--expose-gc"] },
       "measurement": [
         { "mode": "performance", "entryName": "subtemplate-reactive-data-100x500" },
         { "mode": "performance", "entryName": "subtemplate-shorthand-props-100x500" },

--- a/packages/component/bench/tachometer/tachometer-ci-todo-micro.json
+++ b/packages/component/bench/tachometer/tachometer-ci-todo-micro.json
@@ -8,7 +8,7 @@
     {
       "name": "this-change",
       "url": "ci-current-todo.html",
-      "browser": { "name": "chrome", "headless": true },
+      "browser": { "name": "chrome", "headless": true, "addArguments": ["--js-flags=--expose-gc"] },
       "measurement": [
         { "mode": "performance", "entryName": "toggle-first-100" },
         { "mode": "performance", "entryName": "toggle-middle-100" },
@@ -25,7 +25,7 @@
     {
       "name": "tip-of-tree",
       "url": "ci-baseline-todo.html",
-      "browser": { "name": "chrome", "headless": true },
+      "browser": { "name": "chrome", "headless": true, "addArguments": ["--js-flags=--expose-gc"] },
       "measurement": [
         { "mode": "performance", "entryName": "toggle-first-100" },
         { "mode": "performance", "entryName": "toggle-middle-100" },

--- a/packages/component/bench/tachometer/tachometer-ci-todo.json
+++ b/packages/component/bench/tachometer/tachometer-ci-todo.json
@@ -8,7 +8,7 @@
     {
       "name": "this-change",
       "url": "ci-current-todo.html",
-      "browser": { "name": "chrome", "headless": true },
+      "browser": { "name": "chrome", "headless": true, "addArguments": ["--js-flags=--expose-gc"] },
       "measurement": [
         { "mode": "performance", "entryName": "bulk-add-500" },
         { "mode": "performance", "entryName": "add-20" },
@@ -23,7 +23,7 @@
     {
       "name": "tip-of-tree",
       "url": "ci-baseline-todo.html",
-      "browser": { "name": "chrome", "headless": true },
+      "browser": { "name": "chrome", "headless": true, "addArguments": ["--js-flags=--expose-gc"] },
       "measurement": [
         { "mode": "performance", "entryName": "bulk-add-500" },
         { "mode": "performance", "entryName": "add-20" },


### PR DESCRIPTION
Extends collect-on-teardown (validated on krausest) to the todo and template suites.