### PR TITLE
CI: Add PR Hook for AI Authored Pull Requests

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -7,10 +7,26 @@
   "mcpServers": {
     "semantic-ui": {
       "command": "bash",
-      "args": ["-c", "cd tools/mcp && npm run build --silent && node dist/index.js"]
+      "args": [
+        "-c",
+        "cd tools/mcp && npm run build --silent && node dist/index.js"
+      ]
     }
   },
   "enabledPlugins": {
     "typescript-lsp@claude-plugins-official": true
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash tools/hooks/pr-description"
+          }
+        ]
+      }
+    ]
   }
 }

--- a/.github/workflows/pr-description.yml
+++ b/.github/workflows/pr-description.yml
@@ -1,0 +1,47 @@
+name: PR Description
+
+# Reads the PR title and body only, so it runs safely on fork pull requests
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+
+permissions:
+  contents: read
+
+jobs:
+  description:
+    name: Written in your own words
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check title and body
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          # Footers and trailers coding agents append to what they write. The
+          # list is a signal, not a blocklist: a leftover footer is the reliable
+          # tell that a description went up unread. Add tools as they appear.
+          agents='Claude|Codex|Copilot|Cursor|Devin|Aider|Gemini|Windsurf|Cline|OpenHands|Jules\[bot\]'
+          pattern="(Generated (with|by)[[:space:]]*\[?(${agents})|🤖 Generated (with|by)|Co-authored-by:.*(${agents}))"
+          if printf '%s\n%s' "$PR_TITLE" "$PR_BODY" | grep -qiE "$pattern"; then
+            cat <<'EOF'
+          Thanks for the contribution! This description still carries a coding
+          agent's generated footer, so it looks like it went up unedited.
+
+          Plenty of projects reject tool-assisted contributions outright. This
+          one doesn't. Write the code however you work best. What we ask is
+          that you read your own change and summarize it yourself, following
+          .github/pull_request_template.md: one sentence on why it exists,
+          then a few bullets on what it does.
+
+          That summary is the whole ask, and it is deliberately a small one.
+          Every PR spends a maintainer's attention, and a description in your
+          own words is the cheapest way to show that attention is warranted.
+          You can't summarize what you don't understand, which is exactly why
+          we ask for the summary rather than for a promise.
+
+          Edit the description and this check runs again automatically.
+          EOF
+            exit 1
+          fi
+          echo "Description looks hand-written. Thanks!"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -128,3 +128,9 @@ chore: update dependencies
 4. **Code Review:** Respond promptly to maintainers’ feedback.
 
 Significant changes should ideally be discussed in an issue or discussion thread beforehand.
+
+### Coding Agents
+
+Use whatever tools you work best with, including coding agents. We ask one thing in return: write the pull request description yourself, in your own words, following the [template](.github/pull_request_template.md).
+
+Every pull request spends a maintainer's attention, and a description you wrote is the cheapest way to show that attention is warranted. You can't summarize what you don't understand, which is why we ask for the summary rather than for a promise. A CI check looks for leftover generated footers and asks you to replace them.

--- a/tools/hooks/pr-description
+++ b/tools/hooks/pr-description
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+# Local half of the PR description policy, matching .github/workflows/pr-description.yml.
+# A git hook cannot cover this: `gh pr create` talks to the API and never writes
+# a commit, so this runs as a Claude Code PreToolUse hook. Tool call on stdin,
+# exit 2 rejects it.
+
+payload=$(cat)
+command=$(printf '%s' "$payload" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("tool_input",{}).get("command",""))' 2>/dev/null)
+
+case "$command" in
+  *"gh pr create"*|*"gh pr edit"*) ;;
+  *) exit 0 ;;
+esac
+
+# keep in sync with the workflow
+agents='Claude|Codex|Copilot|Cursor|Devin|Aider|Gemini|Windsurf|Cline|OpenHands|Jules\[bot\]'
+pattern="(Generated (with|by)[[:space:]]*\[?(${agents})|🤖 Generated (with|by)|Co-authored-by:.*(${agents}))"
+
+# the text may be inline (--title/--body) or in a file (--body-file/-F)
+text="$command"
+for file in $(printf '%s' "$command" | grep -oE '(--body-file|-F)[= ]+[^ ]+' | sed -E 's/(--body-file|-F)[= ]+//'); do
+  [ -f "$file" ] && text="$text
+$(cat "$file")"
+done
+
+if printf '%s' "$text" | grep -qiE "$pattern"; then
+  cat >&2 <<'EOF'
+Drop the generated-with footer before opening this PR.
+
+The description belongs to whoever puts their name on the change: one
+sentence on why it exists, then the bullets from
+.github/pull_request_template.md. Write it as a summary a reviewer can
+check the diff against, and leave the attribution off.
+
+The PR Description workflow enforces the same policy on GitHub, and
+tools/hooks/commit-msg covers commit trailers.
+EOF
+  exit 2
+fi
+
+exit 0


### PR DESCRIPTION
This adds a hook on pull requests to reject PRs with descriptions that are authored by agents. 

This prevents drive-bys or automated PRs from agents in its weakest form, without human intervention. The goal is to steer developers towards reading and reviewing their code before creating a pull reqeust.