### PR TITLE
Feat: Add version counter to Signal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ xx.xx.xxxx
 * **Feature** - Added `depend()` to register a signal as a dependency without reading the value
 * **Feature** - Added `notify()` to force-trigger subscribers bypassing the equality check
 * **Feature** - Added `hasDependents()` to check if any reactions are subscribed to a signal
+* **Feature** - Added `version`, a monotonic change counter that bumps on every `notify()`, readable without subscribing and seedable via the `version` option
 * **Feature** - Module-level functional surface — `signal`, `reaction`, `derive`, `computed`, `match`, `nonreactive`, `guard`, `afterFlush`, `flush`, `scheduleFlush`, `currentReaction`, `getSource` ship as named exports alongside the classes
 * **Feature** - Added `match(source, matchFn?)` — per-key reactive membership against a source signal, the perf primitive that backs `{#match}` template blocks (Solid's `createSelector` adapted)
 * **Feature** - Added `setItemProperty`, `setIndexProperty`, `toggleItemProperty`, and `toggleProperty` collection helpers for setting or flipping a field by id, by index, or across every item

--- a/ai/skills/authoring/reactive-state.md
+++ b/ai/skills/authoring/reactive-state.md
@@ -51,6 +51,7 @@ signal(initialValue, options)
   - `equality`: Function - Custom equality comparison (default: deep equality)
   - `clone`: Function - Custom clone, used when `safety` is `'clone'` (default: deep clone)
   - `id`: Function - Resolves array-item identity for the id-based collection helpers
+  - `version`: Number - Seeds the change counter (default: `0`), for aligning with an external store's revision
   - `context`: Object - Debugging context metadata
 
 **Examples**:
@@ -79,6 +80,7 @@ const items = signal([], {
 signal.get()           // Read value, creates dependency in reactive contexts
 signal.value           // Property accessor, same as get()
 signal.peek()          // Read value WITHOUT creating dependency
+signal.version         // Monotonic change counter, bumps on every notify(), plain read (no dependency)
 ```
 
 #### Writing Values

--- a/docs/src/content/examples/reactive-version.mdx
+++ b/docs/src/content/examples/reactive-version.mdx
@@ -1,0 +1,11 @@
+---
+title: 'Version'
+shortTitle: 'Version'
+id: 'reactive-version'
+exampleType: 'log'
+category: 'Reactivity'
+subcategory: 'Signals'
+tags: ['reactivity', 'signals', 'version', 'dependencies']
+description: 'Discriminate which of several tracked signals changed'
+tip: 'The get() calls own the subscription, version is read as a plain value so comparing it adds no dependency'
+---

--- a/docs/src/examples/reactivity/introduction/reactive-version/index.js
+++ b/docs/src/examples/reactivity/introduction/reactive-version/index.js
@@ -1,0 +1,31 @@
+import { flush, reaction, signal } from '@semantic-ui/reactivity';
+
+const rows = signal(['a', 'b']);
+const filter = signal('all');
+
+let seenRows = rows.version;
+
+// one reaction tracks both signals, version tells us which one moved
+reaction((computation) => {
+  rows.get(); // these two reads own the subscription
+  filter.get();
+
+  if (computation.firstRun) {
+    console.log('initial render');
+    return;
+  }
+
+  if (rows.version !== seenRows) {
+    seenRows = rows.version;
+    console.log('rows changed — reindex');
+  }
+  else {
+    console.log('filter changed — refilter');
+  }
+});
+
+filter.set('active'); // only filter moved
+flush();
+
+rows.push('c'); // rows moved
+flush();

--- a/docs/src/pages/docs/api/reactivity/signal.mdx
+++ b/docs/src/pages/docs/api/reactivity/signal.mdx
@@ -4,7 +4,7 @@ pageType: 'API Reference'
 title: Signal
 icon: box
 package: "@semantic-ui/reactivity"
-methods: [signal, get, value, peek, raw, set, mutate, clear, depend, notify, hasDependents, derive]
+methods: [signal, get, value, peek, raw, set, mutate, clear, depend, notify, hasDependents, version, derive]
 description: API reference for Signal in Semantic UI's reactivity system
 ---
 import PlaygroundExample from '@components/PlaygroundExample/PlaygroundExample.astro';
@@ -39,6 +39,7 @@ Creates a reactive value.
 | equality | function | deep equality | Decides whether a new value differs from the current one. Snapshotted at construction |
 | clone | function | structured clone | Copies values under `safety: 'clone'` and for change detection in `mutate` |
 | id | function | `id` ?? `_id` ?? `hash` ?? `key` | Resolves an array item's identity for the collection helpers |
+| version | number | `0` | Seeds the change counter, for aligning with an external store's revision |
 
 #### Example
 
@@ -201,6 +202,25 @@ Reports whether any reaction is currently subscribed to this signal.
 #### Example
 
 <PlaygroundExample id="reactive-has-dependents" direction="horizontal"></PlaygroundExample>
+
+### version
+
+```javascript
+signal.version;
+signal.version = revision;
+```
+
+A monotonic integer that increments inside `notify()`, so it advances on every announced change: a `set()` to a non-equal value, an in-place mutation helper, or a force `notify()`. A `set()` that the equality check treats as a no-op leaves it unchanged. Reading it does not subscribe the running reaction.
+
+Assign to it to realign with an external store's revision. Seed the starting value with the `version` option on `signal()`.
+
+#### Returns
+
+The current change count, starting at `0`.
+
+#### Example
+
+<PlaygroundExample id="reactive-version" direction="horizontal"></PlaygroundExample>
 
 ## Deriving
 

--- a/packages/reactivity/src/signal.js
+++ b/packages/reactivity/src/signal.js
@@ -33,6 +33,7 @@ export class Signal {
     clone = Signal.clone,
     equality = (safety === 'none') ? returnsFalse : Signal.equality,
     id = Signal.id,
+    version = 0,
     context,
   } = {}) {
     // create dependency
@@ -51,6 +52,8 @@ export class Signal {
 
     this.safety = safety;
     this.currentValue = this.protect(initialValue);
+    // monotonic change counter for debugging / external-store
+    this.version = version;
 
     // pass through debugging context
     this.setContext(context);
@@ -89,6 +92,7 @@ export class Signal {
   }
 
   notify() {
+    this.version++;
     this.setContext();
     this.setTrace();
     this.dependency.changed(this.context);

--- a/packages/reactivity/test/unit/signal.test.js
+++ b/packages/reactivity/test/unit/signal.test.js
@@ -927,6 +927,65 @@ describe('Signal API', () => {
   });
 
   /***********************************************
+   * version — change counter for debug + sync
+   ***********************************************/
+
+  describe('version', () => {
+    it('starts at 0 and increments on each announced change', () => {
+      const signal = new Signal('a');
+      expect(signal.version).toBe(0);
+      signal.set('b');
+      expect(signal.version).toBe(1);
+      signal.set('c');
+      expect(signal.version).toBe(2);
+    });
+
+    it('does not increment when a set is a no-op under equality', () => {
+      const signal = new Signal('a');
+      signal.set('a');
+      expect(signal.version).toBe(0);
+    });
+
+    it('advances with no subscribers — its readers live outside the reactive graph', () => {
+      const signal = new Signal(0);
+      expect(signal.hasDependents()).toBe(false);
+      signal.set(1);
+      expect(signal.version).toBe(1);
+    });
+
+    it('seeds from the version option for external-store alignment', () => {
+      const signal = new Signal({ rows: [] }, { version: 42 });
+      expect(signal.version).toBe(42);
+      signal.set({ rows: [1] });
+      expect(signal.version).toBe(43);
+    });
+
+    it('is writable so it can be realigned to an external revision', () => {
+      const signal = new Signal('a');
+      signal.version = 100;
+      signal.set('b');
+      expect(signal.version).toBe(101);
+    });
+
+    it('reading version does not subscribe the running reaction', () => {
+      const source = new Signal(0);
+      const cb = vi.fn(() => source.version);
+      reaction(cb);
+      expect(cb).toHaveBeenCalledTimes(1);
+
+      source.set(1);
+      flush();
+      expect(cb).toHaveBeenCalledTimes(1);
+    });
+
+    it('a force notify() advances version even without a value change', () => {
+      const signal = new Signal('a');
+      signal.notify();
+      expect(signal.version).toBe(1);
+    });
+  });
+
+  /***********************************************
    * notify() — force-fire bypassing equality
    ***********************************************/
 

--- a/packages/reactivity/types/signal.d.ts
+++ b/packages/reactivity/types/signal.d.ts
@@ -38,6 +38,12 @@ export interface SignalOptions<T> {
   id?: (item: any) => any;
 
   /**
+   * Seeds the signal's change counter, for aligning `version` with an external
+   * store's revision on hydration. Defaults to `0`.
+   */
+  version?: number;
+
+  /**
    * Debugging context attached to the signal, surfaced in tracing output.
    */
   context?: Record<string, any>;
@@ -192,6 +198,13 @@ export class Signal<T> {
    * @see {@link https://next.semantic-ui.com/docs/api/reactivity/signal#clone clone}
    */
   clone(): T;
+
+  /**
+   * Monotonic change counter, bumped on every announced change. Reading it does not
+   * subscribe the running reaction. Seedable via the `version` option and freely assignable.
+   * @see {@link https://next.semantic-ui.com/docs/api/reactivity/signal#version version}
+   */
+  version: number;
 
   /**
    * Sets the signal's value to undefined.


### PR DESCRIPTION
Adds `version` to signals to allow dirty checking on reactions. 

This can be used in a reaction with multiple sources to determine if data is the same as last run.

## Changes
- Adds `signal.version`  and `option.version` to seed it 

## Risk
2/10 
Just an incrementing counter but in hot path