### PR TITLE
Build: Prebuild staging and production deploys in CI

### DIFF
--- a/.github/workflows/release-deploy.yml
+++ b/.github/workflows/release-deploy.yml
@@ -1,5 +1,8 @@
-# Deploy docs site and MCP server to production on tagged releases.
-# Previews are label-gated by the Deploy Bot (tools/ci/deploy). Vercel's automatic Git deploys are off.
+# Deploy the docs site and MCP server to production on tagged releases.
+# Builds in CI and ships prebuilt (no Vercel build minutes), matching the PR
+# preview (pr-deploy.yml) and staging (staging-deploy.yml) flows. Previews are
+# label-gated by the Deploy Bot; staging tracks main. Vercel's own Git deploys
+# are off, so these workflows are the only deploy path.
 # Requires: VERCEL_TOKEN, VERCEL_ORG_ID, VERCEL_DOCS_PROJECT_ID, VERCEL_MCP_PROJECT_ID
 
 name: Release Deploy
@@ -13,53 +16,63 @@ concurrency:
   group: release-deploy
   cancel-in-progress: false
 
+permissions:
+  contents: read
+
 jobs:
   deploy-docs:
     name: Deploy Docs to Production
     runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_DOCS_PROJECT_ID }}
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v7
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
         with:
           node-version-file: '.node-version'
           cache: 'npm'
 
-      - name: Install dependencies
-        run: npm ci
+      # same caches as the preview and staging deploys (shared docs-astro- prefix)
+      - uses: google/wireit@setup-github-actions-caching/v2
+      - uses: actions/cache@v6
+        with:
+          path: docs/node_modules/.astro
+          key: docs-astro-${{ runner.os }}-${{ github.sha }}
+          restore-keys: |
+            docs-astro-${{ runner.os }}-
 
-      - name: Deploy docs to production
-        run: npx vercel deploy --prod --token=${{ secrets.VERCEL_TOKEN }}
+      - name: Build and deploy docs to production
         env:
-          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_DOCS_PROJECT_ID }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+        run: |
+          npx vercel pull --yes --environment=production --token="$VERCEL_TOKEN"
+          npx vercel build --prod --token="$VERCEL_TOKEN"
+          npx vercel deploy --prebuilt --prod --token="$VERCEL_TOKEN"
 
+  # runs from the repo root, not tools/mcp: the mcp project's Root Directory is
+  # tools/mcp, which vercel applies relative to the working directory, so running
+  # from tools/mcp doubles the path to tools/mcp/tools/mcp.
   deploy-mcp:
     name: Deploy MCP to Production
     needs: deploy-docs
     runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_MCP_PROJECT_ID }}
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v7
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
         with:
           node-version-file: '.node-version'
           cache: 'npm'
 
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Build MCP server
-        run: npm run build:vercel
-        working-directory: tools/mcp
-
-      - name: Deploy MCP to production
-        run: npx vercel deploy --prod --token=${{ secrets.VERCEL_TOKEN }}
-        working-directory: tools/mcp
+      - name: Build and deploy mcp to production
         env:
-          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_MCP_PROJECT_ID }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+        run: |
+          npx vercel pull --yes --environment=production --token="$VERCEL_TOKEN"
+          npx vercel build --prod --token="$VERCEL_TOKEN"
+          npx vercel deploy --prebuilt --prod --token="$VERCEL_TOKEN"

--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -1,0 +1,55 @@
+name: Staging Deploy
+
+# Deploys the docs site to the staging environment (staging.semantic-ui.com) on
+# every push to main. Replaces Vercel's branch tracking for that environment so
+# the build runs in CI and ships prebuilt, matching the PR preview flow and
+# spending no Vercel build minutes. See tools/ci/deploy/README.md.
+
+on:
+  push:
+    branches: [main]
+
+concurrency:
+  # a newer main push supersedes an in-flight staging build
+  group: staging-deploy
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  docs:
+    name: Deploy docs to staging
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_DOCS_PROJECT_ID }}
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: '.node-version'
+          cache: 'npm'
+
+      # same caches as the PR deploy, shared via the docs-astro- prefix: wireit's
+      # per-package outputs + astro's incremental cache, so vercel build reuses
+      # them instead of rebuilding from scratch.
+      - uses: google/wireit@setup-github-actions-caching/v2
+      - uses: actions/cache@v6
+        with:
+          path: docs/node_modules/.astro
+          key: docs-astro-${{ runner.os }}-${{ github.sha }}
+          restore-keys: |
+            docs-astro-${{ runner.os }}-
+
+      # build in CI and ship prebuilt to the staging environment, so Vercel runs
+      # no remote build. the CLI pairs --environment (pull) with --target
+      # (build/deploy) for a custom environment.
+      - name: Build and deploy docs to staging
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+        run: |
+          npx vercel pull --yes --environment=staging --token="$VERCEL_TOKEN"
+          npx vercel build --target=staging --token="$VERCEL_TOKEN"
+          npx vercel deploy --prebuilt --target=staging --token="$VERCEL_TOKEN"

--- a/tools/ci/deploy/README.md
+++ b/tools/ci/deploy/README.md
@@ -63,6 +63,22 @@ why it's fenced to in-repo branches.
 deploy. Until the deploy tooling and the bot secrets exist on `main`, the comment
 jobs stay inert (the deploy jobs still run, a self-test).
 
+## The fixed environments
+
+PR previews are the bot's job. The two long-lived environments deploy the same
+prebuilt way (build in CI, `vercel deploy --prebuilt`, no Vercel build minutes),
+just without a comment since there's no PR to post to:
+
+- **`staging-deploy.yml`** deploys the docs site to the `staging` environment
+  (`staging.semantic-ui.com`) on every push to `main`, replacing Vercel's branch
+  tracking for that environment so the build runs in CI.
+- **`release-deploy.yml`** deploys docs and mcp to production
+  (`next.semantic-ui.com`) on `v*` tags.
+
+With those in place, Vercel's own Git deploys stay off (the `staging`
+environment's branch tracking is disconnected on Vercel), so these workflows are
+the only path to any environment.
+
 ## Setup (one time)
 
 1. Create a GitHub App **Semantic Deploy Bot**.


### PR DESCRIPTION
The moves `main` and `tagged` releases to now use prebuild from CI instead of vercel runners.