### PR TITLE
Bench: Use match selector in krausest apps

### DIFF
--- a/packages/component/bench/tachometer/bench-krausest.js
+++ b/packages/component/bench/tachometer/bench-krausest.js
@@ -106,31 +106,24 @@ function buildData(count) {
       Component Definition
 *******************************/
 
-const signalOptions = { safety: 'reference' };
-
 defineComponent({
   tagName: 'bench-app',
-  template: `<table><tbody>
-    {#each rows as row}
-      <tr class="{isSelected row.id}">
-        <td class="col-md-1">{row.id}</td>
-        <td class="col-md-4"><a class="lbl" data-id="{row.id}">{row.label}</a></td>
-        <td class="col-md-1"><a class="remove" data-id="{row.id}"><span class="glyphicon glyphicon-remove" aria-hidden="true"></span></a></td>
-        <td class="col-md-6"></td>
-      </tr>
-    {/each}
-  </tbody></table>`,
+  // single line: inter-tag whitespace compiles to per-row text nodes
+  template:
+    `<table><tbody>{#each rows as row}<tr class="{isSelected row.id}"><td class="col-md-1">{row.id}</td><td class="col-md-4"><a class="lbl" data-id="{row.id}">{row.label}</a></td><td class="col-md-1"><a class="remove" data-id="{row.id}"><span class="glyphicon glyphicon-remove" aria-hidden="true"></span></a></td><td class="col-md-6"></td></tr>{/each}</tbody></table>`,
   defaultState: {
-    rows: { value: [], options: signalOptions },
-    selected: { value: 0, options: signalOptions },
+    rows: [],
+    selected: 0,
   },
-  createComponent({ state }) {
+  createComponent({ state, match }) {
+    // per-key selector: selection change re-fires only the flipped rows
+    const selectedMatch = match(state.selected);
     return {
       // bench access
       getRows: () => state.rows.peek(),
 
       isSelected(id) {
-        return state.selected.get() === id ? 'danger' : '';
+        return selectedMatch(id) ? 'danger' : '';
       },
 
       run(n) {

--- a/packages/component/bench/tachometer/bench-krausest.js
+++ b/packages/component/bench/tachometer/bench-krausest.js
@@ -108,9 +108,16 @@ function buildData(count) {
 
 defineComponent({
   tagName: 'bench-app',
-  // single line: inter-tag whitespace compiles to per-row text nodes
-  template:
-    `<table><tbody>{#each rows as row}<tr class="{isSelected row.id}"><td class="col-md-1">{row.id}</td><td class="col-md-4"><a class="lbl" data-id="{row.id}">{row.label}</a></td><td class="col-md-1"><a class="remove" data-id="{row.id}"><span class="glyphicon glyphicon-remove" aria-hidden="true"></span></a></td><td class="col-md-6"></td></tr>{/each}</tbody></table>`,
+  template: `<table><tbody>
+    {#each rows as row}
+      <tr class="{isSelected row.id}">
+        <td class="col-md-1">{row.id}</td>
+        <td class="col-md-4"><a class="lbl" data-id="{row.id}">{row.label}</a></td>
+        <td class="col-md-1"><a class="remove" data-id="{row.id}"><span class="glyphicon glyphicon-remove" aria-hidden="true"></span></a></td>
+        <td class="col-md-6"></td>
+      </tr>
+    {/each}
+  </tbody></table>`,
   defaultState: {
     rows: [],
     selected: 0,

--- a/tools/benchmark/src/main.js
+++ b/tools/benchmark/src/main.js
@@ -4,55 +4,56 @@ import mainCSS from '../css/main.css';
 import { buildData } from './store.js';
 import ast from './template.html?ast';
 
-// Pinned to reference safety so equality runs the fast path and each op fires
-// once. Mutations use in-place helpers (push / map / removeItem / new-ref set),
-// never mutate-then-set-same-ref, which would no-op under reference equality.
-const signalOptions = { safety: 'reference' };
-
+// Mutations use in-place helpers (push / removeItem / peek + notify), never
+// mutate-then-set-same-ref, which would no-op under reference equality.
 const defaultState = {
-  rows: { value: [], options: signalOptions },
-  selected: { value: 0, options: signalOptions },
+  rows: [],
+  selected: 0,
 };
 
-const createComponent = ({ state }) => ({
-  isSelected(id) {
-    return state.selected.get() === id ? 'danger' : '';
-  },
+const createComponent = ({ state, match }) => {
+  // per-key selector: selection change re-fires only the flipped rows
+  const selectedMatch = match(state.selected);
+  return {
+    isSelected(id) {
+      return selectedMatch(id) ? 'danger' : '';
+    },
 
-  run() {
-    state.rows.set(buildData(1000));
-  },
+    run() {
+      state.rows.set(buildData(1000));
+    },
 
-  runLots() {
-    state.rows.set(buildData(10000));
-  },
+    runLots() {
+      state.rows.set(buildData(10000));
+    },
 
-  add() {
-    state.rows.push(...buildData(1000));
-  },
+    add() {
+      state.rows.push(...buildData(1000));
+    },
 
-  update() {
-    const rows = state.rows.peek();
-    for (let i = 0, len = rows.length; i < len; i += 10) {
-      rows[i].label += ' !!!';
-    }
-    state.rows.notify();
-  },
-
-  clear() {
-    state.rows.set([]);
-  },
-
-  swapRows() {
-    const rows = state.rows.peek();
-    if (rows.length > 998) {
-      const tmp = rows[1];
-      rows[1] = rows[998];
-      rows[998] = tmp;
+    update() {
+      const rows = state.rows.peek();
+      for (let i = 0, len = rows.length; i < len; i += 10) {
+        rows[i].label += ' !!!';
+      }
       state.rows.notify();
-    }
-  },
-});
+    },
+
+    clear() {
+      state.rows.set([]);
+    },
+
+    swapRows() {
+      const rows = state.rows.peek();
+      if (rows.length > 998) {
+        const tmp = rows[1];
+        rows[1] = rows[998];
+        rows[998] = tmp;
+        state.rows.notify();
+      }
+    },
+  };
+};
 
 const events = {
   'click .lbl'({ state, data }) {

--- a/tools/benchmark/src/template.html
+++ b/tools/benchmark/src/template.html
@@ -27,7 +27,16 @@
     </div>
   </div>
   <table class="table table-hover table-striped test-data">
-    <tbody id="tbody">{#each rows as row}<tr class="{isSelected row.id}"><td class="col-md-1">{row.id}</td><td class="col-md-4"><a class="lbl" data-id="{row.id}">{row.label}</a></td><td class="col-md-1"><a class="remove" data-id="{row.id}"><span class="glyphicon glyphicon-remove" aria-hidden="true"></span></a></td><td class="col-md-6"></td></tr>{/each}</tbody>
+    <tbody id="tbody">
+      {#each rows as row}
+        <tr class="{isSelected row.id}">
+          <td class="col-md-1">{row.id}</td>
+          <td class="col-md-4"><a class="lbl" data-id="{row.id}">{row.label}</a></td>
+          <td class="col-md-1"><a class="remove" data-id="{row.id}"><span class="glyphicon glyphicon-remove" aria-hidden="true"></span></a></td>
+          <td class="col-md-6"></td>
+        </tr>
+      {/each}
+    </tbody>
   </table>
   <span class="preloadicon glyphicon glyphicon-remove" aria-hidden="true"></span>
 </div>

--- a/tools/benchmark/src/template.html
+++ b/tools/benchmark/src/template.html
@@ -27,16 +27,7 @@
     </div>
   </div>
   <table class="table table-hover table-striped test-data">
-    <tbody id="tbody">
-      {#each rows as row}
-        <tr class="{isSelected row.id}">
-          <td class="col-md-1">{row.id}</td>
-          <td class="col-md-4"><a class="lbl" data-id="{row.id}">{row.label}</a></td>
-          <td class="col-md-1"><a class="remove" data-id="{row.id}"><span class="glyphicon glyphicon-remove" aria-hidden="true"></span></a></td>
-          <td class="col-md-6"></td>
-        </tr>
-      {/each}
-    </tbody>
+    <tbody id="tbody">{#each rows as row}<tr class="{isSelected row.id}"><td class="col-md-1">{row.id}</td><td class="col-md-4"><a class="lbl" data-id="{row.id}">{row.label}</a></td><td class="col-md-1"><a class="remove" data-id="{row.id}"><span class="glyphicon glyphicon-remove" aria-hidden="true"></span></a></td><td class="col-md-6"></td></tr>{/each}</tbody>
   </table>
   <span class="preloadicon glyphicon glyphicon-remove" aria-hidden="true"></span>
 </div>


### PR DESCRIPTION
This adds the new performant reactive primitive `match` for use in Krausest in the hot path.

## Changes
- Selection re-fires only the flipped rows via `match` (was all 1000)
- Plain `defaultState` values reference safety is now live
