### PR TITLE
Feat: Async Reactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,11 @@ xx.xx.xxxx
 * **BREAKING** - Removed `signal.clone(value)` prototype method — instance always carries its configured clone function in `this.clone`
 * **BREAKING** - Removed `setArrayProperty`. Use `setIndexProperty(index, property, value)` for one item by position, or `setProperty(property, value)` to set the field on every item
 * **BREAKING** - `signal.setProperty` on an array now takes `(property, value)` and sets the field on every item. Use `setItemProperty(id, property, value)` for the previous by-id form
+* **Feature** - Reactions support async callbacks — runs never overlap, a mid-flight invalidation aborts the run and coalesces into one re-run after it settles, and async re-runs start once the sync flush is stable
+* **Feature** - Added `computation.track(callback)` to re-enter dependency tracking after an `await`
+* **Feature** - Added `computation.abortSignal`, a per-run `AbortSignal` aborted when the run is superseded — sync reactions get it too, for cancelling detached fetches on re-run
+* **Feature** - Added `settled()`, a promise that resolves once all reactions, in-flight async runs, and `afterFlush` callbacks complete
+* **Enhancement** - `computed` and `derive` warn in development when the compute function returns a promise
 
 ### Renderer
 * **Bug** - Fixed property bindings (`.prop={expr}`) incorrectly defaulting to literal mode — properties now evaluate expressions like other bindings, use `{#fn expr}` to pass function references

--- a/ai/skills/authoring/reactive-state.md
+++ b/ai/skills/authoring/reactive-state.md
@@ -334,13 +334,13 @@ const userId = signal(1);
 const locale = signal('en');
 const user = signal(null);
 
-reaction(async (computation) => {
+reaction(async (comp) => {
   const id = userId.get();                     // tracked before the first await
   const res = await fetch(`/api/users/${id}`, {
-    signal: computation.abortSignal,           // aborts when the run is superseded
+    signal: comp.abortSignal,                  // aborts when the run is superseded
   });
-  const language = computation.track(() => locale.get());  // reads after an await need track()
-  user.set(localize(await res.json(), language));          // writes never need track
+  const language = comp.track(() => locale.get());  // reads after an await need track()
+  user.set(localize(await res.json(), language));   // writes never need track
 });
 ```
 

--- a/ai/skills/authoring/reactive-state.md
+++ b/ai/skills/authoring/reactive-state.md
@@ -11,7 +11,7 @@ type: skill
 
 > **Skill:** `reactive-state`
 > **Purpose:** Comprehensive guide to the @semantic-ui/reactivity package — a standalone signals-based reactive system with automatic dependency tracking for state management.
-> **Last Updated:** 2026-06-28
+> **Last Updated:** 2026-07-10
 
 ---
 
@@ -287,7 +287,7 @@ const logReaction = reaction((computation) => {
 
 // Create without running immediately
 const deferredReaction = reaction(callback, { firstRun: false });
-deferredReaction.boundRun(); // Run manually when ready
+deferredReaction.run(); // Run manually when ready
 ```
 
 ### Reaction Lifecycle
@@ -324,6 +324,35 @@ validatorReaction.addContext({ lastRun: Date.now() });
 // Enable stack traces
 validatorReaction.setTrace();
 ```
+
+### Async Reactions
+
+A reaction callback can be async. Return a promise and the run is treated as asynchronous.
+
+```javascript
+const userId = signal(1);
+const locale = signal('en');
+const user = signal(null);
+
+reaction(async (computation) => {
+  const id = userId.get();                     // tracked before the first await
+  const res = await fetch(`/api/users/${id}`, {
+    signal: computation.abortSignal,           // aborts when the run is superseded
+  });
+  const language = computation.track(() => locale.get());  // reads after an await need track()
+  user.set(localize(await res.json(), language));          // writes never need track
+});
+```
+
+**Lifecycle**:
+- Runs never overlap. An invalidation while a run is in flight aborts `computation.abortSignal` and coalesces into one re-run that starts after the in-flight promise settles (latest-wins)
+- Async re-runs start at the flush drain point, after pending sync reactions and before the `afterFlush` snapshot, so same-flush invalidations coalesce and intermediate sync states never launch a run
+- `firstRun` stays `true` through the whole first async run including continuations, flipping once the promise settles
+- Rejections report via `console.error` and never surface as unhandled rejections
+
+**`computation.track(callback)`**: Re-enters dependency tracking for a synchronous block after an `await`. Reads inside register on the reaction and accumulate into the current run. Returns the callback's return value.
+
+**`computation.abortSignal`**: A per-run `AbortSignal`, aborted when the run is superseded by an invalidation, re-run, or `stop()`. Sync reactions get it too, for cancelling a detached `fetch` before the re-run reads a fresh one.
 
 ---
 
@@ -418,6 +447,9 @@ const total = computed(() => subtotal.get() + tax.get());
 ```javascript
 // Force immediate execution of all pending reactions
 flush();
+
+// Wait for full quiescence, including in-flight async runs (flush does not)
+await settled();
 
 // Run code after all reactions complete
 afterFlush(() => {

--- a/docs/src/content/examples/abort-signals.mdx
+++ b/docs/src/content/examples/abort-signals.mdx
@@ -1,0 +1,11 @@
+---
+title: 'Abort Signals'
+shortTitle: 'Abort Signals'
+sortIndex: 1
+exampleType: 'log'
+category: 'Reactivity'
+subcategory: 'Reactions'
+tags: ['reactivity', 'reaction', 'async', 'abort']
+description: Cancels in-flight work when a run is superseded
+tip: 'Pass `comp.abortSignal` to fetch or timers. It aborts when the run is invalidated or stopped'
+---

--- a/docs/src/content/examples/async-reactions.mdx
+++ b/docs/src/content/examples/async-reactions.mdx
@@ -7,5 +7,5 @@ category: 'Reactivity'
 subcategory: 'Introduction'
 tags: ['reactivity', 'reaction', 'async', 'abort']
 description: Aborts stale runs and re-runs with the latest values
-tip: 'Async runs never overlap — an invalidation mid-flight aborts `comp.abortSignal` and coalesces every change into a single re-run that starts once the in-flight promise settles'
+tip: 'Runs never overlap. Mid-flight changes abort the run and coalesce into one re-run after settle'
 ---

--- a/docs/src/content/examples/async-reactions.mdx
+++ b/docs/src/content/examples/async-reactions.mdx
@@ -7,5 +7,5 @@ category: 'Reactivity'
 subcategory: 'Introduction'
 tags: ['reactivity', 'reaction', 'async', 'abort']
 description: Aborts stale runs and re-runs with the latest values
-tip: 'Runs never overlap. Mid-flight changes abort the run and coalesce into one re-run after settle'
+tip: 'Runs never overlap. A change mid-flight coalesces into one re-run after the current run settles'
 ---

--- a/docs/src/content/examples/async-reactions.mdx
+++ b/docs/src/content/examples/async-reactions.mdx
@@ -1,0 +1,11 @@
+---
+title: 'Async Reactions'
+shortTitle: 'Async Reactions'
+sortIndex: 3
+exampleType: 'log'
+category: 'Reactivity'
+subcategory: 'Introduction'
+tags: ['reactivity', 'reaction', 'async', 'abort']
+description: Aborts stale runs and re-runs with the latest values
+tip: 'Async runs never overlap — an invalidation mid-flight aborts `comp.abortSignal` and coalesces every change into a single re-run that starts once the in-flight promise settles'
+---

--- a/docs/src/content/examples/reactive-flush.mdx
+++ b/docs/src/content/examples/reactive-flush.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Forcing Flushes'
 shortTitle: 'Flush'
-sortIndex: 3
+sortIndex: 4
 id: 'reactive-flush'
 exampleType: 'log'
 category: 'Reactivity'

--- a/docs/src/content/examples/using-reactions.mdx
+++ b/docs/src/content/examples/using-reactions.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Using Reactions'
-sortIndex: 4
+sortIndex: 5
 id: 'using-reactions'
 category: 'Reactivity'
 subcategory: 'Introduction'

--- a/docs/src/examples/reactivity/introduction/async-reactions/index.js
+++ b/docs/src/examples/reactivity/introduction/async-reactions/index.js
@@ -1,0 +1,25 @@
+import { reaction, signal } from '@semantic-ui/reactivity';
+
+const query = signal('gala');
+
+const search = (term, abortSignal) =>
+  new Promise((resolve) => {
+    const timer = setTimeout(() => resolve(`${term} apples`), 100);
+    abortSignal.addEventListener('abort', () => {
+      clearTimeout(timer);
+      console.log(`"${term}" aborted`);
+      resolve(null);
+    });
+  });
+
+reaction(async (comp) => {
+  const term = query.get(); // tracked, read before the first await
+  const results = await search(term, comp.abortSignal);
+  if (results) {
+    console.log(`found ${results}`);
+  }
+});
+
+// writes while a run is in flight abort it and coalesce into one re-run
+query.set('fuji');
+query.set('honeycrisp');

--- a/docs/src/examples/reactivity/introduction/async-reactions/index.js
+++ b/docs/src/examples/reactivity/introduction/async-reactions/index.js
@@ -2,24 +2,12 @@ import { reaction, signal } from '@semantic-ui/reactivity';
 
 const query = signal('gala');
 
-const search = (term, abortSignal) =>
-  new Promise((resolve) => {
-    const timer = setTimeout(() => resolve(`${term} apples`), 100);
-    abortSignal.addEventListener('abort', () => {
-      clearTimeout(timer);
-      console.log(`"${term}" aborted`);
-      resolve(null);
-    });
-  });
+const search = (term) => new Promise((resolve) => setTimeout(() => resolve(`${term} apples`), 1000));
 
-reaction(async (comp) => {
+reaction(async () => {
   const term = query.get(); // tracked, read before the first await
-  const results = await search(term, comp.abortSignal);
-  if (results) {
-    console.log(`found ${results}`);
-  }
+  console.log(`found ${await search(term)}`);
 });
 
-// writes while a run is in flight abort it and coalesce into one re-run
-query.set('fuji');
+// a change mid-flight coalesces into one re-run after the current run settles
 query.set('honeycrisp');

--- a/docs/src/examples/reactivity/introduction/async-reactions/index.js
+++ b/docs/src/examples/reactivity/introduction/async-reactions/index.js
@@ -2,7 +2,11 @@ import { reaction, signal } from '@semantic-ui/reactivity';
 
 const query = signal('gala');
 
-const search = (term) => new Promise((resolve) => setTimeout(() => resolve(`${term} apples`), 1000));
+const search = (term) => {
+  return new Promise((resolve) => {
+    setTimeout(() => resolve(`${term} apples`), 1000);
+  });
+};
 
 reaction(async () => {
   const term = query.get(); // tracked, read before the first await

--- a/docs/src/examples/reactivity/reactions/abort-signals/index.js
+++ b/docs/src/examples/reactivity/reactions/abort-signals/index.js
@@ -1,0 +1,25 @@
+import { reaction, signal } from '@semantic-ui/reactivity';
+
+const query = signal('gala');
+
+const search = (term, abortSignal) =>
+  new Promise((resolve) => {
+    const timer = setTimeout(() => resolve(`${term} apples`), 1000);
+    abortSignal.addEventListener('abort', () => {
+      clearTimeout(timer);
+      console.log(`"${term}" aborted`);
+      resolve(null);
+    });
+  });
+
+reaction(async (comp) => {
+  const term = query.get();
+  const results = await search(term, comp.abortSignal);
+  if (results) {
+    console.log(`found ${results}`);
+  }
+});
+
+// both writes abort the in-flight run and coalesce into one re-run
+query.set('fuji');
+query.set('honeycrisp');

--- a/docs/src/pages/docs/api/reactivity/flushing.mdx
+++ b/docs/src/pages/docs/api/reactivity/flushing.mdx
@@ -4,7 +4,7 @@ pageType: 'API Reference'
 title: Flushing
 icon: refresh-cw
 package: "@semantic-ui/reactivity"
-methods: [flush, afterFlush, scheduleFlush]
+methods: [flush, afterFlush, scheduleFlush, settled]
 description: API reference for scheduling and flushing reactions in Semantic UI's reactivity system
 ---
 import PlaygroundExample from '@components/PlaygroundExample/PlaygroundExample.astro';
@@ -12,10 +12,10 @@ import Blockquote from '@components/mdx/Blockquote.astro';
 
 export const components = { blockquote: Blockquote };
 
-Control when pending reactions run. By default a signal change schedules its dependents onto the microtask queue, these free functions let you flush that queue now, run a callback once it settles, or schedule it yourself.
+Control when pending reactions run. By default a signal change schedules its dependents onto the microtask queue, these free functions let you flush that queue now, run a callback once it settles, wait for asynchronous runs to finish, or schedule it yourself.
 
 ```javascript
-import { flush, afterFlush, scheduleFlush } from '@semantic-ui/reactivity';
+import { flush, afterFlush, scheduleFlush, settled } from '@semantic-ui/reactivity';
 ```
 
 > [!info]
@@ -29,7 +29,7 @@ import { flush, afterFlush, scheduleFlush } from '@semantic-ui/reactivity';
 flush();
 ```
 
-Synchronously drains every pending reaction instead of waiting for the microtask. Batched writes resolve to their final value, errors are captured and rethrown after the queue drains so one faulty reaction cannot jam the rest, and a reactive cycle is broken after a fixed iteration cap.
+Synchronously drains every pending reaction instead of waiting for the microtask. Batched writes resolve to their final value, errors are captured and rethrown after the queue drains so one faulty reaction cannot jam the rest, and a reactive cycle is broken after a fixed iteration cap. In-flight [async reactions](/docs/api/reactivity/reaction#async-reactions) are not awaited, use [`settled()`](#settled) to wait for full quiescence.
 
 #### Usage
 
@@ -86,3 +86,33 @@ afterFlush(() => {
 #### Example
 
 <PlaygroundExample id="after-flush" direction="horizontal"></PlaygroundExample>
+
+## Settling
+
+### settled
+
+```javascript
+await settled();
+```
+
+Returns a promise that resolves once the reactive system is fully quiet, after every pending reaction, in-flight async run, and `afterFlush` callback has completed, including any cascades they schedule. Resolves immediately when nothing is pending.
+
+[`flush()`](#flush) drains the sync queue and returns, but it does not wait for in-flight [async reactions](/docs/api/reactivity/reaction#async-reactions). `settled()` is the async counterpart that waits for those runs and the work they schedule.
+
+#### Returns
+
+A promise that resolves when the system is idle.
+
+#### Usage
+
+```javascript
+const userId = signal(1);
+const user = signal(null);
+
+reaction(async () => {
+  user.set(await fetchUser(userId.get()));
+});
+
+userId.set(2);
+await settled(); // resolves after the async re-run and its cascades finish
+```

--- a/docs/src/pages/docs/api/reactivity/reaction.mdx
+++ b/docs/src/pages/docs/api/reactivity/reaction.mdx
@@ -104,10 +104,10 @@ Registers a cleanup callback that fires just before the reaction's next run and 
 ```javascript
 const channel = signal('updates');
 
-reaction((self) => {
+reaction((comp) => {
   const socket = subscribe(channel.get());
   // tears down the old socket before resubscribing, and on stop
-  self.onCleanup(() => socket.close());
+  comp.onCleanup(() => socket.close());
 });
 ```
 
@@ -124,10 +124,10 @@ Permanently stops the reaction. It unsubscribes from every dependency, fires its
 ```javascript
 const count = signal(0);
 
-const counter = reaction((self) => {
+const counter = reaction((comp) => {
   console.log(count.get());
   if (count.get() > 5) {
-    self.stop(); // detach once the threshold is crossed
+    comp.stop(); // detach once the threshold is crossed
   }
 });
 
@@ -233,9 +233,9 @@ reaction.firstRun;
 ```javascript
 const data = signal({ value: 0 });
 
-reaction((self) => {
+reaction((comp) => {
   const current = data.get(); // track before branching
-  if (self.firstRun) {
+  if (comp.firstRun) {
     console.log('initial setup');
   } else {
     console.log('value updated:', current.value);
@@ -258,8 +258,8 @@ reaction.active;
 #### Usage
 
 ```javascript
-const counter = reaction((self) => {
-  console.log('active:', self.active);
+const counter = reaction((comp) => {
+  console.log('active:', comp.active);
 });
 
 counter.stop();

--- a/docs/src/pages/docs/api/reactivity/reaction.mdx
+++ b/docs/src/pages/docs/api/reactivity/reaction.mdx
@@ -149,9 +149,9 @@ import { signal, reaction } from '@semantic-ui/reactivity';
 const userId = signal(1);
 const user = signal(null);
 
-reaction(async (computation) => {
+reaction(async (comp) => {
   const id = userId.get(); // tracked, read before the first await
-  const res = await fetch(`/api/users/${id}`, { signal: computation.abortSignal });
+  const res = await fetch(`/api/users/${id}`, { signal: comp.abortSignal });
   user.set(await res.json()); // writes never need track
 });
 ```
@@ -185,10 +185,10 @@ The callback's return value.
 const query = signal('');
 const page = signal(1);
 
-reaction(async (computation) => {
+reaction(async (comp) => {
   const q = query.get(); // tracked normally
   const results = await search(q);
-  const n = computation.track(() => page.get()); // page re-runs the reaction too
+  const n = comp.track(() => page.get()); // page re-runs the reaction too
   show(results, n);
 });
 ```
@@ -207,10 +207,10 @@ A per-run [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/Abort
 const query = signal('');
 const results = signal([]);
 
-reaction(async (computation) => {
+reaction(async (comp) => {
   const q = query.get();
   // the previous run's request aborts automatically when query changes
-  const res = await fetch(`/search?q=${q}`, { signal: computation.abortSignal });
+  const res = await fetch(`/search?q=${q}`, { signal: comp.abortSignal });
   results.set(await res.json());
 });
 ```

--- a/docs/src/pages/docs/api/reactivity/reaction.mdx
+++ b/docs/src/pages/docs/api/reactivity/reaction.mdx
@@ -4,7 +4,7 @@ pageType: 'API Reference'
 title: Reaction
 icon: refresh-cw
 package: "@semantic-ui/reactivity"
-methods: [reaction, run, onCleanup, stop, firstRun, active, current]
+methods: [reaction, run, onCleanup, stop, track, abortSignal, firstRun, active, current]
 description: API reference for Reaction in Semantic UI's reactivity system
 ---
 import PlaygroundExample from '@components/PlaygroundExample/PlaygroundExample.astro';
@@ -138,6 +138,82 @@ count.set(7); // no output
 #### Example
 
 <PlaygroundExample id="stop-reaction" direction="horizontal"></PlaygroundExample>
+
+## Async Reactions
+
+A reaction callback may be `async`. Return a promise and the run is treated as asynchronous: the reaction tracks the signals read before the first `await`, then stays in flight until the promise settles.
+
+```javascript
+import { signal, reaction } from '@semantic-ui/reactivity';
+
+const userId = signal(1);
+const user = signal(null);
+
+reaction(async (computation) => {
+  const id = userId.get(); // tracked, read before the first await
+  const res = await fetch(`/api/users/${id}`, { signal: computation.abortSignal });
+  user.set(await res.json()); // writes never need track
+});
+```
+
+Runs never overlap. When a dependency changes while a run is in flight, the reaction aborts that run's [`abortSignal`](#abortsignal) and coalesces every change into a single re-run. The re-run starts once the in-flight promise settles, so the latest run wins and intermediate states never launch a run of their own. Rejections report through `console.error` and never surface as unhandled rejections.
+
+> [!info]
+> An async re-run starts at the flush drain point, after pending sync reactions and before the `afterFlush` snapshot. [`firstRun`](#firstrun) stays `true` through the whole first run, including continuations after an `await`, and flips once the promise settles.
+
+### track
+
+```javascript
+reaction.track(callback);
+```
+
+Re-enters dependency tracking for a synchronous block after an `await`. Signals read inside the callback register on the reaction and accumulate into the current run, so an async reaction can depend on values it reads past its first `await`. Reads after an `await` without `track()` register nothing.
+
+#### Parameters
+
+| Name | Type | Description |
+|------|------|-------------|
+| callback | function | Synchronous function whose signal reads should register on the reaction |
+
+#### Returns
+
+The callback's return value.
+
+#### Usage
+
+```javascript
+const query = signal('');
+const page = signal(1);
+
+reaction(async (computation) => {
+  const q = query.get(); // tracked normally
+  const results = await search(q);
+  const n = computation.track(() => page.get()); // page re-runs the reaction too
+  show(results, n);
+});
+```
+
+### abortSignal
+
+```javascript
+reaction.abortSignal;
+```
+
+A per-run [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal), created on first access and aborted when the run is superseded by an invalidation, a re-run, or [`stop()`](#stop). Pass it to `fetch` or any abortable work to cancel in-flight IO when the reaction re-runs. Sync reactions get one too, the signal a run reads aborts just before the next run reads a fresh one.
+
+#### Usage
+
+```javascript
+const query = signal('');
+const results = signal([]);
+
+reaction(async (computation) => {
+  const q = query.get();
+  // the previous run's request aborts automatically when query changes
+  const res = await fetch(`/search?q=${q}`, { signal: computation.abortSignal });
+  results.set(await res.json());
+});
+```
 
 ## Properties
 

--- a/packages/reactivity/src/helpers/derived.js
+++ b/packages/reactivity/src/helpers/derived.js
@@ -1,3 +1,5 @@
+import { isDevelopment, isPromise } from '@semantic-ui/utils';
+
 import { Dependency } from '../dependency.js';
 import { Reaction } from '../reaction.js';
 import { Scheduler } from '../scheduler.js';
@@ -9,13 +11,13 @@ import { Signal } from '../signal.js';
 const createDerivedSignal = (reactionBody, options) => {
   const derivedSignal = new Signal(undefined, options);
   const derivedRef = new WeakRef(derivedSignal);
-  const backingReaction = new Reaction(() => {
+  const backingReaction = new Reaction((computation) => {
     const liveSignal = derivedRef.deref();
     if (!liveSignal) {
       backingReaction.stop();
       return;
     }
-    reactionBody(liveSignal);
+    reactionBody(liveSignal, computation);
   });
   const parent = Scheduler.current;
   if (parent) {
@@ -26,11 +28,27 @@ const createDerivedSignal = (reactionBody, options) => {
   return derivedSignal;
 };
 
+// derived signals hold plain values, an async compute would store the promise itself
+const warnAsyncCompute = (value, computation, name) => {
+  if (isDevelopment && computation.firstRun && isPromise(value)) {
+    console.warn(
+      `${name}: compute returned a promise so the signal holds the promise, not its value. use reaction() with an async callback and set() the result`,
+    );
+  }
+  return value;
+};
+
 export const derive = (source, computeFn, options = {}) =>
-  createDerivedSignal((derivedSignal) => derivedSignal.set(computeFn(source.get())), options);
+  createDerivedSignal(
+    (derivedSignal, computation) => derivedSignal.set(warnAsyncCompute(computeFn(source.get()), computation, 'derive')),
+    options,
+  );
 
 export const computed = (computeFn, options = {}) =>
-  createDerivedSignal((derivedSignal) => derivedSignal.set(computeFn()), options);
+  createDerivedSignal(
+    (derivedSignal, computation) => derivedSignal.set(warnAsyncCompute(computeFn(), computation, 'computed')),
+    options,
+  );
 
 // Per-key reactive membership against a source signal. The returned
 // match(key) function is reactive and returns whether matchFn(key, source.value)

--- a/packages/reactivity/src/helpers/schedule.js
+++ b/packages/reactivity/src/helpers/schedule.js
@@ -4,4 +4,5 @@ import { Scheduler } from '../scheduler.js';
 export const flush = Scheduler.flush;
 export const scheduleFlush = Scheduler.scheduleFlush;
 export const afterFlush = Scheduler.afterFlush;
+export const settled = Scheduler.settled;
 export const getSource = Scheduler.getSource;

--- a/packages/reactivity/src/index.js
+++ b/packages/reactivity/src/index.js
@@ -7,5 +7,5 @@ export { Signal } from './signal.js';
 export { currentReaction, guard, nonreactive } from './helpers/control.js';
 export { reaction, reactiveObject, signal } from './helpers/create.js';
 export { computed, derive, match } from './helpers/derived.js';
-export { afterFlush, flush, getSource, scheduleFlush } from './helpers/schedule.js';
+export { afterFlush, flush, getSource, scheduleFlush, settled } from './helpers/schedule.js';
 export { isStackCapture, isTracing, setStackCapture, setTracing } from './helpers/tracing.js';

--- a/packages/reactivity/src/reaction.js
+++ b/packages/reactivity/src/reaction.js
@@ -1,3 +1,5 @@
+import { isPromise } from '@semantic-ui/utils';
+
 import { captureStack, isTracing } from './helpers/tracing.js';
 import { Scheduler } from './scheduler.js';
 
@@ -11,6 +13,7 @@ export class Reaction {
     this.callback = callback;
     this.dependencies = new Set();
     this.cleanups = null; // lazy, most reactions register none
+    this.async = null; // lazy async run state, most reactions never allocate it
     this.firstRun = true;
     this.active = true;
     if (context && isTracing()) {
@@ -23,6 +26,11 @@ export class Reaction {
 
   // callbacks fire before next run() and on stop. use to scope inner reactions to parent
   onCleanup(callback) {
+    // registered after stop, its run is already torn down
+    if (!this.active) {
+      callback();
+      return;
+    }
     (this.cleanups ??= []).push(callback);
   }
 
@@ -70,6 +78,16 @@ export class Reaction {
     if (!this.active) {
       return;
     }
+    if (this.async !== null) {
+      // runs never overlap. a run requested mid-flight starts after the current one settles
+      if (this.async.settling !== null) {
+        this.async.rerun = true;
+        return;
+      }
+      // supersede the previous run's abort signal so this run reads a fresh one
+      this.async.controller?.abort();
+      this.async.controller = null;
+    }
     if (isTracing()) {
       this.addContext({
         firstRun: this.firstRun,
@@ -79,17 +97,23 @@ export class Reaction {
     // save/restore so nested run() (guard, computed, derive) doesn't strand the parent
     const previousReaction = Scheduler.current;
     Scheduler.current = this;
+    let result;
     try {
       for (const dep of this.dependencies) {
         dep.remove(this);
       }
       this.dependencies.clear();
-      this.callback(this);
+      result = this.callback(this);
     }
     finally {
-      // firstRun advances even on throw so a re-invalidation re-tracks from a known baseline
-      this.firstRun = false;
       Scheduler.current = previousReaction;
+      if (isPromise(result)) {
+        this.beginSettle(result);
+      }
+      else {
+        // firstRun advances even on throw so a re-invalidation re-tracks from a known baseline
+        this.firstRun = false;
+      }
     }
   }
 
@@ -100,8 +124,91 @@ export class Reaction {
     if (context) {
       this.addContext(context);
     }
+    if (this.async !== null) {
+      this.async.controller?.abort();
+      if (this.async.settling !== null) {
+        this.async.rerun = true;
+        return;
+      }
+    }
     Scheduler.scheduleReaction(this);
   }
+
+  /*******************************
+           Async Runs
+  *******************************/
+
+  // a callback that returns a promise stays in flight until it settles. invalidations
+  // abort the run and coalesce into one re-run after settle, started at the flush
+  // drain point. cleanups and dep-tracking stay coherent because runs never overlap.
+
+  // re-enter dependency tracking for a sync block after an await. reads inside the
+  // callback register on this reaction, accumulating into the current run
+  track(callback) {
+    if (!this.active) {
+      return callback();
+    }
+    const previousReaction = Scheduler.current;
+    Scheduler.current = this;
+    try {
+      return callback();
+    }
+    finally {
+      Scheduler.current = previousReaction;
+    }
+  }
+
+  // per-run AbortSignal, aborted when the run is superseded by invalidate, re-run, or stop
+  get abortSignal() {
+    const state = this.asyncState();
+    state.controller ??= new AbortController();
+    return state.controller.signal;
+  }
+
+  // get-or-create the lazy async state. one creation site keeps the shape monomorphic
+  asyncState() {
+    return this.async ??= {
+      deferred: false,
+      settling: null,
+      rerun: false,
+      controller: null,
+    };
+  }
+
+  beginSettle(promise) {
+    const state = this.asyncState();
+    // once a run has gone async, re-runs schedule at the flush drain point
+    state.deferred = true;
+    state.settling = promise;
+    Scheduler.settlingReactions.add(this);
+    promise.then(
+      () => this.finishSettle(),
+      (error) => {
+        // aborts from supersession are expected cancels, anything else is reported
+        if (!(error?.name === 'AbortError' && state.controller?.signal.aborted)) {
+          console.error('Reaction: uncaught error in async run', error);
+        }
+        this.finishSettle();
+      },
+    );
+  }
+
+  finishSettle() {
+    const state = this.async;
+    state.settling = null;
+    // async first runs complete at settle so continuations observe firstRun correctly
+    this.firstRun = false;
+    if (state.rerun && this.active) {
+      state.rerun = false;
+      Scheduler.scheduleReaction(this);
+    }
+    Scheduler.settlingReactions.delete(this);
+    Scheduler.checkSettled();
+  }
+
+  /*******************************
+            Teardown
+  *******************************/
 
   stop() {
     if (!this.active) {
@@ -109,6 +216,11 @@ export class Reaction {
     }
     this.active = false;
     Scheduler.pendingReactions.delete(this);
+    Scheduler.pendingAsyncReactions.delete(this);
+    if (this.async !== null) {
+      this.async.controller?.abort();
+      this.async.rerun = false;
+    }
     this.dependencies.forEach(dep => dep.remove(this));
     this.dependencies.clear();
     this.fireCleanups();

--- a/packages/reactivity/src/reaction.js
+++ b/packages/reactivity/src/reaction.js
@@ -4,7 +4,7 @@ import { captureStack, isTracing } from './helpers/tracing.js';
 import { Scheduler } from './scheduler.js';
 
 export class Reaction {
-  // static mirror of Scheduler.current for debugger breakpoints, where devtools can't import currentReaction()
+  // static mirror of Scheduler.current for debugger breakpoints in dev console
   static get current() {
     return Scheduler.current;
   }
@@ -12,8 +12,8 @@ export class Reaction {
   constructor(callback, { context, firstRun = true } = {}) {
     this.callback = callback;
     this.dependencies = new Set();
-    this.cleanups = null; // lazy, most reactions register none
-    this.async = null; // lazy async run state, most reactions never allocate it
+    this.cleanups = null; // lazy only use if cleanup registered
+    this.async = null; // lazy only use if async
     this.firstRun = true;
     this.active = true;
     if (context && isTracing()) {
@@ -144,13 +144,13 @@ export class Reaction {
       state.rerun = true;
       return true;
     }
-    // supersede the previous run's abort signal so this run reads a fresh one
+    // supersede the previous run's abort signal for each fresh run
     state.controller?.abort();
     state.controller = null;
     return false;
   }
 
-  // re-enter dependency tracking for a sync block after an await. reads inside the
+  // re-enter dep tracking for a sync block after an await. reads inside the
   // callback register on this reaction, accumulating into the current run
   track(callback) {
     if (!this.active) {
@@ -166,14 +166,14 @@ export class Reaction {
     }
   }
 
-  // per-run AbortSignal, aborted when the run is superseded by invalidate, re-run, or stop
+  // per run abort signal, aborted if: invalidated, re-run or stopped
   get abortSignal() {
     const state = this.asyncState();
     state.controller ??= new AbortController();
     return state.controller.signal;
   }
 
-  // get-or-create the lazy async state. one creation site keeps the shape monomorphic
+  // get-or-create async -- keep the shape monomorphic
   asyncState() {
     return this.async ??= {
       deferred: false,
@@ -192,7 +192,7 @@ export class Reaction {
     promise.then(
       () => this.finishSettle(),
       (error) => {
-        // aborts from supersession are expected cancels, anything else is reported
+        // check if this is a user aborting or a real error
         if (!(error?.name === 'AbortError' && state.controller?.signal.aborted)) {
           console.error('Reaction: uncaught error in async run', error);
         }
@@ -204,7 +204,7 @@ export class Reaction {
   finishSettle() {
     const state = this.async;
     state.settling = null;
-    // async first runs complete at settle so continuations observe firstRun correctly
+    // if async firstRun completes when promise resolves
     this.firstRun = false;
     if (state.rerun && this.active) {
       state.rerun = false;

--- a/packages/reactivity/src/reaction.js
+++ b/packages/reactivity/src/reaction.js
@@ -172,7 +172,7 @@ export class Reaction {
     return state.controller.signal;
   }
 
-  // get-or-create async -- keep the shape monomorphic
+  // all fields preset so the hidden class stays monomorphic
   asyncState() {
     return this.async ??= {
       deferred: false,
@@ -203,7 +203,7 @@ export class Reaction {
   finishSettle() {
     const state = this.async;
     state.settling = null;
-    // if async firstRun completes when promise resolves
+    // async first run ends only now, when the promise settles
     this.firstRun = false;
     if (state.rerun && this.active) {
       state.rerun = false;
@@ -230,6 +230,7 @@ export class Reaction {
     if (this.async !== null) {
       this.async.controller?.abort();
       this.async.rerun = false;
+      // an in-flight run stays in settlingReactions, its body is still executing so settled() waits
     }
     this.dependencies.forEach(dep => dep.remove(this));
     this.dependencies.clear();

--- a/packages/reactivity/src/reaction.js
+++ b/packages/reactivity/src/reaction.js
@@ -136,8 +136,7 @@ export class Reaction {
   // abort the run and coalesce into one re-run after settle, started at the flush
   // drain point. cleanups and dep-tracking stay coherent because runs never overlap.
 
-  // fresh abort scope for a starting run. true means a run is already in
-  // flight, runs never overlap, so this one defers until the current settles
+  // fresh abort scope for a starting run, true means defer until the in-flight run settles
   resetAsync() {
     const state = this.async;
     if (state.settling !== null) {

--- a/packages/reactivity/src/reaction.js
+++ b/packages/reactivity/src/reaction.js
@@ -78,15 +78,8 @@ export class Reaction {
     if (!this.active) {
       return;
     }
-    if (this.async !== null) {
-      // runs never overlap. a run requested mid-flight starts after the current one settles
-      if (this.async.settling !== null) {
-        this.async.rerun = true;
-        return;
-      }
-      // supersede the previous run's abort signal so this run reads a fresh one
-      this.async.controller?.abort();
-      this.async.controller = null;
+    if (this.async !== null && this.resetAsync()) {
+      return;
     }
     if (isTracing()) {
       this.addContext({
@@ -142,6 +135,20 @@ export class Reaction {
   // a callback that returns a promise stays in flight until it settles. invalidations
   // abort the run and coalesce into one re-run after settle, started at the flush
   // drain point. cleanups and dep-tracking stay coherent because runs never overlap.
+
+  // fresh abort scope for a starting run. true means a run is already in
+  // flight, runs never overlap, so this one defers until the current settles
+  resetAsync() {
+    const state = this.async;
+    if (state.settling !== null) {
+      state.rerun = true;
+      return true;
+    }
+    // supersede the previous run's abort signal so this run reads a fresh one
+    state.controller?.abort();
+    state.controller = null;
+    return false;
+  }
 
   // re-enter dependency tracking for a sync block after an await. reads inside the
   // callback register on this reaction, accumulating into the current run
@@ -216,8 +223,9 @@ export class Reaction {
       return;
     }
     this.active = false;
-    Scheduler.pendingReactions.delete(this);
-    if (Scheduler.pendingAsyncReactions.size > 0) {
+    // pending sets can only hold entries while a flush is scheduled or running
+    if (Scheduler.isFlushScheduled || Scheduler.isFlushing) {
+      Scheduler.pendingReactions.delete(this);
       Scheduler.pendingAsyncReactions.delete(this);
     }
     if (this.async !== null) {

--- a/packages/reactivity/src/reaction.js
+++ b/packages/reactivity/src/reaction.js
@@ -107,7 +107,8 @@ export class Reaction {
     }
     finally {
       Scheduler.current = previousReaction;
-      if (isPromise(result)) {
+      // undefined check first, callbacks almost never return a value
+      if (result !== undefined && isPromise(result)) {
         this.beginSettle(result);
       }
       else {
@@ -216,7 +217,9 @@ export class Reaction {
     }
     this.active = false;
     Scheduler.pendingReactions.delete(this);
-    Scheduler.pendingAsyncReactions.delete(this);
+    if (Scheduler.pendingAsyncReactions.size > 0) {
+      Scheduler.pendingAsyncReactions.delete(this);
+    }
     if (this.async !== null) {
       this.async.controller?.abort();
       this.async.rerun = false;

--- a/packages/reactivity/src/scheduler.js
+++ b/packages/reactivity/src/scheduler.js
@@ -155,8 +155,6 @@ export class Scheduler {
       && !Scheduler.isFlushing;
   }
 
-  // resolves once every pending reaction, in-flight async run, and afterFlush
-  // callback has completed, including the cascades they schedule
   static settled() {
     if (Scheduler.isSettled()) {
       return Promise.resolve();

--- a/packages/reactivity/src/scheduler.js
+++ b/packages/reactivity/src/scheduler.js
@@ -161,14 +161,7 @@ export class Scheduler {
     if (Scheduler.isSettled()) {
       return Promise.resolve();
     }
-    // hand-rolled deferred, Promise.withResolvers is too new for the CDN runtime floor
-    if (Scheduler.settledDeferred === null) {
-      const deferred = {};
-      deferred.promise = new Promise((resolve) => {
-        deferred.resolve = resolve;
-      });
-      Scheduler.settledDeferred = deferred;
-    }
+    Scheduler.settledDeferred ??= Promise.withResolvers();
     return Scheduler.settledDeferred.promise;
   }
 

--- a/packages/reactivity/src/scheduler.js
+++ b/packages/reactivity/src/scheduler.js
@@ -5,12 +5,20 @@ const flushTask = () => Scheduler.flush();
 export class Scheduler {
   static current = null;
   static pendingReactions = new Set();
+  static pendingAsyncReactions = new Set();
+  static settlingReactions = new Set();
   static afterFlushCallbacks = [];
+  static settledDeferred = null;
   static isFlushScheduled = false;
   static isFlushing = false;
 
   static scheduleReaction(reaction) {
-    Scheduler.pendingReactions.add(reaction);
+    // known-async reactions start at the drain point, so intra-flush glitches never
+    // launch a run and same-flush invalidations coalesce to one start
+    const pending = (reaction.async !== null && reaction.async.deferred)
+      ? Scheduler.pendingAsyncReactions
+      : Scheduler.pendingReactions;
+    pending.add(reaction);
     Scheduler.scheduleFlush();
   }
 
@@ -30,34 +38,55 @@ export class Scheduler {
     let firstError;
     let iterations = 0;
     try {
-      // alternate: drain all pending reactions, then run one snapshot of afterFlush callbacks.
-      // afterFlushes registered during the batch land in the next alternation, which drains
-      // any reactions they queued before the next batch runs.
-      while (Scheduler.pendingReactions.size > 0 || Scheduler.afterFlushCallbacks.length > 0) {
+      // alternate: drain all pending reactions, start async re-runs, then run one snapshot
+      // of afterFlush callbacks. work queued during a phase lands in the next alternation,
+      // so afterFlush always observes a stable sync world.
+      while (
+        Scheduler.pendingReactions.size > 0
+        || Scheduler.pendingAsyncReactions.size > 0
+        || Scheduler.afterFlushCallbacks.length > 0
+      ) {
         while (Scheduler.pendingReactions.size > 0) {
           if (++iterations > Scheduler.maxFlushIterations) {
-            console.error('Reactive cycle detected: flush exceeded maximum iterations');
-            Scheduler.pendingReactions.clear();
-            Scheduler.afterFlushCallbacks.length = 0;
+            Scheduler.reportCycle();
             break;
           }
           // set-swap: avoid the per-pass array spread. new invalidations land in the next pass.
           const toRun = Scheduler.pendingReactions;
           Scheduler.pendingReactions = new Set();
-          for (const r of toRun) {
-            if (!r.active) { continue; }
+          for (const reaction of toRun) {
+            if (!reaction.active) { continue; }
             try {
-              r.run();
+              reaction.run();
             }
             catch (e) {
               if (!firstError) { firstError = e; }
             }
           }
         }
+        if (Scheduler.pendingAsyncReactions.size > 0) {
+          if (++iterations > Scheduler.maxFlushIterations) {
+            Scheduler.reportCycle();
+            break;
+          }
+          // async heads run synchronously here, their tails stay in flight
+          const toStart = Scheduler.pendingAsyncReactions;
+          Scheduler.pendingAsyncReactions = new Set();
+          for (const reaction of toStart) {
+            if (!reaction.active) { continue; }
+            try {
+              reaction.run();
+            }
+            catch (e) {
+              if (!firstError) { firstError = e; }
+            }
+          }
+          // heads may have queued sync work, drain it before the afterFlush snapshot
+          continue;
+        }
         if (Scheduler.afterFlushCallbacks.length > 0) {
           if (++iterations > Scheduler.maxFlushIterations) {
-            console.error('Reactive cycle detected: flush exceeded maximum iterations');
-            Scheduler.afterFlushCallbacks.length = 0;
+            Scheduler.reportCycle();
             break;
           }
           const callbacks = Scheduler.afterFlushCallbacks;
@@ -75,15 +104,55 @@ export class Scheduler {
     }
     finally {
       Scheduler.isFlushing = false;
+      Scheduler.checkSettled();
     }
 
     if (firstError) { throw firstError; }
+  }
+
+  // a cycle keeps scheduling work faster than the flush drains it. clear everything and bail
+  static reportCycle() {
+    console.error('Reactive cycle detected: flush exceeded maximum iterations');
+    Scheduler.pendingReactions.clear();
+    Scheduler.pendingAsyncReactions.clear();
+    Scheduler.afterFlushCallbacks.length = 0;
   }
 
   static afterFlush(callback) {
     Scheduler.afterFlushCallbacks.push(callback);
     if (!Scheduler.isFlushing) {
       Scheduler.scheduleFlush();
+    }
+  }
+
+  /*******************************
+           Quiescence
+  *******************************/
+
+  static isSettled() {
+    return Scheduler.pendingReactions.size === 0
+      && Scheduler.pendingAsyncReactions.size === 0
+      && Scheduler.settlingReactions.size === 0
+      && Scheduler.afterFlushCallbacks.length === 0
+      && !Scheduler.isFlushScheduled
+      && !Scheduler.isFlushing;
+  }
+
+  // resolves once every pending reaction, in-flight async run, and afterFlush
+  // callback has completed, including the cascades they schedule
+  static settled() {
+    if (Scheduler.isSettled()) {
+      return Promise.resolve();
+    }
+    Scheduler.settledDeferred ??= Promise.withResolvers();
+    return Scheduler.settledDeferred.promise;
+  }
+
+  static checkSettled() {
+    if (Scheduler.settledDeferred !== null && Scheduler.isSettled()) {
+      const deferred = Scheduler.settledDeferred;
+      Scheduler.settledDeferred = null;
+      deferred.resolve();
     }
   }
 

--- a/packages/reactivity/src/scheduler.js
+++ b/packages/reactivity/src/scheduler.js
@@ -13,12 +13,14 @@ export class Scheduler {
   static isFlushing = false;
 
   static scheduleReaction(reaction) {
-    // known-async reactions start at the drain point, so intra-flush glitches never
-    // launch a run and same-flush invalidations coalesce to one start
-    const pending = (reaction.async !== null && reaction.async.deferred)
-      ? Scheduler.pendingAsyncReactions
-      : Scheduler.pendingReactions;
-    pending.add(reaction);
+    if (reaction.async === null || !reaction.async.deferred) {
+      Scheduler.pendingReactions.add(reaction);
+    }
+    else {
+      // known-async reactions start at the drain point, so intra-flush glitches never
+      // launch a run and same-flush invalidations coalesce to one start
+      Scheduler.pendingAsyncReactions.add(reaction);
+    }
     Scheduler.scheduleFlush();
   }
 
@@ -104,7 +106,10 @@ export class Scheduler {
     }
     finally {
       Scheduler.isFlushing = false;
-      Scheduler.checkSettled();
+      // field check inline, most flushes have no settled() waiter
+      if (Scheduler.settledDeferred !== null) {
+        Scheduler.checkSettled();
+      }
     }
 
     if (firstError) { throw firstError; }

--- a/packages/reactivity/src/scheduler.js
+++ b/packages/reactivity/src/scheduler.js
@@ -161,7 +161,14 @@ export class Scheduler {
     if (Scheduler.isSettled()) {
       return Promise.resolve();
     }
-    Scheduler.settledDeferred ??= Promise.withResolvers();
+    // hand-rolled deferred, Promise.withResolvers is too new for the CDN runtime floor
+    if (Scheduler.settledDeferred === null) {
+      const deferred = {};
+      deferred.promise = new Promise((resolve) => {
+        deferred.resolve = resolve;
+      });
+      Scheduler.settledDeferred = deferred;
+    }
     return Scheduler.settledDeferred.promise;
   }
 

--- a/packages/reactivity/src/scheduler.js
+++ b/packages/reactivity/src/scheduler.js
@@ -35,6 +35,18 @@ export class Scheduler {
 
   static flush() {
     Scheduler.isFlushScheduled = false;
+    // bare dispatch with nothing pending exits before the try/finally frame.
+    // a waiter can be parked here when scheduled work was stopped before the flush
+    if (
+      Scheduler.pendingReactions.size === 0
+      && Scheduler.pendingAsyncReactions.size === 0
+      && Scheduler.afterFlushCallbacks.length === 0
+    ) {
+      if (Scheduler.settledDeferred !== null) {
+        Scheduler.checkSettled();
+      }
+      return;
+    }
     Scheduler.isFlushing = true;
     // capture first error but finish draining so one faulty reaction or afterFlush callback can't jam the queue
     let firstError;

--- a/packages/reactivity/test/unit/async-reaction.test.js
+++ b/packages/reactivity/test/unit/async-reaction.test.js
@@ -413,6 +413,31 @@ describe('Async Reactions', () => {
       expect(Scheduler.pendingAsyncReactions.size).toBe(0);
       expect(Scheduler.pendingReactions.size).toBe(0);
     });
+
+    it('settled() waits for a stopped run still in flight', async () => {
+      // stop() leaves the run in settlingReactions on purpose, its body is still executing
+      const opened = gate();
+      const instance = reaction(async () => {
+        await opened.promise; // never reads abortSignal, nothing hastens the settle
+      });
+
+      instance.stop();
+      let resolved = false;
+      settled().then(() => {
+        resolved = true;
+      });
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(Scheduler.settlingReactions.size).toBe(1);
+      expect(resolved).toBe(false);
+
+      opened.resolve();
+      await settled();
+
+      expect(resolved).toBe(true);
+      expect(Scheduler.settlingReactions.size).toBe(0);
+    });
   });
 
   /*******************************

--- a/packages/reactivity/test/unit/async-reaction.test.js
+++ b/packages/reactivity/test/unit/async-reaction.test.js
@@ -1,0 +1,494 @@
+import {
+  afterFlush,
+  computed,
+  flush,
+  nonreactive,
+  reaction,
+  Scheduler,
+  settled,
+  signal,
+} from '@semantic-ui/reactivity';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// hands the test control over when an async run body proceeds
+const gate = () => Promise.withResolvers();
+
+describe('Async Reactions', () => {
+  beforeEach(() => {
+    Scheduler.current = null;
+    Scheduler.pendingReactions.clear();
+    Scheduler.pendingAsyncReactions.clear();
+    Scheduler.settlingReactions.clear();
+    Scheduler.afterFlushCallbacks = [];
+    Scheduler.settledDeferred = null;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  /*******************************
+            Tracking
+  *******************************/
+
+  describe('Tracking', () => {
+    it('tracks dependencies read before the first await', async () => {
+      const count = signal(0);
+      const runs = vi.fn();
+      reaction(async () => {
+        runs(count.get());
+        await Promise.resolve();
+      });
+      await settled();
+
+      count.set(1);
+      await settled();
+
+      expect(runs).toHaveBeenCalledTimes(2);
+      expect(runs).toHaveBeenLastCalledWith(1);
+    });
+
+    it('reads after an await register nothing without track', async () => {
+      const count = signal(0);
+      const runs = vi.fn();
+      reaction(async () => {
+        runs();
+        await Promise.resolve();
+        count.get();
+      });
+      await settled();
+
+      count.set(1);
+      await settled();
+
+      expect(runs).toHaveBeenCalledTimes(1);
+    });
+
+    it('track() registers dependencies read after an await', async () => {
+      const count = signal(0);
+      const runs = vi.fn();
+      reaction(async (comp) => {
+        runs();
+        await Promise.resolve();
+        comp.track(() => count.get());
+      });
+      await settled();
+
+      count.set(1);
+      await settled();
+
+      expect(runs).toHaveBeenCalledTimes(2);
+    });
+
+    it('track() returns the callback value', async () => {
+      const count = signal(5);
+      let tracked;
+      reaction(async (comp) => {
+        await Promise.resolve();
+        tracked = comp.track(() => count.get() * 2);
+      });
+      await settled();
+
+      expect(tracked).toBe(10);
+    });
+
+    it('head and tracked dependencies accumulate in one run', async () => {
+      const first = signal(0);
+      const second = signal(0);
+      const runs = vi.fn();
+      reaction(async (comp) => {
+        runs();
+        first.get();
+        await Promise.resolve();
+        comp.track(() => second.get());
+      });
+      await settled();
+
+      first.set(1);
+      await settled();
+      second.set(1);
+      await settled();
+
+      expect(runs).toHaveBeenCalledTimes(3);
+    });
+
+    it('nonreactive suppresses tracking inside track()', async () => {
+      const count = signal(0);
+      const runs = vi.fn();
+      reaction(async (comp) => {
+        runs();
+        await Promise.resolve();
+        comp.track(() => nonreactive(() => count.get()));
+      });
+      await settled();
+
+      count.set(1);
+      await settled();
+
+      expect(runs).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  /*******************************
+            Lifecycle
+  *******************************/
+
+  describe('Lifecycle', () => {
+    it('runs never overlap, a mid-flight invalidation re-runs after settle', async () => {
+      const dep = signal(0);
+      const order = [];
+      const gates = [gate(), gate()];
+      let runCount = 0;
+      reaction(async () => {
+        const run = ++runCount;
+        dep.get();
+        order.push(`start ${run}`);
+        await gates[run - 1].promise;
+        order.push(`end ${run}`);
+      });
+
+      dep.set(1); // invalidate while run 1 is in flight
+      gates[0].resolve();
+      gates[1].resolve();
+      await settled();
+
+      expect(order).toEqual(['start 1', 'end 1', 'start 2', 'end 2']);
+    });
+
+    it('invalidations mid-flight coalesce into one trailing re-run', async () => {
+      const dep = signal(0);
+      const gates = [gate(), gate()];
+      let runCount = 0;
+      reaction(async () => {
+        const run = ++runCount;
+        dep.get();
+        await gates[run - 1].promise;
+      });
+
+      dep.set(1);
+      dep.set(2);
+      dep.set(3);
+      gates[0].resolve();
+      gates[1].resolve();
+      await settled();
+
+      expect(runCount).toBe(2);
+    });
+
+    it('abortSignal aborts when invalidated mid-flight', async () => {
+      const dep = signal(0);
+      const opened = gate();
+      let abortSignal;
+      reaction(async (comp) => {
+        if (comp.firstRun) {
+          dep.get();
+          abortSignal = comp.abortSignal;
+          await opened.promise;
+        }
+      });
+      expect(abortSignal.aborted).toBe(false);
+
+      dep.set(1);
+      expect(abortSignal.aborted).toBe(true);
+
+      opened.resolve();
+      await settled();
+    });
+
+    it('each run reads a fresh abortSignal', async () => {
+      const dep = signal(0);
+      const signals = [];
+      reaction(async (comp) => {
+        dep.get();
+        signals.push(comp.abortSignal);
+        await Promise.resolve();
+      });
+      await settled();
+
+      dep.set(1);
+      await settled();
+
+      expect(signals[0]).not.toBe(signals[1]);
+      expect(signals[1].aborted).toBe(false);
+    });
+
+    it('abortSignal aborts on stop', async () => {
+      let abortSignal;
+      const instance = reaction(async (comp) => {
+        abortSignal = comp.abortSignal;
+        await Promise.resolve();
+      });
+      await settled();
+
+      instance.stop();
+      expect(abortSignal.aborted).toBe(true);
+    });
+
+    it('a sync reaction abortSignal aborts before its re-run', () => {
+      // the fetch-cancel pattern: a sync head hands its signal to detached io,
+      // the next invalidation cancels that io before the re-run reads a fresh one
+      const dep = signal(0);
+      const signals = [];
+      reaction((comp) => {
+        dep.get();
+        signals.push(comp.abortSignal);
+      });
+
+      dep.set(1);
+      flush();
+
+      expect(signals[0].aborted).toBe(true);
+      expect(signals[1].aborted).toBe(false);
+    });
+
+    it('firstRun stays true through the first run and its continuations', async () => {
+      const dep = signal(0);
+      const observed = [];
+      reaction(async (comp) => {
+        dep.get();
+        await Promise.resolve();
+        observed.push(comp.firstRun);
+      });
+      await settled();
+
+      dep.set(1);
+      await settled();
+
+      expect(observed).toEqual([true, false]);
+    });
+
+    it('onCleanup registered after an await fires before the next run', async () => {
+      const dep = signal(0);
+      const order = [];
+      let runCount = 0;
+      reaction(async (comp) => {
+        const run = ++runCount;
+        dep.get();
+        order.push(`run ${run}`);
+        await Promise.resolve();
+        comp.onCleanup(() => order.push(`cleanup ${run}`));
+      });
+      await settled();
+
+      dep.set(1);
+      await settled();
+
+      expect(order).toEqual(['run 1', 'cleanup 1', 'run 2']);
+    });
+
+    it('onCleanup after stop fires immediately', async () => {
+      const opened = gate();
+      const cleanup = vi.fn();
+      const instance = reaction(async (comp) => {
+        await opened.promise;
+        comp.onCleanup(cleanup);
+      });
+
+      instance.stop();
+      opened.resolve();
+      await settled();
+
+      expect(cleanup).toHaveBeenCalledTimes(1);
+    });
+
+    it('stop mid-flight prevents the trailing re-run', async () => {
+      const dep = signal(0);
+      const opened = gate();
+      let runCount = 0;
+      const instance = reaction(async () => {
+        runCount++;
+        dep.get();
+        await opened.promise;
+      });
+
+      dep.set(1); // requests a re-run
+      instance.stop();
+      opened.resolve();
+      await settled();
+
+      expect(runCount).toBe(1);
+    });
+  });
+
+  /*******************************
+           Scheduling
+  *******************************/
+
+  describe('Scheduling', () => {
+    it('async re-runs start after pending sync reactions in the same flush', async () => {
+      const dep = signal(0);
+      const order = [];
+      reaction(async () => {
+        dep.get();
+        order.push('async');
+        await Promise.resolve();
+      });
+      await settled();
+      reaction(() => {
+        dep.get();
+        order.push('sync');
+      });
+      order.length = 0;
+
+      dep.set(1);
+      await settled();
+
+      expect(order).toEqual(['sync', 'async']);
+    });
+
+    it('sync work scheduled by an async head drains before afterFlush', async () => {
+      const dep = signal(0);
+      const inner = signal(0);
+      const order = [];
+      reaction(() => {
+        inner.get();
+        order.push('sync');
+      });
+      reaction(async () => {
+        dep.get();
+        order.push('async');
+        inner.increment();
+        afterFlush(() => order.push('afterFlush'));
+        await Promise.resolve();
+      });
+      await settled();
+      order.length = 0;
+
+      dep.set(1);
+      await settled();
+
+      expect(order).toEqual(['async', 'sync', 'afterFlush']);
+    });
+
+    it('settled() resolves after in-flight runs and their cascades', async () => {
+      const dep = signal(0);
+      const result = signal(null);
+      let cascaded = false;
+      reaction(() => {
+        if (result.get() === 'done') {
+          cascaded = true;
+        }
+      });
+      reaction(async () => {
+        dep.get();
+        await Promise.resolve();
+        result.set('done');
+      });
+
+      await settled();
+
+      expect(cascaded).toBe(true);
+    });
+
+    it('settled() resolves immediately when idle', async () => {
+      await settled();
+      expect(Scheduler.settlingReactions.size).toBe(0);
+    });
+
+    it('flush() stays synchronous while runs are in flight', async () => {
+      const opened = gate();
+      reaction(async () => {
+        await opened.promise;
+      });
+
+      flush();
+      expect(Scheduler.settlingReactions.size).toBe(1);
+
+      opened.resolve();
+      await settled();
+      expect(Scheduler.settlingReactions.size).toBe(0);
+    });
+
+    it('retains no scheduler state once runs complete', async () => {
+      const dep = signal(0);
+      const instance = reaction(async () => {
+        dep.get();
+        await Promise.resolve();
+      });
+      dep.set(1);
+      await settled();
+      instance.stop();
+
+      expect(Scheduler.settlingReactions.size).toBe(0);
+      expect(Scheduler.pendingAsyncReactions.size).toBe(0);
+      expect(Scheduler.pendingReactions.size).toBe(0);
+    });
+  });
+
+  /*******************************
+             Errors
+  *******************************/
+
+  describe('Errors', () => {
+    it('a rejected run reports and the reaction keeps working', async () => {
+      const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const dep = signal(0);
+      const values = [];
+      reaction(async () => {
+        const value = dep.get();
+        await Promise.resolve();
+        if (value === 0) {
+          throw new Error('boom');
+        }
+        values.push(value);
+      });
+      await settled();
+
+      expect(consoleError).toHaveBeenCalledTimes(1);
+
+      dep.set(1);
+      await settled();
+
+      expect(values).toEqual([1]);
+    });
+
+    it('an abort-caused rejection is not reported', async () => {
+      const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const dep = signal(0);
+      const opened = gate();
+      let runCount = 0;
+      reaction(async (comp) => {
+        runCount++;
+        dep.get();
+        const { abortSignal } = comp;
+        if (comp.firstRun) {
+          await opened.promise;
+          if (abortSignal.aborted) {
+            throw new DOMException('aborted', 'AbortError');
+          }
+        }
+      });
+
+      dep.set(1); // aborts run 1
+      opened.resolve();
+      await settled();
+
+      expect(consoleError).not.toHaveBeenCalled();
+      expect(runCount).toBe(2);
+    });
+
+    it('a throw before the first await reports through the async path', async () => {
+      const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+      reaction(async () => {
+        throw new Error('early');
+      });
+      await settled();
+
+      expect(consoleError).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  /*******************************
+         Derived Guardrail
+  *******************************/
+
+  describe('Derived Guardrail', () => {
+    it('computed warns when the compute returns a promise', () => {
+      const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      computed(async () => 1);
+
+      expect(consoleWarn).toHaveBeenCalledTimes(1);
+      expect(consoleWarn.mock.calls[0][0]).toContain('computed');
+    });
+  });
+});

--- a/packages/reactivity/types/helpers/schedule.d.ts
+++ b/packages/reactivity/types/helpers/schedule.d.ts
@@ -2,7 +2,8 @@
  * Synchronously processes all pending reactions instead of waiting for the
  * microtask queue. Batched writes resolve to their final value, errors are
  * captured and rethrown after the queue drains, and a reactive cycle is broken
- * after a fixed iteration cap.
+ * after a fixed iteration cap. Does not wait for in-flight async runs. Use
+ * `settled()` for full quiescence.
  * @see {@link https://next.semantic-ui.com/docs/api/reactivity/flushing#flush flush}
  */
 export function flush(): void;
@@ -21,6 +22,16 @@ export function scheduleFlush(): void;
  * @param callback - Function to run after updates are processed
  */
 export function afterFlush(callback: () => void): void;
+
+/**
+ * Returns a promise that resolves once every pending reaction, in-flight async
+ * run, and `afterFlush` callback has completed, including the cascades they
+ * schedule. Resolves immediately when the system is already idle. Unlike
+ * `flush()`, which stays synchronous and returns before an in-flight async run
+ * settles, `settled()` awaits those runs.
+ * @see {@link https://next.semantic-ui.com/docs/api/reactivity/flushing#settled settled}
+ */
+export function settled(): Promise<void>;
 
 /**
  * Logs the source of the currently running reaction to the console, for

--- a/packages/reactivity/types/index.d.ts
+++ b/packages/reactivity/types/index.d.ts
@@ -14,5 +14,5 @@ export { currentReaction, guard, nonreactive } from './helpers/control.js';
 export { reaction, reactiveObject, signal } from './helpers/create.js';
 export { computed, derive, match } from './helpers/derived.js';
 export type { Matcher } from './helpers/derived.js';
-export { afterFlush, flush, getSource, scheduleFlush } from './helpers/schedule.js';
+export { afterFlush, flush, getSource, scheduleFlush, settled } from './helpers/schedule.js';
 export { isStackCapture, isTracing, setStackCapture, setTracing } from './helpers/tracing.js';

--- a/packages/reactivity/types/reaction.d.ts
+++ b/packages/reactivity/types/reaction.d.ts
@@ -25,6 +25,13 @@ export class Reaction {
    * Creates a new Reaction. The callback runs immediately (tracking the signals
    * it reads) and re-runs whenever any of them change. The callback receives the
    * Reaction instance.
+   *
+   * The callback may be `async`. A callback that returns a promise runs
+   * asynchronously: runs never overlap, an invalidation while a run is in flight
+   * aborts its `abortSignal` and coalesces into a single re-run that starts once
+   * the in-flight promise settles (the latest run wins). Reads after an `await`
+   * no longer track. Use `track()` to re-enter dependency tracking. Rejections
+   * report via `console.error` rather than surfacing as unhandled rejections.
    * @see {@link https://next.semantic-ui.com/docs/api/reactivity/reaction#constructor constructor}
    * @param callback - Function to run reactively
    * @param options - Optional configuration
@@ -32,7 +39,7 @@ export class Reaction {
    * @param options.firstRun - Whether to run the callback immediately on creation. Defaults to `true`. Set `false` to create the reaction without an initial run.
    */
   constructor(
-    callback: (computation: Reaction) => void,
+    callback: (computation: Reaction) => void | Promise<void>,
     options?: { context?: Record<string, any>; firstRun?: boolean; },
   );
 
@@ -41,6 +48,10 @@ export class Reaction {
    * initialization that should happen only once. Read the signals you depend on
    * before any early `if (firstRun) return`, otherwise the reaction registers no
    * dependencies and never re-runs.
+   *
+   * A sync reaction flips this to `false` when the callback returns. An async
+   * reaction holds it `true` through the whole first run, including continuations
+   * after an `await`, and flips only once the returned promise settles.
    */
   readonly firstRun: boolean;
 
@@ -61,10 +72,22 @@ export class Reaction {
   readonly dependencies: Set<Dependency>;
 
   /**
+   * A per-run `AbortSignal`, created on first access and aborted when the run is
+   * superseded by an invalidation, a re-run, or `stop()`. Pass it to `fetch` or
+   * any abortable work to cancel in-flight IO when the reaction re-runs. Sync
+   * reactions get one too: the signal a run reads aborts just before the next run
+   * reads a fresh one.
+   * @see {@link https://next.semantic-ui.com/docs/api/reactivity/reaction#abortsignal abortSignal}
+   */
+  readonly abortSignal: AbortSignal;
+
+  /**
    * Registers a cleanup callback that fires just before the reaction's next run
    * and once when it stops. Callbacks fire in registration order and the queue
    * is cleared after firing, so a callback registered on `firstRun` fires once.
-   * Use it to tear down resources or scope inner reactions to this one.
+   * Use it to tear down resources or scope inner reactions to this one. In an
+   * async run a cleanup registered after an `await` still fires before the next
+   * run, and a cleanup registered after `stop()` fires immediately.
    * @see {@link https://next.semantic-ui.com/docs/api/reactivity/reaction#oncleanup onCleanup}
    * @param callback - Function to run on the next re-run or on stop
    */
@@ -97,6 +120,17 @@ export class Reaction {
    * @see {@link https://next.semantic-ui.com/docs/api/reactivity/reaction#run run}
    */
   run(): void;
+
+  /**
+   * Re-enters dependency tracking for a synchronous block after an `await`.
+   * Signals read inside the callback register on this reaction and accumulate
+   * into the current run, so an async reaction can depend on values it reads past
+   * its first `await`.
+   * @see {@link https://next.semantic-ui.com/docs/api/reactivity/reaction#track track}
+   * @param callback - Synchronous function whose signal reads should be tracked
+   * @returns The callback's return value
+   */
+  track<T>(callback: () => T): T;
 
   /**
    * Marks the reaction invalid and schedules it to run again on the next flush.

--- a/packages/reactivity/types/scheduler.d.ts
+++ b/packages/reactivity/types/scheduler.d.ts
@@ -3,7 +3,8 @@ import type { Reaction } from './reaction.js';
 /**
  * Manages scheduling and execution of reactive updates, batching reactions and
  * draining them on a microtask. Application code uses the free functions
- * `flush()`, `scheduleFlush()`, and `afterFlush()` rather than the class directly.
+ * `flush()`, `scheduleFlush()`, `afterFlush()`, and `settled()` rather than the
+ * class directly.
  * @see {@link https://next.semantic-ui.com/docs/api/reactivity/scheduler Scheduler Documentation}
  *
  * @internal Primarily used internally by the reactivity system.
@@ -14,6 +15,12 @@ export class Scheduler {
 
   /** Reactions queued to run on the next flush. */
   static pendingReactions: Set<Reaction>;
+
+  /** Known-async reactions whose deferred re-runs start at the flush drain point. */
+  static pendingAsyncReactions: Set<Reaction>;
+
+  /** Async reactions with a run currently in flight. */
+  static settlingReactions: Set<Reaction>;
 
   /** Callbacks queued to run after the next flush drains. */
   static afterFlushCallbacks: Array<() => void>;
@@ -41,12 +48,20 @@ export class Scheduler {
   static scheduleFlush(): void;
 
   /**
-   * Synchronously drains all pending reactions and after-flush callbacks. Caps
-   * at `maxFlushIterations` to break reactive cycles, logging an error and
-   * clearing both queues if the cap is exceeded.
+   * Synchronously drains all pending reactions, async run starts, and after-flush
+   * callbacks. Does not wait for in-flight async runs. Use `settled()` for full
+   * quiescence. Caps at `maxFlushIterations` to break reactive cycles, logging an
+   * error and clearing the queues if the cap is exceeded.
    * @see {@link https://next.semantic-ui.com/docs/api/reactivity/flushing#flush flush}
    */
   static flush(): void;
+
+  /**
+   * Clears every queue and logs an error when a flush exceeds
+   * `maxFlushIterations`, breaking a runaway reactive cycle.
+   * @internal
+   */
+  static reportCycle(): void;
 
   /**
    * Registers a callback to run after the next flush drains.
@@ -54,6 +69,27 @@ export class Scheduler {
    * @param callback - Function to run after updates are processed
    */
   static afterFlush(callback: () => void): void;
+
+  /**
+   * Whether no reactions are pending, in flight, or settling and no flush is
+   * scheduled or running.
+   * @internal
+   */
+  static isSettled(): boolean;
+
+  /**
+   * Returns a promise that resolves once every pending reaction, in-flight async
+   * run, and `afterFlush` callback has completed, including the cascades they
+   * schedule. Resolves immediately when already idle.
+   * @see {@link https://next.semantic-ui.com/docs/api/reactivity/flushing#settled settled}
+   */
+  static settled(): Promise<void>;
+
+  /**
+   * Resolves the pending `settled()` promise once the system goes idle.
+   * @internal
+   */
+  static checkSettled(): void;
 
   /**
    * Logs the source of the currently running reaction for debugging.

--- a/packages/reactivity/types/scheduler.d.ts
+++ b/packages/reactivity/types/scheduler.d.ts
@@ -25,6 +25,9 @@ export class Scheduler {
   /** Callbacks queued to run after the next flush drains. */
   static afterFlushCallbacks: Array<() => void>;
 
+  /** Deferred backing the pending `settled()` promise, or null when nobody waits. */
+  static settledDeferred: { promise: Promise<void>; resolve: () => void; } | null;
+
   /** Whether a flush is scheduled on the microtask queue. */
   static isFlushScheduled: boolean;
 


### PR DESCRIPTION
This adds first-class support for `async` function usage in `reaction` in `@semantic-ui/reactivity`.

## Changes
- Adds `computation.abortSignal` to kill an inflight async
- Adds `settled()` after all in-flight async work is done
- `computed`/`derive` now have errors for async since they cannot support natively

## Risk
8/10 - Rewrites the core reactivity primitive's render loop. Code changes are well understood but this change reverberates through all packages.