### PR TITLE
Refactor: Back Async Blocks With Resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ xx.xx.xxxx
 ### Templates
 * **Feature** - Added `{#fn expression}` directive to pass values as-is without auto-invoking functions — mirrors `{#html}` pattern, useful for passing callbacks through property bindings
 * **Feature** - Added `{#match}` blocks for value-based branching — name a discriminant once and list `{is value}` cases (loose `==`) or `{isExactly value}` cases (strict `===`, to tell `undefined` from `null` or split the falsy set), replacing repetitive `{#if is x 'a'}{else if is x 'b'}` chains
+* **Enhancement** - `{#async}` blocks in both engines are backed by the resource primitive — same behavior, one shared lifecycle, and the lit engine now holds the last value through a rejection like the native engine
 
 ### Reactivity
 * **Enhancement** - `mutate()` on large values now detects changes by tracking writes through a proxy instead of clone-and-compare, so editing one row of a big list costs the writes, not the list. The callback sees a tracked wrapper at that scale (shows as `Proxy(Object)` in the console), and the wrapper is only valid inside the callback. Small values keep the previous snapshot behavior and see the real object
@@ -41,6 +42,7 @@ xx.xx.xxxx
 * **Feature** - Added `settled()`, a promise that resolves once all reactions, in-flight async runs, and `afterFlush` callbacks complete
 * **Feature** - Added `resource(fetcher)` — a Signal whose value an async fetcher produces, with reactive `loading`/`error`/`settled` faces, latest-wins refetches that abort superseded runs, and a value that holds last-good through refresh and rejection
 * **Feature** - Added `onError` to resource options for value-only consumers — rejections still land in the `error` face, superseded runs never report
+* **Feature** - Added `concurrency` to resource options — `'latest'` (default) serializes runs with abort-and-coalesce, `'overlap'` starts every fetch immediately with newest-settle-wins for fetchers that cannot cooperate with cancellation
 * **Feature** - Added `Resource` class export for `instanceof` checks and subclassing
 * **Enhancement** - `computed` and `derive` warn in development when the compute function returns a promise
 

--- a/ai/skills/authoring/reactive-state.md
+++ b/ai/skills/authoring/reactive-state.md
@@ -358,7 +358,7 @@ reaction(async (comp) => {
 
 ## Resource
 
-A `Resource` is a `Signal` whose value an async fetcher produces. The fetcher runs as an async reaction — signals it reads before the first `await` are tracked and refetch when they change, runs never overlap, and a superseded run aborts through `comp.abortSignal` (latest-wins). The value holds last-good through a refresh and through a rejection, while fetch status lives in three independent faces.
+A `Resource` is a `Signal` whose value an async fetcher produces. The fetcher runs as an async reaction — signals it reads before the first `await` are tracked and refetch when they change, by default runs never overlap and a superseded run aborts through `comp.abortSignal` (latest-wins). The value holds last-good through a refresh and through a rejection, while fetch status lives in three independent faces.
 
 ```javascript
 import { resource, signal } from '@semantic-ui/reactivity';
@@ -393,7 +393,9 @@ A skeleton state is `loading && !settled`, a refresh shimmer is `loading && sett
 
 **Teardown**: `stop()` ends re-fires, clears loading, and leaves the last value readable. A resource created inside a reaction tears down with its parent, an unreferenced handle self-stops, and `settled()` waits for in-flight fetches.
 
-**Caveat**: `comp.abortSignal` is cooperative. A fetcher that ignores it and returns a promise that never settles blocks the next refetch, since runs never overlap. Pass the abort signal to your IO so a superseded run can actually cancel.
+**Concurrency**: `concurrency` defaults to `'latest'`, which serializes runs. A refetch fired mid-flight aborts the in-flight run and coalesces into one re-run after it settles, so at most one fetch is in flight and `settled()` tracks it. Pass `'overlap'` for fetchers that cannot cooperate with cancellation. Every invalidation fetches immediately, concurrent runs are allowed, and the newest run's settle wins. Overlap costs concurrent fetches under churn, and its runs are invisible to `settled()` because the backing reaction stays synchronous.
+
+**Caveat**: in the default `'latest'` mode `comp.abortSignal` is cooperative. A fetcher that ignores it and returns a promise that never settles blocks the next refetch, since runs never overlap. Pass the abort signal to your IO so a superseded run can actually cancel, or switch to `concurrency: 'overlap'` so an uncancellable fetch never blocks the next one.
 
 ---
 

--- a/docs/src/pages/docs/api/reactivity/resource.mdx
+++ b/docs/src/pages/docs/api/reactivity/resource.mdx
@@ -37,6 +37,7 @@ Creates a resource and runs the fetcher immediately. The fetcher runs as an [asy
 |------|------|---------|-------------|
 | initialValue | any | `undefined` | The value [`get()`](#get) returns before the first settle |
 | onError | function | `undefined` | Called with the rejection error after the faces settle. Superseded runs never report |
+| concurrency | `'latest'` \| `'overlap'` | `'latest'` | `'latest'` serializes runs (abort and coalesce), `'overlap'` starts every fetch at once with newest-settle-wins for fetchers that can't cooperate with cancellation |
 | equality | function | deep equality | Becomes the refresh dedup, so a refetch producing an equal value wakes no value readers |
 | safety | `'clone'` \| `'reference'` \| `'none'` | `'reference'` | Value-protection preset. See [Signal Options](/docs/guides/reactivity/signal-options) |
 | id | function | `id` ?? `_id` ?? `hash` ?? `key` | Resolves an array item's identity for `getItem` and the collection helpers |
@@ -60,10 +61,18 @@ const results = resource(async (comp) => {
 ```
 
 > [!info]
-> Runs never overlap. When a tracked read changes or [`refresh()`](#refresh) fires while a fetch is in flight, that run's [`abortSignal`](/docs/api/reactivity/reaction#abortsignal) aborts and a superseded run drops its settle entirely, with no value, no error, and no face flip from a stale run. Supersession is signaled once the fetch is in flight, so a write from inside the fetcher's own synchronous head re-fires the fetch and converges on the latest value rather than dropping. The latest run wins.
+> By default ([`concurrency: 'latest'`](#concurrency)), runs never overlap. When a tracked read changes or [`refresh()`](#refresh) fires while a fetch is in flight, that run's [`abortSignal`](/docs/api/reactivity/reaction#abortsignal) aborts and a superseded run drops its settle entirely, with no value, no error, and no face flip from a stale run. Supersession is signaled once the fetch is in flight, so a write from inside the fetcher's own synchronous head re-fires the fetch and converges on the latest value rather than dropping. The latest run wins.
 
 > [!warning]
-> The abort is cooperative. A fetcher that ignores `comp.abortSignal` and returns a promise that never settles blocks the next refetch, since runs never overlap. Pass the abort signal to your `fetch` or timers so a superseded run can actually cancel.
+> In the default `'latest'` mode the abort is cooperative. A fetcher that ignores `comp.abortSignal` and returns a promise that never settles blocks the next refetch, since runs never overlap. Pass the abort signal to your `fetch` or timers so a superseded run can actually cancel, or set [`concurrency: 'overlap'`](#concurrency) so an uncancellable fetch never blocks the next one.
+
+#### Concurrency
+
+`concurrency` sets how a refetch behaves when one fires while a fetch is still in flight.
+
+`'latest'` (the default) serializes runs as described above. The in-flight run aborts, the refetch coalesces into one re-run after it settles, at most one fetch is ever in flight, and [`settled()`](/docs/api/reactivity/flushing#settled) tracks it.
+
+`'overlap'` starts every fetch immediately. Concurrent fetches are allowed and the newest run's settle wins, so an out-of-order arrival never clobbers the latest value and the [`loading`](#loading) face stays `true` until the newest run settles. A superseded run still aborts its `abortSignal`, but progress never waits on that cooperation. Reach for it when a fetcher cannot thread cancellation and a hung request must not block the next refetch. Two costs come with it: concurrent fetches under rapid churn, and overlap runs are invisible to [`settled()`](/docs/api/reactivity/flushing#settled) because the backing reaction stays synchronous.
 
 #### Example
 

--- a/packages/reactivity/src/resource.js
+++ b/packages/reactivity/src/resource.js
@@ -30,6 +30,7 @@ export class Resource extends Signal {
     loadingDependency: null,
     errorDependency: null,
     settledDependency: null,
+    runId: 0,
   };
 
   constructor(fetcher, options = {}) {
@@ -37,6 +38,7 @@ export class Resource extends Signal {
     extend(this, Resource.defaults);
     this.fetcher = fetcher;
     this.onError = options.onError ?? null;
+    this.concurrency = options.concurrency ?? 'latest';
     // weakly held so the backing reaction self-stops once nothing else holds the handle
     const resourceRef = new WeakRef(this);
     const backingReaction = new Reaction((computation) => {
@@ -107,6 +109,31 @@ export class Resource extends Signal {
       return;
     }
     this.beginFetch();
+    if (this.concurrency === 'overlap') {
+      // the promise stays out of the backing reaction, so re-fires start at once
+      // instead of waiting for the in-flight settle. the newest run owns the
+      // settle, tracked by runId since nothing is aborted for it
+      const runId = ++this.runId;
+      result.then(
+        (value) => {
+          if (runId === this.runId && computation.active) {
+            this.fulfillFetch(value);
+          }
+          else {
+            this.dropFetch(computation);
+          }
+        },
+        (error) => {
+          if (runId === this.runId && computation.active) {
+            this.rejectFetch(error);
+          }
+          else {
+            this.dropFetch(computation);
+          }
+        },
+      );
+      return;
+    }
     // a superseded run's settle is dropped, the trailing re-run owns the next state
     const abortSignal = computation.abortSignal;
     return result.then(

--- a/packages/reactivity/test/unit/resource.test.js
+++ b/packages/reactivity/test/unit/resource.test.js
@@ -682,6 +682,97 @@ describe('Resource', () => {
             Identity
   *******************************/
 
+  describe('Concurrency', () => {
+    const tick = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+    it('overlap starts a new fetch immediately while one is in flight', async () => {
+      const term = signal('a');
+      const gates = [gate(), gate()];
+      let fetches = 0;
+      const results = resource(async () => {
+        term.get();
+        return gates[fetches++].promise;
+      }, { concurrency: 'overlap' });
+
+      term.set('b');
+      flush();
+
+      expect(fetches).toBe(2); // no waiting for the first settle
+      expect(results.loading).toBe(true);
+
+      gates[0].resolve('stale');
+      gates[1].resolve('fresh');
+      await tick();
+
+      expect(results.get()).toBe('fresh');
+      expect(results.loading).toBe(false);
+    });
+
+    it('the latest run wins when settles arrive out of order', async () => {
+      const term = signal('a');
+      const gates = [gate(), gate()];
+      let fetches = 0;
+      const results = resource(async () => {
+        term.get();
+        return gates[fetches++].promise;
+      }, { concurrency: 'overlap' });
+
+      term.set('b');
+      flush();
+
+      gates[1].resolve('fresh'); // the newer run lands first
+      await tick();
+
+      expect(results.get()).toBe('fresh');
+      expect(results.loading).toBe(false);
+
+      gates[0].resolve('stale'); // the stale run must not clobber
+      await tick();
+
+      expect(results.get()).toBe('fresh');
+      expect(results.loading).toBe(false);
+    });
+
+    it('a superseded overlap run still aborts for fetchers that read the signal', async () => {
+      const term = signal('a');
+      const abortSignals = [];
+      const results = resource(async (comp) => {
+        term.get();
+        abortSignals.push(comp.abortSignal);
+        return new Promise(() => {}); // never settles, the abort is the observable
+      }, { concurrency: 'overlap' });
+
+      term.set('b');
+      flush();
+
+      expect(abortSignals[0].aborted).toBe(true);
+      expect(abortSignals[1].aborted).toBe(false);
+      results.stop();
+    });
+
+    it('stop() during overlapping fetches resets the faces', async () => {
+      const term = signal('a');
+      const gates = [gate(), gate()];
+      let fetches = 0;
+      const results = resource(async () => {
+        term.get();
+        return gates[fetches++].promise;
+      }, { concurrency: 'overlap' });
+      term.set('b');
+      flush();
+
+      results.stop();
+      expect(results.loading).toBe(false);
+
+      gates[0].resolve('a');
+      gates[1].resolve('b');
+      await tick();
+
+      expect(results.get()).toBe(undefined); // stopped runs land nothing
+      expect(results.loading).toBe(false);
+    });
+  });
+
   describe('Hardening', () => {
     it('comp.stop() after an await clears loading and drops the settle', async () => {
       // the only in-fetcher stop available on a first run, the handle binding is unassigned

--- a/packages/reactivity/types/resource.d.ts
+++ b/packages/reactivity/types/resource.d.ts
@@ -20,13 +20,26 @@ export interface ResourceOptions<T> extends SignalOptions<T> {
    * otherwise miss rejections landing silently in the `error` face.
    */
   onError?: (error: unknown) => void;
+
+  /**
+   * How a refetch behaves when a tracked read or `refresh()` fires while a run
+   * is in flight. `'latest'` (the default) serializes runs: the in-flight run
+   * aborts through `computation.abortSignal` and the refetch coalesces into one
+   * re-run after it settles, so at most one fetch is ever in flight. `'overlap'`
+   * starts every fetch immediately and lets the newest run's settle win, for
+   * fetchers that cannot cooperate with cancellation. Overlap costs concurrent
+   * fetches under churn, and its runs are invisible to `settled()` because the
+   * backing reaction stays synchronous. Defaults to `'latest'`.
+   */
+  concurrency?: 'latest' | 'overlap';
 }
 
 /**
  * A Resource is a Signal whose value an async fetcher produces. The fetcher runs
  * as an async reaction: signals it reads before its first `await` are tracked
- * and re-fire the fetch when they change, runs never overlap, and a superseded
- * run aborts through `computation.abortSignal` (latest-wins). The stored value
+ * and re-fire the fetch when they change. By default runs never overlap and a
+ * superseded run aborts through `computation.abortSignal` (latest-wins), which
+ * the `concurrency` option can relax to overlapping runs. The stored value
  * holds last-good through a refresh and through a rejection. Fetch status lives
  * in the separate `loading`, `error`, and `settled` faces, each reactive on its
  * own.

--- a/packages/renderer/src/engines/lit/directives/reactive-async.js
+++ b/packages/renderer/src/engines/lit/directives/reactive-async.js
@@ -1,19 +1,23 @@
-import { noChange, nothing } from 'lit';
+import { noChange } from 'lit';
 import { AsyncDirective } from 'lit/async-directive.js';
 import { directive } from 'lit/directive.js';
 
-import { reaction } from '@semantic-ui/reactivity';
-import { each, isClient, isPlainObject, isPromise } from '@semantic-ui/utils';
+import { nonreactive, reaction, resource } from '@semantic-ui/reactivity';
+import { each, isClient, isPlainObject } from '@semantic-ui/utils';
+
+/*
+  {#async ...} backed by a Resource, overlap concurrency — a re-fire starts its
+  fetch immediately and the newest run's settle wins, matching what the block
+  always did for template expressions that can't thread an abort signal. The
+  directive's reaction reads the faces and renders the branch that matches.
+*/
 
 export class ReactiveAsyncDirective extends AsyncDirective {
   constructor(partInfo) {
     super(partInfo);
     this.reaction = null;
-    this.generation = 0;
-    this.state = 'loading'; // 'loading', 'success', 'error'
-    this.resolvedValue = null;
-    this.hasResolved = false;
-    this.error = null;
+    this.resource = null;
+    this.syncThrew = false;
   }
 
   render(asyncCondition) {
@@ -24,7 +28,23 @@ export class ReactiveAsyncDirective extends AsyncDirective {
       return noChange;
     }
 
-    // Create a new reaction that watches for reactive changes on client
+    // fetcher reads through `this` so a re-render's fresh closures flow in.
+    // created nonreactive so an enclosing reaction can't tear it down,
+    // disconnected() owns the teardown
+    this.resource = nonreactive(() =>
+      resource(() => {
+        this.syncThrew = false;
+        try {
+          return this.asyncCondition.expression();
+        }
+        catch (error) {
+          // flagged so a synchronous throw with no error branch stays loud
+          this.syncThrew = true;
+          throw error;
+        }
+      }, { concurrency: 'overlap' })
+    );
+
     if (isClient) {
       this.watchChanges();
     }
@@ -33,7 +53,7 @@ export class ReactiveAsyncDirective extends AsyncDirective {
   }
 
   watchChanges() {
-    let context = {
+    const context = {
       message: `async block: {#async ${this.asyncCondition.expression}}`,
       async: this.asyncCondition,
     };
@@ -44,102 +64,54 @@ export class ReactiveAsyncDirective extends AsyncDirective {
         return;
       }
 
-      // Evaluate the expression to get the promise or value
-      const expressionResult = this.asyncCondition.expression();
+      // face reads register here, a flip re-runs and re-renders
+      const rendered = this.renderCurrentState(this.asyncCondition);
 
-      // Handle the result
-      this.handleExpressionResult(expressionResult, this.asyncCondition);
-
-      // Render based on current state (after first run)
       if (!computation.firstRun) {
-        const rendered = this.renderCurrentState(this.asyncCondition);
         this.setValue(rendered);
       }
     }, { context });
   }
 
-  handleExpressionResult(result, asyncCondition) {
-    const currentGeneration = ++this.generation;
-
-    // Preserve previous resolved value for stale-while-revalidate
-    this.state = 'loading';
-    this.error = null;
-
-    // Check if result is a promise
-    if (isPromise(result)) {
-      // Handle promise
-      result
-        .then((value) => {
-          if (currentGeneration < this.generation) {
-            return;
-          }
-          this.state = 'success';
-          this.resolvedValue = value;
-          this.hasResolved = true;
-          if (this.isConnected) {
-            const rendered = this.renderCurrentState(asyncCondition);
-            this.setValue(rendered);
-          }
-        })
-        .catch((error) => {
-          if (currentGeneration < this.generation) { return; }
-          this.state = 'error';
-          this.resolvedValue = null;
-          this.hasResolved = false;
-          this.error = error;
-          if (this.isConnected) {
-            const rendered = this.renderCurrentState(asyncCondition);
-            this.setValue(rendered);
-          }
-        });
-    }
-    else {
-      // Synchronous value
-      this.state = 'success';
-      this.resolvedValue = result;
-      this.hasResolved = true;
-    }
-  }
-
   renderCurrentState(asyncCondition) {
-    switch (this.state) {
-      case 'loading':
-        if (asyncCondition.loadingContent) {
-          return asyncCondition.loadingContent();
-        }
-        // No loading block: preserve previous content if available
-        if (this.hasResolved && asyncCondition.content) {
-          const successData = this.createSuccessDataContext(asyncCondition);
-          return asyncCondition.content(successData);
-        }
-        return noChange;
+    const handle = this.resource;
 
-      case 'error':
-        if (asyncCondition.errorContent) {
-          // Create data context with error
-          const errorData = asyncCondition.errorAs
-            ? { [asyncCondition.errorAs]: this.error }
-            : { this: this.error };
-
-          return asyncCondition.errorContent(errorData);
-        }
-        return noChange;
-
-      case 'success':
-        if (asyncCondition.content) {
-          // Create data context with resolved value
-          const successData = this.createSuccessDataContext(asyncCondition);
-          return asyncCondition.content(successData);
-        }
-        return noChange;
-
-      default:
-        return noChange;
+    if (handle.loading) {
+      if (asyncCondition.loadingContent) {
+        return asyncCondition.loadingContent();
+      }
+      // No loading block: preserve previous content if available
+      if (handle.settled && asyncCondition.content) {
+        return asyncCondition.content(this.createSuccessDataContext(asyncCondition));
+      }
+      return noChange;
     }
+
+    const error = handle.error;
+    if (error !== undefined) {
+      if (asyncCondition.errorContent) {
+        const errorData = asyncCondition.errorAs
+          ? { [asyncCondition.errorAs]: error }
+          : { this: error };
+        return asyncCondition.errorContent(errorData);
+      }
+      if (this.syncThrew) {
+        throw error;
+      }
+      return noChange;
+    }
+
+    if (!handle.settled) {
+      return noChange;
+    }
+    if (asyncCondition.content) {
+      return asyncCondition.content(this.createSuccessDataContext(asyncCondition));
+    }
+    return noChange;
   }
 
   createSuccessDataContext(asyncCondition) {
-    const value = this.resolvedValue;
+    const value = this.resource.get();
 
     // Handle {#async expression as alias}
     if (asyncCondition.as) {
@@ -150,14 +122,12 @@ export class ReactiveAsyncDirective extends AsyncDirective {
     if (asyncCondition.parts && isPlainObject(value)) {
       const data = {};
 
-      // Extract specified properties
       each(asyncCondition.parts, (prop) => {
         if (prop in value) {
           data[prop] = value[prop];
         }
       });
 
-      // Handle rest parameter
       if (asyncCondition.rest) {
         const restObj = { ...value };
         each(asyncCondition.parts, (prop) => {
@@ -174,14 +144,14 @@ export class ReactiveAsyncDirective extends AsyncDirective {
   }
 
   disconnected() {
-    if (this.reaction) {
-      this.reaction.stop();
-      this.reaction = null;
-    }
+    this.reaction?.stop();
+    this.reaction = null;
+    this.resource?.stop();
+    this.resource = null;
   }
 
   reconnected() {
-    // Lit calls render() on reconnect which recreates the reaction
+    // Lit calls render() on reconnect which recreates the reaction and resource
   }
 }
 

--- a/packages/renderer/src/engines/native/blocks/async.js
+++ b/packages/renderer/src/engines/native/blocks/async.js
@@ -1,14 +1,17 @@
-import { each, isPlainObject, isPromise } from '@semantic-ui/utils';
+import { nonreactive, resource } from '@semantic-ui/reactivity';
+import { each, isPlainObject } from '@semantic-ui/utils';
 import { defineBlock } from '../define-block.js';
 import { markScopeRange } from '../scope-context.js';
 import { registerBlock } from './registry.js';
 
 /*
 
-  {#async ...} — three-state construct (loading / success / error). The
-  generation counter on self discards stale promise resolutions: each
-  re-evaluation bumps self.generation, and pending .then/.catch callbacks
-  bail out if their captured generation is less than the current one.
+  {#async ...} — three-state construct (loading / success / error) backed by a
+  Resource. The expression runs as the resource's fetcher, so its reads re-fire
+  the fetch and the value holds last-good through a refetch. Overlap concurrency
+  matches what the block always did: a re-fire starts its fetch immediately and
+  the newest run's settle wins, template expressions can't thread an abort signal.
+  The block's own reaction reads the faces and renders the branch that matches.
 
   States:
   • sync value            → render node.content with success data context
@@ -48,74 +51,6 @@ function createSuccessDataContext(node, value) {
   return { this: value };
 }
 
-// Shared helper invoked from render/update: evaluates the expression,
-// fans out to loading/success/error based on result shape. On hydrate the
-// server already rendered the current state, so we skip the synchronous
-// loadingContent re-render (see hydrate hook).
-function evaluateAndRender(ctx, { skipLoadingRender = false } = {}) {
-  const { node, data, scope, region, renderAST, lookupExpression, childContext, self, isSVG } = ctx;
-  const result = lookupExpression(node.expression);
-  const currentGen = ++self.generation;
-
-  const renderState = (ast, extraData = {}) => {
-    const stateScope = scope.child();
-    const fragment = renderAST({
-      ast,
-      data: childContext(data, extraData),
-      scope: stateScope,
-      isSVG,
-    });
-    region.setContent(fragment, stateScope);
-    stampAsyncScope(region, extraData);
-  };
-
-  if (isPromise(result)) {
-    if (!skipLoadingRender) {
-      if (node.loadingContent?.length) {
-        renderState(node.loadingContent);
-      }
-      else if (self.hasResolved && node.content?.length) {
-        // Re-show last resolved value while a new promise is in flight.
-        // Better than flashing empty when the template has no loadingContent.
-        renderState(node.content, createSuccessDataContext(node, self.resolvedValue));
-      }
-    }
-
-    result.then((value) => {
-      if (currentGen < self.generation) { return; }
-      self.resolvedValue = value;
-      self.hasResolved = true;
-      renderState(node.content, createSuccessDataContext(node, value));
-    }).catch((error) => {
-      if (currentGen < self.generation) { return; }
-      if (node.errorContent?.length) {
-        const errorData = node.errorAs ? { [node.errorAs]: error } : { this: error };
-        renderState(node.errorContent, errorData);
-      }
-    });
-  }
-  else {
-    self.resolvedValue = result;
-    self.hasResolved = true;
-    renderState(node.content, createSuccessDataContext(node, result));
-  }
-}
-
-function renderErrorState(ctx, err) {
-  const { node, data, scope, region, renderAST, childContext, isSVG } = ctx;
-  if (!node.errorContent?.length) { return; }
-  const stateScope = scope.child();
-  const errorData = node.errorAs ? { [node.errorAs]: err } : { this: err };
-  const fragment = renderAST({
-    ast: node.errorContent,
-    data: childContext(data, errorData),
-    scope: stateScope,
-    isSVG,
-  });
-  region.setContent(fragment, stateScope);
-  stampAsyncScope(region, errorData);
-}
-
 const asyncBlock = defineBlock({
   name: 'async',
   syntax: (node) => `{#async ${node.expression}}`,
@@ -126,30 +61,105 @@ const asyncBlock = defineBlock({
   shouldRecover: (node) => Boolean(node.errorContent?.length),
 
   create() {
-    return { generation: 0, hasResolved: false, resolvedValue: null };
+    return { resource: null, syncThrew: false };
+  },
+
+  // the resource owns expression evaluation, its backing reaction tracks the
+  // reads. created nonreactive so the block's own re-runs can't tear it down,
+  // destroy() owns the teardown instead
+  ensureResource({ self, node, lookupExpression }) {
+    if (self.resource === null) {
+      self.resource = nonreactive(() =>
+        resource(() => {
+          self.syncThrew = false;
+          try {
+            return lookupExpression(node.expression);
+          }
+          catch (error) {
+            // flagged so a synchronous throw with no error branch stays loud
+            self.syncThrew = true;
+            throw error;
+          }
+        }, { concurrency: 'overlap' })
+      );
+    }
+    return self.resource;
+  },
+
+  renderState(ctx, ast, extraData = {}) {
+    const { data, scope, region, renderAST, childContext, isSVG } = ctx;
+    const stateScope = scope.child();
+    const fragment = renderAST({
+      ast,
+      data: childContext(data, extraData),
+      scope: stateScope,
+      isSVG,
+    });
+    region.setContent(fragment, stateScope);
+    stampAsyncScope(region, extraData);
+  },
+
+  // face-driven branch chooser. the face reads register on the block's own
+  // reaction, so a flip re-runs update() without re-evaluating the expression
+  renderCurrent(ctx, { preservePending = false } = {}) {
+    const { node, self } = ctx;
+    const handle = self.resource;
+    if (handle.loading) {
+      if (preservePending) { return; }
+      if (node.loadingContent?.length) {
+        this.renderState(ctx, node.loadingContent);
+      }
+      else if (handle.settled && node.content?.length) {
+        // re-show the held value while a new fetch is in flight
+        this.renderState(ctx, node.content, createSuccessDataContext(node, handle.get()));
+      }
+      return;
+    }
+    const error = handle.error;
+    if (error !== undefined) {
+      if (node.errorContent?.length) {
+        const errorData = node.errorAs ? { [node.errorAs]: error } : { this: error };
+        this.renderState(ctx, node.errorContent, errorData);
+      }
+      else if (self.syncThrew) {
+        throw error;
+      }
+      return;
+    }
+    if (!handle.settled) { return; }
+    if (node.content?.length) {
+      this.renderState(ctx, node.content, createSuccessDataContext(node, handle.get()));
+    }
   },
 
   render(ctx) {
-    evaluateAndRender(ctx);
+    this.ensureResource(ctx);
+    this.renderCurrent(ctx);
   },
 
   hydrate(ctx) {
-    // skipLoadingRender splits behavior by branch: pending promise
-    // preserves server's loadingContent (no flash); sync value still
-    // re-renders success because server emitted loadingContent that
-    // doesn't match the resolved value.
-    evaluateAndRender(ctx, { skipLoadingRender: true });
+    this.ensureResource(ctx);
+    // pending keeps the server's loadingContent in place, a sync settle
+    // re-renders because the server emitted loading that no longer matches
+    this.renderCurrent(ctx, { preservePending: true });
   },
 
   update(ctx) {
-    evaluateAndRender(ctx);
+    this.renderCurrent(ctx);
   },
 
-  // Sync throws in expression evaluation route here; promise rejections are
-  // handled inside evaluateAndRender's .catch. Both end up rendering the
+  destroy(ctx) {
+    ctx.self.resource?.stop();
+  },
+
+  // Sync throws in expression evaluation route here through the block's
+  // reaction; promise rejections land in the error face. Both render the
   // same errorContent path.
   error({ err, ...ctx }) {
-    renderErrorState(ctx, err);
+    const { node } = ctx;
+    if (!node.errorContent?.length) { return; }
+    const errorData = node.errorAs ? { [node.errorAs]: err } : { this: err };
+    this.renderState(ctx, node.errorContent, errorData);
   },
   // No evaluateText: async cannot operate in raw-text contexts (promise
   // lifecycle needs per-invocation state and DOM region tracking the text


### PR DESCRIPTION
This updates the rendering engine to use a `resource` to handle implementation of an `{#async}` block

## Changes
- Adds new setting `concurrency: 'latest' | 'overlap'` on resource
- Native block and lit directive rewritten to use `resource`

## Risk
5/10 

`{#async}` blocks are a top-level templating block and are used frequently.