### PR TITLE
Bug: Fix behavior registration under new bundler

### DIFF
--- a/docs/src/components/CodePlayground/CodePlaygroundPreview.js
+++ b/docs/src/components/CodePlayground/CodePlaygroundPreview.js
@@ -1,6 +1,7 @@
 import { TemplateCompiler } from '@semantic-ui/compiler';
 import { defineComponent } from '@semantic-ui/component';
-import { Tooltip } from '@semantic-ui/core';
+// bare side-effect import: a named import gets elided by the bundler, dropping registration
+import '@semantic-ui/core';
 import css from './CodePlaygroundPreview.css?raw';
 import template from './CodePlaygroundPreview.html?raw';
 import './lib/pretty-json.js';

--- a/docs/src/components/CodeSample/CodeSample.js
+++ b/docs/src/components/CodeSample/CodeSample.js
@@ -1,4 +1,5 @@
-import { CopyButton, Tooltip } from '@semantic-ui/core';
+// bare side-effect import: a named import gets elided by the bundler, dropping registration
+import '@semantic-ui/core';
 import pretty from 'pretty';
 import { codeToHtml } from 'shiki';
 

--- a/docs/src/components/Sidebar.astro
+++ b/docs/src/components/Sidebar.astro
@@ -19,7 +19,8 @@ const sidebarSubheader = sidebarHeader || (showSidebarNav) ? 'Categories' : 'Nav
 ---
 <script>
 import { $, $$ } from '@semantic-ui/query';
-import { Tooltip } from '@semantic-ui/core';
+// bare side-effect import: a named import gets elided by the bundler, dropping registration
+import '@semantic-ui/core';
 import { idleCallback } from '@semantic-ui/utils';
 
 const isCollapsed = () => {

--- a/docs/src/examples/query/plugins/query-tooltip-behavior/page.js
+++ b/docs/src/examples/query/plugins/query-tooltip-behavior/page.js
@@ -1,4 +1,4 @@
-import { Tooltip } from '@semantic-ui/core';
+import '@semantic-ui/core';
 import { $ } from '@semantic-ui/query';
 
 // Basic tooltip using data-text attribute

--- a/packages/query/src/register-behavior.js
+++ b/packages/query/src/register-behavior.js
@@ -60,7 +60,7 @@ export const registerBehavior = (behavior) => {
   // may be called via side effects which should not throw an error
   // when multiple components rely on same behavior
   if (Query.behaviors.has(name)) {
-    return;
+    return Query.prototype[name];
   }
 
   // Register this behavior
@@ -174,4 +174,6 @@ export const registerBehavior = (behavior) => {
   Query.prototype[name].classNames = classNames;
   Query.prototype[name].selectors = selectors;
   Query.prototype[name].errors = errors;
+
+  return Query.prototype[name];
 };

--- a/src/behaviors/tooltip/tooltip.js
+++ b/src/behaviors/tooltip/tooltip.js
@@ -3,9 +3,9 @@ import { isString, noop, tokenize } from '@semantic-ui/utils';
 
 // bare side-effect imports: these register tooltip's dependency behaviors.
 // a named import gets elided by the bundler, dropping the registration.
-import '../attach/attach.js';
-import '../escape/escape.js';
-import '../transition/transition.js';
+import { Attach } from '../attach/attach.js';
+import { Escape } from '../escape/escape.js';
+import { Transition } from '../transition/transition.js';
 
 import css from './tooltip.css?raw';
 

--- a/src/behaviors/tooltip/tooltip.js
+++ b/src/behaviors/tooltip/tooltip.js
@@ -1,8 +1,6 @@
 import { registerBehavior } from '@semantic-ui/query';
 import { isString, noop, tokenize } from '@semantic-ui/utils';
 
-// bare side-effect imports: these register tooltip's dependency behaviors.
-// a named import gets elided by the bundler, dropping the registration.
 import { Attach } from '../attach/attach.js';
 import { Escape } from '../escape/escape.js';
 import { Transition } from '../transition/transition.js';

--- a/src/behaviors/tooltip/tooltip.js
+++ b/src/behaviors/tooltip/tooltip.js
@@ -1,9 +1,11 @@
 import { registerBehavior } from '@semantic-ui/query';
 import { isString, noop, tokenize } from '@semantic-ui/utils';
 
-import { Attach } from '../attach/attach.js';
-import { Escape } from '../escape/escape.js';
-import { Transition } from '../transition/transition.js';
+// bare side-effect imports: these register tooltip's dependency behaviors.
+// a named import gets elided by the bundler, dropping the registration.
+import '../attach/attach.js';
+import '../escape/escape.js';
+import '../transition/transition.js';
 
 import css from './tooltip.css?raw';
 


### PR DESCRIPTION
Vite 8's Rolldown elides unused named imports, dropping side-effect behavior/component registration. Use bare imports where registration is the intent; `registerBehavior` returns its installed function instead of `undefined`.