### PR TITLE
Test: Cover condense whitespace raw-text edge paths

### DIFF
--- a/packages/compiler/test/condense-whitespace.test.js
+++ b/packages/compiler/test/condense-whitespace.test.js
@@ -126,6 +126,53 @@ describe('condenseWhitespace', () => {
       ]);
     });
 
+    it('preserves whitespace inside script', () => {
+      const ast = compile(`<script>
+  let a = 1
+  let b = 2
+</script><div>
+  <p>a</p>
+</div>`);
+      expect(ast).toEqual([
+        { type: 'html', html: '<script>\n  let a = 1\n  let b = 2\n</script><div><p>a</p></div>' },
+      ]);
+    });
+
+    it('preserves whitespace inside style', () => {
+      const ast = compile(`<style>
+  @import url(a.css);
+  @import url(b.css);
+</style><div>
+  <p>a</p>
+</div>`);
+      expect(ast).toEqual([
+        { type: 'html', html: '<style>\n  @import url(a.css);\n  @import url(b.css);\n</style><div><p>a</p></div>' },
+      ]);
+    });
+
+    it('preserves textarea content when an expression splits the open tag', () => {
+      const ast = compile(`<textarea class="{fieldClass}">  keep
+    this  </textarea><div>
+  <p>a</p>
+</div>`);
+      expect(ast).toEqual([
+        { type: 'html', html: '<textarea class="' },
+        { type: 'expression', value: 'fieldClass' },
+        { type: 'html', html: '">  keep\n    this  </textarea><div><p>a</p></div>' },
+      ]);
+    });
+
+    it('does not treat a self-closed split tag as raw text', () => {
+      const ast = compile(`<textarea class="{x}"/><div>
+  <p>a</p>
+</div>`);
+      expect(ast).toEqual([
+        { type: 'html', html: '<textarea class="' },
+        { type: 'expression', value: 'x' },
+        { type: 'html', html: '"/><div><p>a</p></div>' },
+      ]);
+    });
+
     it('preserves pre content across an expression boundary', () => {
       const ast = compile(`<pre>  before
 {code}

--- a/packages/component/test/unit/whitespace-css.test.js
+++ b/packages/component/test/unit/whitespace-css.test.js
@@ -30,4 +30,14 @@ describe('whitespace-sensitive css', () => {
     const component = defineComponent({ template, css: '.code { white-space-collapse: preserve; }' });
     expect(component.ast[0].html).toContain('\n');
   });
+
+  it('still condenses for non-sensitive white-space values', () => {
+    const component = defineComponent({ template, css: 'li { white-space: nowrap; }' });
+    expect(component.ast[0].html).toBe('<ul><li>a</li></ul>');
+  });
+
+  it('explicit true preserves without css', () => {
+    const component = defineComponent({ template, preserveWhitespace: true });
+    expect(component.ast[0].html).toContain('\n');
+  });
 });


### PR DESCRIPTION
Adds missing tests from #246 for degenerate whitespace cases.