### PR TITLE
Bug(compiler): Render literals written in templates

### DIFF
--- a/packages/compiler/src/template-compiler.js
+++ b/packages/compiler/src/template-compiler.js
@@ -258,9 +258,8 @@ class TemplateCompiler {
             // attribute context decides ifDefined, only expressions consume it
             const context = (type === 'EXPRESSION') ? scanner.getContext() : null;
             scanner.consume(regex);
-            const rawContent = getTagContent();
+            const content = getTagContent();
             scanner.consume(parserRegExp.EXPRESSION_END);
-            const content = this.getValue(rawContent);
             return { type, content, ...context };
           }
         }
@@ -270,7 +269,7 @@ class TemplateCompiler {
       for (const [type, regex] of TemplateCompiler.htmlRegExpEntries) {
         if (scanner.matches(regex)) {
           scanner.consume(regex);
-          const content = this.getValue(scanner.consumeUntil(parserRegExp.TAG_CLOSE).trim());
+          const content = scanner.consumeUntil(parserRegExp.TAG_CLOSE).trim();
           scanner.consume(parserRegExp.TAG_CLOSE);
           return { type, content };
         }
@@ -744,19 +743,6 @@ class TemplateCompiler {
     // offsets against the source string, so they never condense
     const condense = !includePositions && !recoverable && !preserveWhitespace;
     return TemplateCompiler.optimizeAST(ast, { condense });
-  }
-
-  getValue(expression) {
-    if (expression == 'true') {
-      return true;
-    }
-    else if (expression == 'false') {
-      return false;
-    }
-    else if (isString(expression) && expression.trim() !== '' && Number.isFinite(+expression)) {
-      return Number(expression);
-    }
-    return expression;
   }
 
   parseRerenderExpression(content) {

--- a/packages/compiler/test/compiler-coverage.test.js
+++ b/packages/compiler/test/compiler-coverage.test.js
@@ -31,47 +31,6 @@ describe('TemplateCompiler - Extended Coverage', () => {
   });
 
   /*-----------------------------------------
-    getValue
-  -----------------------------------------*/
-
-  describe('getValue', () => {
-    it('should convert "true" to boolean true', () => {
-      const compiler = new TemplateCompiler();
-      expect(compiler.getValue('true')).toBe(true);
-    });
-
-    it('should convert "false" to boolean false', () => {
-      const compiler = new TemplateCompiler();
-      expect(compiler.getValue('false')).toBe(false);
-    });
-
-    it('should convert numeric strings to numbers', () => {
-      const compiler = new TemplateCompiler();
-      expect(compiler.getValue('42')).toBe(42);
-      expect(compiler.getValue('0')).toBe(0);
-      expect(compiler.getValue('3.14')).toBe(3.14);
-      expect(compiler.getValue('-7')).toBe(-7);
-    });
-
-    it('should return non-numeric strings as-is', () => {
-      const compiler = new TemplateCompiler();
-      expect(compiler.getValue('hello')).toBe('hello');
-      expect(compiler.getValue('user.name')).toBe('user.name');
-    });
-
-    it('should return whitespace-only strings as-is', () => {
-      const compiler = new TemplateCompiler();
-      expect(compiler.getValue('  ')).toBe('  ');
-    });
-
-    it('should pass through undefined and null', () => {
-      const compiler = new TemplateCompiler();
-      expect(compiler.getValue(undefined)).toBe(undefined);
-      expect(compiler.getValue(null)).toBe(null);
-    });
-  });
-
-  /*-----------------------------------------
     parseIteratorString (static)
   -----------------------------------------*/
 

--- a/packages/compiler/test/compiler.test.js
+++ b/packages/compiler/test/compiler.test.js
@@ -72,7 +72,7 @@ describe('TemplateCompiler', () => {
       expect(ast).toEqual(expectedAST);
     });
 
-    // literals stay source text in the AST — the evaluator resolves them, so
+    // literals stay source text in the AST. the evaluator resolves them, so
     // every expression field is a string no matter what the author wrote
     it('should keep boolean literals as expressions', () => {
       const compiler = new TemplateCompiler();

--- a/packages/compiler/test/compiler.test.js
+++ b/packages/compiler/test/compiler.test.js
@@ -72,7 +72,9 @@ describe('TemplateCompiler', () => {
       expect(ast).toEqual(expectedAST);
     });
 
-    it('should preserve boolean values', () => {
+    // literals stay source text in the AST — the evaluator resolves them, so
+    // every expression field is a string no matter what the author wrote
+    it('should keep boolean literals as expressions', () => {
       const compiler = new TemplateCompiler();
       const template = `
         <div>
@@ -83,9 +85,9 @@ describe('TemplateCompiler', () => {
       const ast = compiler.compile(template);
       const expectedAST = [
         { type: 'html', html: '<div><p>' },
-        { type: 'expression', value: true },
+        { type: 'expression', value: 'true' },
         { type: 'html', html: '</p><p>' },
-        { type: 'expression', value: false },
+        { type: 'expression', value: 'false' },
         { type: 'html', html: '</p></div>' },
       ];
       expect(ast).toEqual(expectedAST);
@@ -118,7 +120,7 @@ describe('TemplateCompiler', () => {
       expect(ast).toEqual(expectedAST);
     });
 
-    it('should preserve boolean values in conditionals', () => {
+    it('should keep boolean literals in conditionals', () => {
       const compiler = new TemplateCompiler();
       const template = `
         <div>
@@ -135,7 +137,7 @@ describe('TemplateCompiler', () => {
         { type: 'html', html: '<div>' },
         {
           type: 'if',
-          condition: true,
+          condition: 'true',
           branches: [],
           content: [
             { type: 'html', html: '<p>True</p>' },
@@ -143,7 +145,7 @@ describe('TemplateCompiler', () => {
         },
         {
           type: 'if',
-          condition: false,
+          condition: 'false',
           branches: [],
           content: [
             { type: 'html', html: '<p>False</p>' },
@@ -154,7 +156,7 @@ describe('TemplateCompiler', () => {
       expect(ast).toEqual(expectedAST);
     });
 
-    it('should preserve numerical values', () => {
+    it('should keep numeric literals as expressions', () => {
       const compiler = new TemplateCompiler();
       const template = `
         <div>
@@ -165,9 +167,9 @@ describe('TemplateCompiler', () => {
       const ast = compiler.compile(template);
       const expectedAST = [
         { type: 'html', html: '<div><p>' },
-        { type: 'expression', value: 10 },
+        { type: 'expression', value: '10' },
         { type: 'html', html: '</p><p>' },
-        { type: 'expression', value: 0 },
+        { type: 'expression', value: '0' },
         { type: 'html', html: '</p></div>' },
       ];
       expect(ast).toEqual(expectedAST);

--- a/packages/compiler/types/template-compiler.d.ts
+++ b/packages/compiler/types/template-compiler.d.ts
@@ -149,14 +149,6 @@ export class TemplateCompiler {
   errors: { message: string; pos: number; }[];
 
   /**
-   * Extracts value
-   * @internal
-   * @param expression string containing value
-   * @returns the value
-   */
-  getValue(expression: string): any;
-
-  /**
    * Parses a template string expression (e.g., `templateName data1=value1 data2=value2`).
    * @param {string} expression -
    * @returns {TemplateInfo} Parsed template info.

--- a/packages/renderer/test/browser/node-types.test.js
+++ b/packages/renderer/test/browser/node-types.test.js
@@ -99,6 +99,38 @@ RENDERING_ENGINES.forEach(engine => {
   });
 
   /*******************************
+       Literal Expressions
+  *******************************/
+
+  describe('literal expression rendering', () => {
+    it('should render literals written directly in the template', async () => {
+      const tag = uniqueTag();
+      defineComponent({
+        tagName: tag,
+        renderingEngine: engine,
+        template: "<div>{true}|{false}|{1}|{0}|{-7}|{'baz'}</div>",
+      });
+      const el = document.createElement(tag);
+      document.body.appendChild(el);
+      await waitForUpdate(el);
+      expect(el.shadowRoot.querySelector('div').textContent).toBe('true|false|1|0|-7|baz');
+    });
+
+    it('should branch on a literal condition', async () => {
+      const tag = uniqueTag();
+      defineComponent({
+        tagName: tag,
+        renderingEngine: engine,
+        template: '<div>{#if true}yes{/if}{#if false}no{/if}</div>',
+      });
+      const el = document.createElement(tag);
+      document.body.appendChild(el);
+      await waitForUpdate(el);
+      expect(el.shadowRoot.querySelector('div').textContent).toBe('yes');
+    });
+  });
+
+  /*******************************
      Literal Value ({#fn})
   *******************************/
 

--- a/packages/renderer/test/unit/server.test.js
+++ b/packages/renderer/test/unit/server.test.js
@@ -114,6 +114,21 @@ describe('renderToString', () => {
       expect(stripMarkers(dsdContent(result))).toBe('<span>42</span>');
     });
 
+    // false and 0 are the ones worth guarding — a literal that resolves falsy
+    // used to disappear rather than throw, so it never surfaced as a failure
+    it('renders literal expressions', () => {
+      const cases = [['true', 'true'], ['false', 'false'], ['1', '1'], ['0', '0'], ["'baz'", 'baz']];
+      for (const [expression, expected] of cases) {
+        const ast = compile(`<div>{${expression}}</div>`);
+        expect(stripMarkers(dsdContent(renderToString({ ast })))).toBe(`<div>${expected}</div>`);
+      }
+    });
+
+    it('renders a literal expression in an attribute', () => {
+      const ast = compile('<div class="{1}">x</div>');
+      expect(stripMarkers(dsdContent(renderToString({ ast })))).toBe('<div class="1">x</div>');
+    });
+
     it('escapes HTML in text expressions', () => {
       const ast = compile('<div>{text}</div>');
       const result = renderToString({ ast, data: { text: '<script>alert(1)</script>' } });
@@ -196,6 +211,13 @@ describe('renderToString', () => {
       const ast = compile('<div>{#if show}<span>content</span>{/if}</div>');
       const result = renderToString({ ast, data: { show: false } });
       expect(stripMarkers(dsdContent(result))).toBe('<div></div>');
+    });
+
+    it('renders a literal condition', () => {
+      const yes = compile('<div>{#if true}<span>yes</span>{else}<span>no</span>{/if}</div>');
+      expect(stripMarkers(dsdContent(renderToString({ ast: yes })))).toBe('<div><span>yes</span></div>');
+      const no = compile('<div>{#if false}<span>yes</span>{else}<span>no</span>{/if}</div>');
+      expect(stripMarkers(dsdContent(renderToString({ ast: no })))).toBe('<div><span>no</span></div>');
     });
 
     it('preserves block markers for hydration', () => {

--- a/packages/renderer/test/unit/server.test.js
+++ b/packages/renderer/test/unit/server.test.js
@@ -114,10 +114,19 @@ describe('renderToString', () => {
       expect(stripMarkers(dsdContent(result))).toBe('<span>42</span>');
     });
 
-    // false and 0 are the ones worth guarding — a literal that resolves falsy
-    // used to disappear rather than throw, so it never surfaced as a failure
+    // false and 0 are the ones worth guarding. a literal resolving falsy
+    // disappears rather than throwing, so it never surfaces as a failure
     it('renders literal expressions', () => {
-      const cases = [['true', 'true'], ['false', 'false'], ['1', '1'], ['0', '0'], ["'baz'", 'baz']];
+      const cases = [
+        ['true', 'true'],
+        ['false', 'false'],
+        ['null', ''],
+        ['1', '1'],
+        ['0', '0'],
+        ['-7', '-7'],
+        ['3.14', '3.14'],
+        ["'baz'", 'baz'],
+      ];
       for (const [expression, expected] of cases) {
         const ast = compile(`<div>{${expression}}</div>`);
         expect(stripMarkers(dsdContent(renderToString({ ast })))).toBe(`<div>${expected}</div>`);


### PR DESCRIPTION
This fixes literal js values passed directly to expressions like `{#if true}` to no longer error. 

This was caused by template-compiler optimistically preserving types but the render expecting strings.

## Changes
- `{true}`, `{1}`, `{-7}`, `{#if true}` and `class="{1}"` render instead of throwing
- `{false}` and `{0}` render their value instead of nothing
- Every AST expression field is a string again

## Risk
3/10. The compiler is on everyone's path, but the folding branch only fired on a whole-tag literal, which no template in this repo contains. Literal resolution moved from the compiler to the evaluator's `getLiteralValue`.
