### PR TITLE
Bug: Don't fire the size and heap bots on harness-only edits

### DIFF
--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -14,9 +14,12 @@ on:
       # build scripts shape the output bytes, so a change here is a real
       # (and measurable) size change, not a harness edit
       - 'internal-packages/scripts/**'
-      # the size harness itself — self-test on its own PRs
-      - 'tools/ci/size/**'
+      # this workflow — changes take effect on the PR's own run, so self-test
       - '.github/workflows/bundle-size.yml'
+      # The harness (tools/ci/size/**) is deliberately NOT listed. The measure
+      # job overlays it from main before every run, so a PR-side harness edit
+      # can't affect its own comment — harness changes land on main first, same
+      # as the bench suite.
 
 concurrency:
   group: bundle-size-${{ github.ref }}

--- a/.github/workflows/memory.yml
+++ b/.github/workflows/memory.yml
@@ -16,9 +16,13 @@ on:
       - 'packages/renderer/**'
       - 'packages/templating/**'
       - 'packages/component/**'
-      # the heap harness itself — self-test on its own PRs
-      - 'tools/ci/memory/**'
+      # this workflow — changes take effect on the PR's own run (pull_request
+      # uses PR-head YAML), so self-test
       - '.github/workflows/memory.yml'
+      # The harness (tools/ci/memory/**) is deliberately NOT listed. The measure
+      # job overlays it from main before every run, so a PR-side harness edit
+      # can't affect its own comment — harness changes land on main first, same
+      # as the bench suite.
 
 concurrency:
   group: memory-${{ github.ref }}


### PR DESCRIPTION
Fixes heap bot firing on CI changes surfaced from #270

## Risk
0/10 — CI triggers only, no published code.
