### PR TITLE
Bench: Add Signal mutate benches

### DIFF
--- a/packages/reactivity/bench/tachometer/bench-signal.js
+++ b/packages/reactivity/bench/tachometer/bench-signal.js
@@ -29,6 +29,13 @@ const makeRecords = (n) => {
   return out;
 };
 
+const makeDoc = () => ({
+  title: 'Untitled',
+  meta: { author: 'anon', created: 0, updated: 0, tags: ['draft'] },
+  settings: { theme: 'light', fontSize: 14, autosave: true },
+  body: { blocks: ['intro', 'body', 'outro'], wordCount: 0 },
+});
+
 let sink = null;
 
 /*******************************
@@ -270,6 +277,49 @@ let sink = null;
   }
   performance.measure('reactive-set-property-by-id-200', startMark('reactive-set-property-by-id-200'));
   r.stop();
+}
+
+/*******************************
+      Mutate dirty-detection
+      (no subscriber — isolates the
+       clone-before / compare-after
+       cost the proxy rewrite targets)
+*******************************/
+
+// mutate-grid-row-edit-600 — edits two fields of one row in a 1000-row grid
+// in place. mutate() clones the whole list up front and deep-compares after, so
+// the cost is O(list) (~340µs/op here) no matter how little the callback
+// touches — the shape a revocable-proxy dirty-check would collapse to O(touched).
+// 600 iters lands ~200ms, comfortably above the σ-floor.
+{
+  const sig = new Signal(makeRecords(1000));
+  // purpose: Edits two fields of one row in a 1000-row list signal via mutate(), in place, 600 times. Clone-before/compare-after cost.
+  performance.mark(startMark('mutate-grid-row-edit-600'));
+  for (let i = 0; i < 600; i++) {
+    const idx = i % 1000;
+    sig.mutate(rows => {
+      rows[idx].name = `Record ${i}`;
+      rows[idx].active = !rows[idx].active;
+    });
+  }
+  performance.measure('mutate-grid-row-edit-600', startMark('mutate-grid-row-edit-600'));
+}
+
+// mutate-doc-nested-200k — edits two nested fields of a small structured
+// document in place. Cheap to clone and compare (~1.1µs/op), so this is where a
+// per-call Proxy setup cost has to earn itself — the honesty counterpart to the
+// grid case, not a win-flattering one. 200k iters lands ~230ms.
+{
+  const sig = new Signal(makeDoc());
+  // purpose: Edits two nested fields of a structured document signal via mutate(), in place, 200000 times. Small-object clone/compare baseline.
+  performance.mark(startMark('mutate-doc-nested-200k'));
+  for (let i = 0; i < 200_000; i++) {
+    sig.mutate(doc => {
+      doc.meta.updated = i;
+      doc.body.wordCount = i & 1023;
+    });
+  }
+  performance.measure('mutate-doc-nested-200k', startMark('mutate-doc-nested-200k'));
 }
 
 /*******************************


### PR DESCRIPTION
Baseline for the upcoming revocable-proxy `mutate()` change — there's no `mutate()` coverage today. Two real shapes: a 1000-row list edit, where the clone-before/compare-after is O(list) (~340µs/op), and a small nested-object edit, where the per-call Proxy overhead has to earn itself.

No subscriber on either, so they isolate the dirty-detection path the proxy rewrites. They land flat here and give the feature PR something to move.