### PR TITLE
Bug: Fix subtemplate event routing

### DIFF
--- a/docs/src/pages/test.astro
+++ b/docs/src/pages/test.astro
@@ -9,10 +9,9 @@ import { importMap } from './examples/importmap.json.js';
 <div style="padding: 24px; max-width: 1100px;">
   <h3>Naked event bindings</h3>
   <p style="max-width: 62ch; font-size: 14px; line-height: 1.5;">
-    An event key with no selector binds on the host element. Shadow retargeting rewrites
-    <code>event.target</code> to the host for anything raised inside the shadow root, so the containment
-    check in <code>isNodeInTemplate</code> is handed the host no matter where the event started.
-    Click each demo and watch the log.
+    An event key with no selector binds on the host element, and shadow retargeting rewrites
+    <code>event.target</code> to the host for anything raised inside the shadow root. Subtemplates
+    listen at the render root instead, where the target survives. Click each demo and watch the log.
   </p>
   <div id="event-cases" style="display: grid; gap: 16px;"></div>
 </div>
@@ -95,9 +94,9 @@ defineComponent({
   /* 2 — same binding inside a subtemplate */
 
   const logSub = addCase({
-    status: 'broken',
+    status: 'works',
     title: 'Subtemplate, naked click',
-    expected: 'Clicking inside the item should fire. Clicking outside it should not. Neither fires.',
+    expected: 'Fires for a click inside the item, and stays silent for the button outside it.',
     tagName: 'lab-subtemplate',
     source: `
 defineComponent({
@@ -125,9 +124,9 @@ defineComponent({
   /* 3 — the scoping question: which row owns the click */
 
   const logEach = addCase({
-    status: 'broken',
+    status: 'works',
     title: 'Each row, naked click',
-    expected: 'Clicking a row should fire that row only. No row fires.',
+    expected: 'Fires for the row that was clicked, and only that row.',
     tagName: 'lab-each',
     source: `
 defineComponent({

--- a/docs/src/pages/test.astro
+++ b/docs/src/pages/test.astro
@@ -34,7 +34,7 @@ import { importMap } from './examples/importmap.json.js';
 
   // each case renders its own source, mounts a live component, and appends a line
   // per handler call — a case that stays on "no handler calls" is the failure
-  const addCase = ({ status, title, expected, source, tagName }) => {
+  const addCase = ({ status, title, expected, source, tagName, onElement }) => {
     const card = document.createElement('section');
     card.style.cssText = 'border: 1px solid #444; border-radius: 6px; padding: 14px 16px;';
     const works = status === 'works';
@@ -53,17 +53,98 @@ import { importMap } from './examples/importmap.json.js';
     card.querySelector('[data-title]').textContent = title;
     card.querySelector('[data-expected]').textContent = expected;
     card.querySelector('[data-source]').textContent = source.trim();
-    card.querySelector('[data-demo]').appendChild(document.createElement(tagName));
-    container.appendChild(card);
 
     const logEl = card.querySelector('[data-log]');
     const lines = [];
-
-    return (line) => {
+    const log = (line) => {
       lines.push(line);
       logEl.textContent = lines.join('\n');
     };
+
+    // runs before connect so a case can catch lifecycle events
+    const element = document.createElement(tagName);
+    onElement?.(element, log);
+    card.querySelector('[data-demo]').appendChild(element);
+    container.appendChild(card);
+
+    return log;
   };
+
+  /* open — a page listener counts one lifecycle event per subtemplate instance */
+
+  addCase({
+    status: 'broken',
+    title: 'Lifecycle events reaching the page',
+    expected: 'A page listener on the tag should see one created and one rendered, whatever the template is built from. It sees one per subtemplate instance.',
+    tagName: 'lab-lifecycle',
+    source: `
+defineComponent({
+  tagName: 'lab-lifecycle',
+  template: '<div>{> panel}<ul>{#each item in rows}{> row label=item.label}{/each}</ul></div>',
+  defaultState: { rows: [{ label: 'a' }, { label: 'b' }, { label: 'c' }] },
+  subTemplates: { panel, row },
+});
+
+// on the page
+element.addEventListener('created', ...);
+element.addEventListener('rendered', ...);`,
+    onElement(element, log) {
+      const counts = { created: 0, rendered: 0 };
+      for (const name of ['created', 'rendered']) {
+        element.addEventListener(name, (event) => {
+          counts[name] += 1;
+          log(`${name} ×${counts[name]} from ${event.detail?.component?.templateName ?? '?'}`);
+        });
+      }
+    },
+  });
+  defineComponent({
+    tagName: 'lab-lifecycle',
+    templateName: 'theTag',
+    template: '<div>{> panel}<ul>{#each item in rows}{> row label=item.label}{/each}</ul></div>',
+    defaultState: { rows: [{ label: 'a' }, { label: 'b' }, { label: 'c' }] },
+    subTemplates: {
+      panel: { templateName: 'panel', template: '<div class="panel">panel</div>' },
+      row: { templateName: 'row', template: '<li>{label}</li>' },
+    },
+  });
+
+  /* open — composed:false should stop at the component, not before it */
+
+  const logQuiet = addCase({
+    status: 'broken',
+    title: 'Uncomposed event from a subtemplate',
+    expected: 'The tag should hear it and the page should not. Neither hears it — the tag listens on its host, which is outside the shadow root.',
+    tagName: 'lab-quiet',
+    source: `
+subTemplates: {
+  inner: {
+    template: '<button class="btn">emit</button>',
+    events: {
+      'click .btn'({ dispatchEvent }) {
+        dispatchEvent('quiet', { n: 1 }, { composed: false });
+      },
+    },
+  },
+},
+events: { quiet() { log('tag heard it'); } },`,
+    onElement(element, log) {
+      document.addEventListener('quiet', () => log('page heard it (should not)'));
+    },
+  });
+  defineComponent({
+    tagName: 'lab-quiet',
+    template: '<div>{> inner}</div>',
+    subTemplates: {
+      inner: {
+        template: '<button class="btn">emit</button>',
+        events: {
+          'click .btn'({ dispatchEvent }) { dispatchEvent('quiet', { n: 1 }, { composed: false }); },
+        },
+      },
+    },
+    events: { quiet() { logQuiet('tag heard it'); } },
+  });
 
   /* 1 — the mechanism, on a template that works today */
 

--- a/docs/src/pages/test.astro
+++ b/docs/src/pages/test.astro
@@ -189,9 +189,9 @@ defineComponent({
   /* 5 — the reported shape: one subtemplate emits, a sibling listens */
 
   const logSibling = addCase({
-    status: 'broken',
+    status: 'works',
     title: 'Subtemplate emits, sibling subtemplate listens',
-    expected: 'The listener subtemplate should hear the custom event. It never fires.',
+    expected: 'Silent, and should stay silent — the event fired on the host, which is not inside the listener\'s range.',
     tagName: 'lab-sibling',
     source: `
 defineComponent({

--- a/docs/src/pages/test.astro
+++ b/docs/src/pages/test.astro
@@ -7,6 +7,17 @@ import { importMap } from './examples/importmap.json.js';
 ---
 <Body>
 <div style="padding: 24px; max-width: 1100px;">
+  <h3>Naked event bindings</h3>
+  <p style="max-width: 62ch; font-size: 14px; line-height: 1.5;">
+    An event key with no selector binds on the host element. Shadow retargeting rewrites
+    <code>event.target</code> to the host for anything raised inside the shadow root, so the containment
+    check in <code>isNodeInTemplate</code> is handed the host no matter where the event started.
+    Click each demo and watch the log.
+  </p>
+  <div id="event-cases" style="display: grid; gap: 16px;"></div>
+</div>
+
+<div style="padding: 24px; max-width: 1100px;">
   <h3>Playground Engine Test</h3>
   <pre id="status" style="font-size: 12px; min-height: 80px;"></pre>
   <div style="display: flex; gap: 16px;">
@@ -16,6 +27,240 @@ import { importMap } from './examples/importmap.json.js';
   </div>
 </div>
 <script type="application/json" id="importmap-data" set:html={JSON.stringify(importMap)}></script>
+
+<script>
+  import { defineComponent } from '@semantic-ui/component';
+
+  const container = document.getElementById('event-cases');
+
+  // each case renders its own source, mounts a live component, and appends a line
+  // per handler call — a case that stays on "no handler calls" is the failure
+  const addCase = ({ status, title, expected, source, tagName }) => {
+    const card = document.createElement('section');
+    card.style.cssText = 'border: 1px solid #444; border-radius: 6px; padding: 14px 16px;';
+    const works = status === 'works';
+    card.innerHTML = `
+      <div style="display: flex; align-items: baseline; gap: 10px;">
+        <span style="font: 600 11px/1 monospace; letter-spacing: .06em; padding: 4px 7px; border-radius: 3px;
+          background: ${works ? '#1b5e20' : '#7f1d1d'}; color: #fff;">${works ? 'WORKS' : 'BROKEN'}</span>
+        <strong data-title style="font-size: 14px;"></strong>
+      </div>
+      <p data-expected style="font-size: 13px; opacity: .8; margin: 8px 0;"></p>
+      <pre data-source style="font-size: 12px; line-height: 1.45; overflow-x: auto; padding: 10px;
+        background: rgba(127,127,127,.12); border-radius: 4px;"></pre>
+      <div data-demo style="display: flex; gap: 8px; align-items: center; margin: 10px 0;"></div>
+      <pre data-log style="font-size: 12px; margin: 0; min-height: 2.4em; opacity: .85;">no handler calls</pre>
+    `;
+    card.querySelector('[data-title]').textContent = title;
+    card.querySelector('[data-expected]').textContent = expected;
+    card.querySelector('[data-source]').textContent = source.trim();
+    card.querySelector('[data-demo]').appendChild(document.createElement(tagName));
+    container.appendChild(card);
+
+    const logEl = card.querySelector('[data-log]');
+    const lines = [];
+
+    return (line) => {
+      lines.push(line);
+      logEl.textContent = lines.join('\n');
+    };
+  };
+
+  /* 1 — the mechanism, on a template that works today */
+
+  const logRetarget = addCase({
+    status: 'works',
+    title: 'Top-level tag, naked click',
+    expected: 'Fires. Note the reported target is the tag itself, not the button that was clicked.',
+    tagName: 'lab-retarget',
+    source: `
+defineComponent({
+  tagName: 'lab-retarget',
+  template: '<button class="btn">click me</button>',
+  events: {
+    click({ event }) { log(event.target.tagName); },
+  },
+});`,
+  });
+  defineComponent({
+    tagName: 'lab-retarget',
+    template: '<button class="btn">click me</button>',
+    events: {
+      click({ event }) {
+        logRetarget(`fired — event.target is <${event.target.tagName.toLowerCase()}>`);
+      },
+    },
+  });
+
+  /* 2 — same binding inside a subtemplate */
+
+  const logSub = addCase({
+    status: 'broken',
+    title: 'Subtemplate, naked click',
+    expected: 'Clicking inside the item should fire. Clicking outside it should not. Neither fires.',
+    tagName: 'lab-subtemplate',
+    source: `
+defineComponent({
+  tagName: 'lab-subtemplate',
+  template: '<div>{> item}<button class="outside">outside item</button></div>',
+  subTemplates: {
+    item: {
+      template: '<button class="btn">inside item</button>',
+      events: { click() { log('item handler'); } },
+    },
+  },
+});`,
+  });
+  defineComponent({
+    tagName: 'lab-subtemplate',
+    template: '<div>{> item}<button class="outside">outside item</button></div>',
+    subTemplates: {
+      item: {
+        template: '<button class="btn">inside item</button>',
+        events: { click() { logSub('item handler fired'); } },
+      },
+    },
+  });
+
+  /* 3 — the scoping question: which row owns the click */
+
+  const logEach = addCase({
+    status: 'broken',
+    title: 'Each row, naked click',
+    expected: 'Clicking a row should fire that row only. No row fires.',
+    tagName: 'lab-each',
+    source: `
+defineComponent({
+  tagName: 'lab-each',
+  template: '<div>{#each rows}{> row label=label}{/each}</div>',
+  defaultState: { rows: [{ label: 'A' }, { label: 'B' }] },
+  subTemplates: {
+    row: {
+      template: '<button class="btn">row {label}</button>',
+      events: { click({ data }) { log(data.label); } },
+    },
+  },
+});`,
+  });
+  defineComponent({
+    tagName: 'lab-each',
+    template: '<div>{#each rows}{> row label=label}{/each}</div>',
+    defaultState: { rows: [{ label: 'A' }, { label: 'B' }] },
+    subTemplates: {
+      row: {
+        template: '<button class="btn">row {label}</button>',
+        events: {
+          click({ data }) { logEach(`row ${data?.label ?? '(no data)'} fired`); },
+        },
+      },
+    },
+  });
+
+  /* 4 — control: the same subtemplate with a selector */
+
+  const logSelector = addCase({
+    status: 'works',
+    title: 'Subtemplate, click with a selector',
+    expected: 'Fires. Subtemplate events are attached — only the naked form is unreachable.',
+    tagName: 'lab-selector',
+    source: `
+defineComponent({
+  tagName: 'lab-selector',
+  template: '<div>{> item}</div>',
+  subTemplates: {
+    item: {
+      template: '<button class="btn">click me</button>',
+      events: { 'click .btn'() { log('item handler'); } },
+    },
+  },
+});`,
+  });
+  defineComponent({
+    tagName: 'lab-selector',
+    template: '<div>{> item}</div>',
+    subTemplates: {
+      item: {
+        template: '<button class="btn">click me</button>',
+        events: { 'click .btn'() { logSelector('item handler fired'); } },
+      },
+    },
+  });
+
+  /* 5 — the reported shape: one subtemplate emits, a sibling listens */
+
+  const logSibling = addCase({
+    status: 'broken',
+    title: 'Subtemplate emits, sibling subtemplate listens',
+    expected: 'The listener subtemplate should hear the custom event. It never fires.',
+    tagName: 'lab-sibling',
+    source: `
+defineComponent({
+  tagName: 'lab-sibling',
+  template: '<div>{> sender}{> listener}</div>',
+  subTemplates: {
+    sender: {
+      template: '<button class="btn">emit custom</button>',
+      events: { 'click .btn'({ dispatchEvent }) { dispatchEvent('custom', { n: 1 }); } },
+    },
+    listener: {
+      template: '<span></span>',
+      events: { custom({ data }) { log(data.n); } },
+    },
+  },
+});`,
+  });
+  defineComponent({
+    tagName: 'lab-sibling',
+    template: '<div>{> sender}{> listener}</div>',
+    subTemplates: {
+      sender: {
+        template: '<button class="btn">emit custom</button>',
+        events: {
+          'click .btn'({ dispatchEvent }) { dispatchEvent('custom', { n: 1 }); },
+        },
+      },
+      listener: {
+        template: '<span></span>',
+        events: { custom({ data }) { logSibling(`listener heard custom, n=${data?.n}`); } },
+      },
+    },
+  });
+
+  /* 6 — same emit, heard by the top-level tag */
+
+  const logTop = addCase({
+    status: 'works',
+    title: 'Subtemplate emits, top-level tag listens',
+    expected: 'Fires. The top-level template has no range markers, so the containment check is skipped.',
+    tagName: 'lab-top-listener',
+    source: `
+defineComponent({
+  tagName: 'lab-top-listener',
+  template: '<div>{> sender}</div>',
+  subTemplates: {
+    sender: {
+      template: '<button class="btn">emit custom</button>',
+      events: { 'click .btn'({ dispatchEvent }) { dispatchEvent('custom', { n: 1 }); } },
+    },
+  },
+  events: { custom({ data }) { log(data.n); } },
+});`,
+  });
+  defineComponent({
+    tagName: 'lab-top-listener',
+    template: '<div>{> sender}</div>',
+    subTemplates: {
+      sender: {
+        template: '<button class="btn">emit custom</button>',
+        events: {
+          'click .btn'({ dispatchEvent }) { dispatchEvent('custom', { n: 1 }); },
+        },
+      },
+    },
+    events: { custom({ data }) { logTop(`tag heard custom, n=${data?.n}`); } },
+  });
+</script>
+
 <script>
   import { PlaygroundProject } from '@semantic-ui/playground';
 

--- a/packages/component/test/browser/subtemplate-events.test.js
+++ b/packages/component/test/browser/subtemplate-events.test.js
@@ -208,6 +208,111 @@ describe('custom events dispatched from a subtemplate', () => {
 });
 
 /*******************************
+      Lifecycle Boundary
+*******************************/
+
+// a page listener sees the component, not its internals — the count must not
+// track how many subtemplates the template happens to be built from
+describe('lifecycle events from subtemplates', () => {
+  function defineNested(tagName) {
+    const row = defineComponent({
+      templateName: 'row',
+      template: '<li>{label}</li>',
+    });
+    const panel = defineComponent({
+      templateName: 'panel',
+      template: '<div class="panel">panel</div>',
+    });
+    return { row, panel, tagName };
+  }
+
+  it('a page listener on the tag sees one created and one rendered', async () => {
+    const { row, panel } = defineNested();
+    const created = [];
+    const rendered = [];
+    defineComponent({
+      tagName: 'life-once',
+      templateName: 'theTag',
+      template: '<div>{> panel}<ul>{#each item in rows}{> row label=item.label}{/each}</ul></div>',
+      defaultState: { rows: [{ label: 'a' }, { label: 'b' }, { label: 'c' }] },
+      subTemplates: { panel, row },
+    });
+
+    const element = document.createElement('life-once');
+    element.addEventListener('created', () => created.push(1));
+    element.addEventListener('rendered', () => rendered.push(1));
+    document.body.appendChild(element);
+    mounted.push(element);
+    await settle();
+
+    expect({ created: created.length, rendered: rendered.length }).toEqual({ created: 1, rendered: 1 });
+  });
+
+  it('the tag still hears its own subtemplates render', async () => {
+    const { row, panel } = defineNested();
+    const heard = [];
+    defineComponent({
+      tagName: 'life-inside',
+      templateName: 'theTag',
+      template: '<div>{> panel}<ul>{#each item in rows}{> row label=item.label}{/each}</ul></div>',
+      defaultState: { rows: [{ label: 'a' }, { label: 'b' }, { label: 'c' }] },
+      subTemplates: { panel, row },
+      events: {
+        rendered({ data }) {
+          heard.push(data?.component?.templateName ?? '?');
+        },
+      },
+    });
+
+    const element = mount('life-inside');
+    await settle();
+
+    // its own render plus the panel and three rows
+    expect(heard.length).toBe(5);
+  });
+});
+
+/*******************************
+      Uncomposed Events
+*******************************/
+
+describe('a subtemplate event with composed false', () => {
+  it('reaches the tag but not the page', async () => {
+    const tagHeard = vi.fn();
+    const pageHeard = vi.fn();
+
+    const inner = defineComponent({
+      template: '<button class="btn">go</button>',
+      events: {
+        'click .btn'({ dispatchEvent }) {
+          dispatchEvent('quiet', { n: 1 }, { composed: false });
+        },
+      },
+    });
+    defineComponent({
+      tagName: 'quiet-tag',
+      template: '<div>{> inner}</div>',
+      subTemplates: { inner },
+      events: { quiet: tagHeard },
+    });
+
+    const element = mount('quiet-tag');
+    await settle();
+
+    document.addEventListener('quiet', pageHeard);
+    try {
+      click(element.shadowRoot.querySelector('.btn'));
+      await settle();
+      expect(tagHeard).toHaveBeenCalledTimes(1);
+      expect(pageHeard).not.toHaveBeenCalled();
+    }
+    finally {
+      document.removeEventListener('quiet', pageHeard);
+    }
+  });
+});
+
+/*******************************
         Unchanged Paths
 *******************************/
 

--- a/packages/component/test/browser/subtemplate-events.test.js
+++ b/packages/component/test/browser/subtemplate-events.test.js
@@ -266,40 +266,6 @@ describe('lifecycle events from subtemplates', () => {
 *******************************/
 
 describe('a subtemplate event with composed false', () => {
-  it('reaches a handler on the tag but not the page', async () => {
-    const tagHeard = vi.fn();
-    const pageHeard = vi.fn();
-
-    const inner = defineComponent({
-      template: '<button class="btn">go</button>',
-      events: {
-        'click .btn'({ dispatchEvent }) {
-          dispatchEvent('quiet', { n: 1 }, { composed: false });
-        },
-      },
-    });
-    defineComponent({
-      tagName: 'quiet-bare',
-      template: '<div>{> inner}</div>',
-      subTemplates: { inner },
-      events: { quiet: tagHeard },
-    });
-
-    const element = mount('quiet-bare');
-    await settle();
-
-    document.addEventListener('quiet', pageHeard);
-    try {
-      click(element.shadowRoot.querySelector('.btn'));
-      await settle();
-      expect(tagHeard).toHaveBeenCalledTimes(1);
-      expect(pageHeard).not.toHaveBeenCalled();
-    }
-    finally {
-      document.removeEventListener('quiet', pageHeard);
-    }
-  });
-
   it('reaches a selector-scoped handler on the tag but not the page', async () => {
     const tagHeard = vi.fn();
     const pageHeard = vi.fn();

--- a/packages/component/test/browser/subtemplate-events.test.js
+++ b/packages/component/test/browser/subtemplate-events.test.js
@@ -266,6 +266,40 @@ describe('lifecycle events from subtemplates', () => {
 *******************************/
 
 describe('a subtemplate event with composed false', () => {
+  it('reaches a handler on the tag but not the page', async () => {
+    const tagHeard = vi.fn();
+    const pageHeard = vi.fn();
+
+    const inner = defineComponent({
+      template: '<button class="btn">go</button>',
+      events: {
+        'click .btn'({ dispatchEvent }) {
+          dispatchEvent('quiet', { n: 1 }, { composed: false });
+        },
+      },
+    });
+    defineComponent({
+      tagName: 'quiet-bare',
+      template: '<div>{> inner}</div>',
+      subTemplates: { inner },
+      events: { quiet: tagHeard },
+    });
+
+    const element = mount('quiet-bare');
+    await settle();
+
+    document.addEventListener('quiet', pageHeard);
+    try {
+      click(element.shadowRoot.querySelector('.btn'));
+      await settle();
+      expect(tagHeard).toHaveBeenCalledTimes(1);
+      expect(pageHeard).not.toHaveBeenCalled();
+    }
+    finally {
+      document.removeEventListener('quiet', pageHeard);
+    }
+  });
+
   it('reaches a selector-scoped handler on the tag but not the page', async () => {
     const tagHeard = vi.fn();
     const pageHeard = vi.fn();

--- a/packages/component/test/browser/subtemplate-events.test.js
+++ b/packages/component/test/browser/subtemplate-events.test.js
@@ -1,0 +1,249 @@
+// An event key with no selector binds on the host. Inside a shadow root that
+// makes event.target useless for placing the event — retargeting reports the
+// host for anything raised in the tree — so subtemplates listen at the render
+// root instead and the top-level tag treats its own host as in-template.
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { defineComponent } from '../../src/index.js';
+
+const mounted = [];
+
+afterEach(() => {
+  mounted.forEach((element) => element.remove());
+  mounted.length = 0;
+});
+
+function mount(tagName) {
+  const element = document.createElement(tagName);
+  document.body.appendChild(element);
+  mounted.push(element);
+  return element;
+}
+
+// components render on a microtask, and handlers fire through the same queue
+const settle = () => new Promise((resolve) => setTimeout(resolve, 30));
+
+function click(element) {
+  element.dispatchEvent(new MouseEvent('click', { bubbles: true, composed: true }));
+}
+
+/*******************************
+      Naked Events — Scoping
+*******************************/
+
+describe('subtemplate events — no selector', () => {
+  it('fires for a click inside the subtemplate', async () => {
+    const handler = vi.fn();
+    defineComponent({
+      tagName: 'sub-event-inside',
+      template: '<div>{> item}</div>',
+      subTemplates: {
+        item: {
+          template: '<button class="btn">go</button>',
+          events: { click: handler },
+        },
+      },
+    });
+    const element = mount('sub-event-inside');
+    await settle();
+
+    click(element.shadowRoot.querySelector('.btn'));
+    await settle();
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it('stays silent for a click elsewhere in the same render root', async () => {
+    const handler = vi.fn();
+    defineComponent({
+      tagName: 'sub-event-outside',
+      template: '<div>{> item}<button class="outside">out</button></div>',
+      subTemplates: {
+        item: {
+          template: '<button class="btn">go</button>',
+          events: { click: handler },
+        },
+      },
+    });
+    const element = mount('sub-event-outside');
+    await settle();
+
+    click(element.shadowRoot.querySelector('.outside'));
+    await settle();
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  // one listener per row instance, so a leak shows up as a second call
+  it('scopes each row to its own instance', async () => {
+    const clicked = [];
+    defineComponent({
+      tagName: 'sub-event-each',
+      template: '<div>{#each rows}{> row label=label}{/each}</div>',
+      defaultState: { rows: [{ label: 'A' }, { label: 'B' }] },
+      subTemplates: {
+        row: {
+          template: '<button class="btn">{label}</button>',
+          events: {
+            click({ target }) {
+              clicked.push(target.textContent.trim());
+            },
+          },
+        },
+      },
+    });
+    const element = mount('sub-event-each');
+    await settle();
+
+    const buttons = element.shadowRoot.querySelectorAll('.btn');
+    expect(buttons.length).toBe(2);
+
+    click(buttons[0]);
+    await settle();
+    expect(clicked).toEqual(['A']);
+
+    click(buttons[1]);
+    await settle();
+    expect(clicked).toEqual(['A', 'B']);
+  });
+});
+
+/*******************************
+     Dispatched Custom Events
+*******************************/
+
+describe('custom events dispatched from a subtemplate', () => {
+  it('reaches a listener on the top-level tag', async () => {
+    const handler = vi.fn();
+    defineComponent({
+      tagName: 'sub-emit-to-tag',
+      template: '<div>{> sender}</div>',
+      subTemplates: {
+        sender: {
+          template: '<button class="btn">emit</button>',
+          events: {
+            'click .btn'({ dispatchEvent }) {
+              dispatchEvent('custom', { n: 1 });
+            },
+          },
+        },
+      },
+      events: { custom: handler },
+    });
+    const element = mount('sub-emit-to-tag');
+    await settle();
+
+    click(element.shadowRoot.querySelector('.btn'));
+    await settle();
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler.mock.calls[0][0].data.n).toBe(1);
+  });
+
+  // tag > shop > list, where list emits and shop listens — the event has to
+  // travel through shop's range to be heard, so dispatching from the host misses it
+  it('reaches a listener one level up, and the tag above that', async () => {
+    const shopHeard = vi.fn();
+    const tagHeard = vi.fn();
+
+    const list = defineComponent({
+      template: '<div class="list"><button class="add">add</button></div>',
+      events: {
+        'click .add'({ dispatchEvent }) {
+          dispatchEvent('addToCart', { itemId: 'apple' });
+        },
+      },
+    });
+    const shop = defineComponent({
+      template: '<div class="shop">{> list}</div>',
+      subTemplates: { list },
+      events: { addToCart: shopHeard },
+    });
+    defineComponent({
+      tagName: 'sub-emit-up-two',
+      template: '<div class="app">{> shop}</div>',
+      subTemplates: { shop },
+      events: { addToCart: tagHeard },
+    });
+
+    const element = mount('sub-emit-up-two');
+    await settle();
+
+    click(element.shadowRoot.querySelector('.add'));
+    await settle();
+    expect(shopHeard).toHaveBeenCalledTimes(1);
+    expect(shopHeard.mock.calls[0][0].data.itemId).toBe('apple');
+    expect(tagHeard).toHaveBeenCalledTimes(1);
+
+    // re-dispatching inside a handler keeps the element that started it
+    expect(shopHeard.mock.calls[0][0].target).toBe(element.shadowRoot.querySelector('.add'));
+  });
+
+  // the event fires on the host, which is outside every subtemplate's range
+  it('does not reach a sibling subtemplate', async () => {
+    const handler = vi.fn();
+    defineComponent({
+      tagName: 'sub-emit-to-sibling',
+      template: '<div>{> sender}{> listener}</div>',
+      subTemplates: {
+        sender: {
+          template: '<button class="btn">emit</button>',
+          events: {
+            'click .btn'({ dispatchEvent }) {
+              dispatchEvent('custom', { n: 1 });
+            },
+          },
+        },
+        listener: {
+          template: '<span></span>',
+          events: { custom: handler },
+        },
+      },
+    });
+    const element = mount('sub-emit-to-sibling');
+    await settle();
+
+    click(element.shadowRoot.querySelector('.btn'));
+    await settle();
+    expect(handler).not.toHaveBeenCalled();
+  });
+});
+
+/*******************************
+        Unchanged Paths
+*******************************/
+
+describe('bindings that already worked', () => {
+  it('fires a selector-scoped subtemplate handler', async () => {
+    const handler = vi.fn();
+    defineComponent({
+      tagName: 'sub-event-selector',
+      template: '<div>{> item}</div>',
+      subTemplates: {
+        item: {
+          template: '<button class="btn">go</button>',
+          events: { 'click .btn': handler },
+        },
+      },
+    });
+    const element = mount('sub-event-selector');
+    await settle();
+
+    click(element.shadowRoot.querySelector('.btn'));
+    await settle();
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it('fires a naked handler on the top-level tag for a click in its tree', async () => {
+    const handler = vi.fn();
+    defineComponent({
+      tagName: 'tag-event-naked',
+      template: '<div><button class="btn">go</button></div>',
+      events: { click: handler },
+    });
+    const element = mount('tag-event-naked');
+    await settle();
+
+    click(element.shadowRoot.querySelector('.btn'));
+    await settle();
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/component/test/browser/subtemplate-events.test.js
+++ b/packages/component/test/browser/subtemplate-events.test.js
@@ -1,7 +1,4 @@
-// An event key with no selector binds on the host. Inside a shadow root that
-// makes event.target useless for placing the event — retargeting reports the
-// host for anything raised in the tree — so subtemplates listen at the render
-// root instead and the top-level tag treats its own host as in-template.
+// where a template's events come from and who can hear them
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
@@ -138,8 +135,7 @@ describe('custom events dispatched from a subtemplate', () => {
     expect(handler.mock.calls[0][0].data.n).toBe(1);
   });
 
-  // tag > shop > list, where list emits and shop listens — the event has to
-  // travel through shop's range to be heard, so dispatching from the host misses it
+  // dispatching from the host skips every template between the two
   it('reaches a listener one level up, and the tag above that', async () => {
     const shopHeard = vi.fn();
     const tagHeard = vi.fn();
@@ -211,8 +207,7 @@ describe('custom events dispatched from a subtemplate', () => {
       Lifecycle Boundary
 *******************************/
 
-// a page listener sees the component, not its internals — the count must not
-// track how many subtemplates the template happens to be built from
+// the count must not track how many subtemplates the template is built from
 describe('lifecycle events from subtemplates', () => {
   function defineNested(tagName) {
     const row = defineComponent({
@@ -248,27 +243,21 @@ describe('lifecycle events from subtemplates', () => {
     expect({ created: created.length, rendered: rendered.length }).toEqual({ created: 1, rendered: 1 });
   });
 
-  it('the tag still hears its own subtemplates render', async () => {
-    const { row, panel } = defineNested();
-    const heard = [];
+  // naming the subtemplate's own markup is how a tag observes it from inside
+  it('a selector-scoped handler on the tag still hears a subtemplate render', async () => {
+    const handler = vi.fn();
     defineComponent({
-      tagName: 'life-inside',
-      templateName: 'theTag',
-      template: '<div>{> panel}<ul>{#each item in rows}{> row label=item.label}{/each}</ul></div>',
-      defaultState: { rows: [{ label: 'a' }, { label: 'b' }, { label: 'c' }] },
-      subTemplates: { panel, row },
-      events: {
-        rendered({ data }) {
-          heard.push(data?.component?.templateName ?? '?');
-        },
+      tagName: 'life-selector',
+      template: '<div>{> panel}</div>',
+      subTemplates: {
+        panel: { template: '<div class="panel">panel</div>' },
       },
+      events: { 'rendered .panel': handler },
     });
 
-    const element = mount('life-inside');
+    mount('life-selector');
     await settle();
-
-    // its own render plus the panel and three rows
-    expect(heard.length).toBe(5);
+    expect(handler).toHaveBeenCalledTimes(1);
   });
 });
 
@@ -277,7 +266,7 @@ describe('lifecycle events from subtemplates', () => {
 *******************************/
 
 describe('a subtemplate event with composed false', () => {
-  it('reaches the tag but not the page', async () => {
+  it('reaches a selector-scoped handler on the tag but not the page', async () => {
     const tagHeard = vi.fn();
     const pageHeard = vi.fn();
 
@@ -293,7 +282,7 @@ describe('a subtemplate event with composed false', () => {
       tagName: 'quiet-tag',
       template: '<div>{> inner}</div>',
       subTemplates: { inner },
-      events: { quiet: tagHeard },
+      events: { 'quiet .btn': tagHeard },
     });
 
     const element = mount('quiet-tag');

--- a/packages/renderer/test/browser/subtree-spurious.test.js
+++ b/packages/renderer/test/browser/subtree-spurious.test.js
@@ -1,6 +1,6 @@
 import { defineComponent } from '@semantic-ui/component';
 import { $ } from '@semantic-ui/query';
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { RENDERING_ENGINES } from './test-utils.js';
 
 RENDERING_ENGINES.forEach(engine => {
@@ -614,9 +614,9 @@ RENDERING_ENGINES.forEach(engine => {
 
         // change only label — both expressions should re-evaluate
         // because data=expression is a blob (coarse reactivity)
-        const updated = $(el).onNext('updated');
+        // only the child updates here, and its lifecycle stays in the shadow root
         el.component.updateLabel('changed');
-        await updated;
+        await vi.waitFor(() => expect(shadowText(el)).toContain('changed'));
 
         expect(shadowText(el)).toContain('changed');
         expect(shadowText(el)).toContain('active');

--- a/packages/templating/src/template.js
+++ b/packages/templating/src/template.js
@@ -654,13 +654,15 @@ export const Template = class Template {
             $(this.renderRoot).on(eventName, selector, eventHandler, eventSettings);
           }
           else if (this.isSubtemplate()) {
-            // inside the shadow root event.target survives retargeting
+            // if we are on a subtemplate permits 'click' to mean {>item} scope not
             $(this.renderRoot).on(eventName, eventHandler, eventSettings);
           }
           else {
-            // naked: bind on host so events on the host's own surface fire
+            // the common case - a regular old event
             $(this.element).on(eventName, eventHandler, eventSettings);
-            // uncomposed events never reach the host, so catch them where they rise
+
+            // if this is a custom event that isnt composed (an internal custom event)
+            // we want to fire it still
             $(this.renderRoot).on(eventName, function(event) {
               if (!event.composed) {
                 eventHandler.call(this, event);

--- a/packages/templating/src/template.js
+++ b/packages/templating/src/template.js
@@ -248,14 +248,14 @@ export const Template = class Template {
     // this is necessary for tree traversal with findParent/getChild
     template.instance.templateName = this.templateName;
 
-    // lifecycle reports on the component, so it fires from the host even for a
-    // subtemplate, where a user event comes from the subtemplate's own content
+    // uncomposed, so a subtemplate's lifecycle stops at the shadow root. the
+    // component hears its own internals, the page only hears the component
     const dispatchLifecycle = (eventName) =>
       this.dispatchEvent(
         eventName,
         { component: this.instance },
         { composed: false },
-        { triggerCallback: false, origin: this.element },
+        { triggerCallback: false },
       );
 
     this.onCreated = () => {

--- a/packages/templating/src/template.js
+++ b/packages/templating/src/template.js
@@ -248,12 +248,11 @@ export const Template = class Template {
     // this is necessary for tree traversal with findParent/getChild
     template.instance.templateName = this.templateName;
 
-    // uncomposed, so a subtemplate's lifecycle stops at the shadow root. the
-    // component hears its own internals, the page only hears the component
+    // uncomposed so a subtemplates lifecycle stops at the shadow root
     const dispatchLifecycle = (eventName) =>
       this.dispatchEvent(
         eventName,
-        { component: this.instance },
+        { component: this.instance, templateName: this.templateName },
         { composed: false },
         { triggerCallback: false },
       );
@@ -262,7 +261,8 @@ export const Template = class Template {
       this.call(this.onCreatedCallback);
       Template.addTemplate(this);
       this.resolveLifecyclePromise('created');
-      if (!this.isHydrating) {
+      // created fires before attach so theres no content to raise it from
+      if (!this.isHydrating && !this.isSubtemplate()) {
         dispatchLifecycle('created');
       }
     };
@@ -617,8 +617,7 @@ export const Template = class Template {
           }
 
           // prepare data for users event handler
-          // a delegated binding lands on the matched element, a naked one lands
-          // on whatever the listener sits on, so the event carries the real target
+          // the element that was hit, not whatever the listener sits on
           const targetElement = selector ? this : event.target;
           const boundEvent = userHandler.bind(targetElement);
           const elValue = targetElement?.value ?? event.target?.value ?? event?.detail?.value;
@@ -655,8 +654,7 @@ export const Template = class Template {
             $(this.renderRoot).on(eventName, selector, eventHandler, eventSettings);
           }
           else if (this.isSubtemplate()) {
-            // listening at the root keeps event.target as the node that was hit,
-            // so the range check can tell whose content it landed in
+            // inside the shadow root event.target survives retargeting
             $(this.renderRoot).on(eventName, eventHandler, eventSettings);
           }
           else {
@@ -756,9 +754,7 @@ export const Template = class Template {
   // Find the direct child of the renderRoot that is an ancestor of the event.target
   // then confirm position
   isNodeInTemplate(node) {
-    // the host is the tag's own outer boundary, and retargeting reports it as
-    // event.target for anything raised inside the shadow tree. subtemplates
-    // borrow the same host but sit inside it, so it is never theirs.
+    // the host is the tags own boundary, a subtemplate only borrows it
     const host = this.renderRoot?.host;
     if (host && node === host) {
       return !this.isSubtemplate();
@@ -1032,8 +1028,7 @@ export const Template = class Template {
     }
   }
 
-  // an event only bubbles through the templates containing this one if it comes
-  // from this template's own content. a tag has nowhere to sit but its host
+  // only content inside this template bubbles through the templates around it
   getEventOrigin() {
     for (let node = this.startNode; node && node !== this.endNode; node = node.nextSibling) {
       if (node.nodeType === Node.ELEMENT_NODE) {

--- a/packages/templating/src/template.js
+++ b/packages/templating/src/template.js
@@ -609,7 +609,9 @@ export const Template = class Template {
           }
 
           // prepare data for users event handler
-          const targetElement = this;
+          // a delegated binding lands on the matched element, a naked one lands
+          // on whatever the listener sits on, so the event carries the real target
+          const targetElement = selector ? this : event.target;
           const boundEvent = userHandler.bind(targetElement);
           const elValue = targetElement?.value ?? event.target?.value ?? event?.detail?.value;
           return template.call(boundEvent, {
@@ -619,6 +621,10 @@ export const Template = class Template {
               target: targetElement,
               value: elValue,
               data: template.getEventData(targetElement, event),
+              // events dispatched from event handlers originate from the element
+              dispatchEvent: (name, data, settings) => (
+                template.dispatchEvent(name, data, settings, { origin: targetElement })
+              ),
             },
           });
         };
@@ -639,6 +645,11 @@ export const Template = class Template {
         else {
           if (selector) {
             $(this.renderRoot).on(eventName, selector, eventHandler, eventSettings);
+          }
+          else if (this.isSubtemplate()) {
+            // listening at the root keeps event.target as the node that was hit,
+            // so the range check can tell whose content it landed in
+            $(this.renderRoot).on(eventName, eventHandler, eventSettings);
           }
           else {
             // naked: bind on host so events on the host's own surface fire
@@ -737,6 +748,13 @@ export const Template = class Template {
   // Find the direct child of the renderRoot that is an ancestor of the event.target
   // then confirm position
   isNodeInTemplate(node) {
+    // the host is the tag's own outer boundary, and retargeting reports it as
+    // event.target for anything raised inside the shadow tree. subtemplates
+    // borrow the same host but sit inside it, so it is never theirs.
+    const host = this.renderRoot?.host;
+    if (host && node === host) {
+      return !this.isSubtemplate();
+    }
     // subtemplates attach while their content is still in the build
     // fragment, so stored parentNode can be a dead fragment — the start
     // anchor's live parent is the real boundary at event time
@@ -1006,8 +1024,19 @@ export const Template = class Template {
     }
   }
 
+  // an event only bubbles through the templates containing this one if it comes
+  // from this template's own content. a tag has nowhere to sit but its host
+  getEventOrigin() {
+    for (let node = this.startNode; node && node !== this.endNode; node = node.nextSibling) {
+      if (node.nodeType === Node.ELEMENT_NODE) {
+        return node;
+      }
+    }
+    return this.element;
+  }
+
   // dispatches an event from this template
-  dispatchEvent(eventName, eventData, eventSettings, { triggerCallback = true } = {}) {
+  dispatchEvent(eventName, eventData, eventSettings, { triggerCallback = true, origin = this.getEventOrigin() } = {}) {
     if (Template.isServer) {
       return;
     }
@@ -1018,7 +1047,7 @@ export const Template = class Template {
       wrapFunction(callback).call(this.element, eventData);
     }
 
-    return $(this.element).dispatchEvent(eventName, eventData, eventSettings);
+    return $(origin).dispatchEvent(eventName, eventData, eventSettings);
   }
 
   /*******************************

--- a/packages/templating/src/template.js
+++ b/packages/templating/src/template.js
@@ -653,21 +653,10 @@ export const Template = class Template {
           if (selector) {
             $(this.renderRoot).on(eventName, selector, eventHandler, eventSettings);
           }
-          else if (this.isSubtemplate()) {
-            // if we are on a subtemplate permits 'click' to mean {>item} scope not
-            $(this.renderRoot).on(eventName, eventHandler, eventSettings);
-          }
           else {
-            // the common case - a regular old event
-            $(this.element).on(eventName, eventHandler, eventSettings);
-
-            // if this is a custom event that isnt composed (an internal custom event)
-            // we want to fire it still
-            $(this.renderRoot).on(eventName, function(event) {
-              if (!event.composed) {
-                eventHandler.call(this, event);
-              }
-            }, eventSettings);
+            // a subtemplate has no host of its own, so 'click' means its own scope
+            const root = this.isSubtemplate() ? this.renderRoot : this.element;
+            $(root).on(eventName, eventHandler, eventSettings);
           }
         }
       });

--- a/packages/templating/src/template.js
+++ b/packages/templating/src/template.js
@@ -660,6 +660,12 @@ export const Template = class Template {
           else {
             // naked: bind on host so events on the host's own surface fire
             $(this.element).on(eventName, eventHandler, eventSettings);
+            // uncomposed events never reach the host, so catch them where they rise
+            $(this.renderRoot).on(eventName, function(event) {
+              if (!event.composed) {
+                eventHandler.call(this, event);
+              }
+            }, eventSettings);
           }
         }
       });

--- a/packages/templating/src/template.js
+++ b/packages/templating/src/template.js
@@ -248,14 +248,22 @@ export const Template = class Template {
     // this is necessary for tree traversal with findParent/getChild
     template.instance.templateName = this.templateName;
 
-    const eventSettings = { composed: false };
+    // lifecycle reports on the component, so it fires from the host even for a
+    // subtemplate, where a user event comes from the subtemplate's own content
+    const dispatchLifecycle = (eventName) =>
+      this.dispatchEvent(
+        eventName,
+        { component: this.instance },
+        { composed: false },
+        { triggerCallback: false, origin: this.element },
+      );
 
     this.onCreated = () => {
       this.call(this.onCreatedCallback);
       Template.addTemplate(this);
       this.resolveLifecyclePromise('created');
       if (!this.isHydrating) {
-        this.dispatchEvent('created', { component: this.instance }, eventSettings, { triggerCallback: false });
+        dispatchLifecycle('created');
       }
     };
     this.onRendered = () => {
@@ -268,7 +276,7 @@ export const Template = class Template {
       }
       this.resolveLifecyclePromise('rendered');
       if (!this.isHydrating) {
-        this.dispatchEvent('rendered', { component: this.instance }, eventSettings, { triggerCallback: false });
+        dispatchLifecycle('rendered');
       }
     };
     this.onUpdated = () => {
@@ -281,7 +289,7 @@ export const Template = class Template {
         }
         this.call(this.onUpdatedCallback);
         this.resolveLifecyclePromise('updated');
-        this.dispatchEvent('updated', { component: this.instance }, eventSettings, { triggerCallback: false });
+        dispatchLifecycle('updated');
       });
     };
 
@@ -302,7 +310,7 @@ export const Template = class Template {
       this.removeParent();
       this.call(this.onDestroyedCallback);
       this.resolveLifecyclePromise('destroyed');
-      this.dispatchEvent('destroyed', { component: this.instance }, eventSettings, { triggerCallback: false });
+      dispatchLifecycle('destroyed');
     };
 
     this.initialized = true;


### PR DESCRIPTION
This consolidates logic around how subtemplates use `dispatchEvent` to make them easier to reason about.

This also fixes issues in event handlers expecting to listen to their own custom events. They resolved on the `host` element which would cause it to appear to be out of the components shadow DOM. 


## Changes
- Custom events from a subtemplate now bubble to the parent component
- `dispatchEvent` now permits specifying an origin, event handlers specify their own

## Risk
6/10 - event routing in `Template`, and every component with an events block sits on it.