### PR TITLE
Bug: Assorted Fixes From Types Sweep

### DIFF
--- a/docs/src/pages/docs/api/component/web-component-base.mdx
+++ b/docs/src/pages/docs/api/component/web-component-base.mdx
@@ -321,7 +321,7 @@ const buttons = this.$('button');
 $$(selector)
 ```
 
-Queries the original DOM content.
+Queries the component's rendered DOM, descending into nested components' shadow roots. Use `$` to stay inside your own component and `$$` to reach an element inside one you render.
 
 #### Parameters
 
@@ -336,7 +336,7 @@ Query result set.
 #### Example
 
 ```javascript
-const content = this.$$('.content');
+const buried = el.$$('.inside-a-child-component');
 ```
 
 ### call

--- a/docs/src/pages/docs/api/component/web-component-base.mdx
+++ b/docs/src/pages/docs/api/component/web-component-base.mdx
@@ -5,7 +5,7 @@ title: Web Component Base
 icon: box
 description: API reference for the WebComponentBase class in Semantic UI Component system
 package: "@semantic-ui/component"
-methods: ["getProperties", "getPropertySettings", "addRenderCallback", "setDefaultSettings", "getSettingsFromConfig", "createSettingsProxy", "getUIClasses", "getContent", "isDarkMode", "$", "$$", "call"]
+methods: ["getProperties", "getPropertySettings", "addRenderCallback", "setDefaultSettings", "getSettingsFromConfig", "createSettingsProxy", "getUIClasses", "isDarkMode", "$", "$$", "call"]
 ---
 
 `WebComponentBase` is the base web component class used to create web components with `defineComponent`. It handles internal utilities related to component lifecycle and other internals of the framework.
@@ -20,10 +20,10 @@ import { WebComponentBase } from '@semantic-ui/component';
 
 ## Static Properties
 
-| Name                | Type   | Description                                          |
-|---------------------|--------|------------------------------------------------------|
-| shadowRootOptions   | Object | Options for the shadow root, including delegatesFocus |
-| scopedStyleSheet    | CSSStyleSheet | Scoped stylesheet for use with light DOM rendering |
+| Name              | Type    | Description                                                     |
+|-------------------|---------|-----------------------------------------------------------------|
+| delegatesFocus    | boolean | Passed to `attachShadow` when the element creates its shadow root |
+| shadowRootOptions | Object  | Shadow root options. `lit` engine only                            |
 
 ## Instance Properties
 
@@ -111,7 +111,7 @@ const propConfig = WebComponentBase.getPropertySettings(
 addRenderCallback(callback)
 ```
 
-Adds a callback to be executed after rendering.
+Adds a callback to be executed after rendering. Only available on the `lit` engine — the native engine, which is the default, does not implement it.
 
 #### Parameters
 
@@ -238,32 +238,6 @@ const classes = this.getUIClasses({
 });
 ```
 
-### getContent
-
-```javascript
-getContent({componentSpec})
-```
-
-Retrieves slotted content from a component.
-
-#### Parameters
-
-| Name          | Type   | Description                    |
-|---------------|--------|--------------------------------|
-| componentSpec | Object | Component specification object |
-
-#### Returns
-
-An object containing slotted content.
-
-#### Example
-
-```javascript
-const content = this.getContent({
-  componentSpec: mySpec
-});
-```
-
 ### isDarkMode
 
 ```javascript
@@ -290,7 +264,7 @@ if (this.isDarkMode()) {
 $(selector, { root } = {})
 ```
 
-Queries the component's render root.
+Queries the component's rendered DOM, scoped to the nodes this component owns. Use `$$` to descend into nested components' shadow roots.
 
 #### Parameters
 
@@ -301,9 +275,10 @@ Queries the component's render root.
 
 #### Options Object
 
-| Name | Type    | Description          |
-|------|---------|---------------------|
-| root | Element | Root to query from  |
+| Name         | Type    | Description                                     |
+|--------------|---------|-------------------------------------------------|
+| root         | Element | Root to query from                              |
+| pierceShadow | boolean | Descend into nested shadow roots                |
 
 #### Returns
 
@@ -312,7 +287,7 @@ Query result set.
 #### Example
 
 ```javascript
-const buttons = this.$('button');
+const buttons = el.$('button');
 ```
 
 ### $$(selector)

--- a/packages/component/src/engines/lit/base.js
+++ b/packages/component/src/engines/lit/base.js
@@ -1,4 +1,3 @@
-import { $ } from '@semantic-ui/query';
 import { camelToKebab, each, isFunction, isServer } from '@semantic-ui/utils';
 import { LitElement } from 'lit';
 
@@ -238,15 +237,21 @@ class LitWebComponentBase extends LitElement {
             DOM Helpers
   *******************************/
 
-  $(selector, { root = this?.renderRoot || this.shadowRoot } = {}) {
-    if (!root) {
+  // see the native base: the element's DOM API delegates to the template
+  $(...args) {
+    if (!this.template) {
       console.error('Cannot query DOM until element has rendered.');
+      return;
     }
-    return $(selector, { root });
+    return this.template.$(...args);
   }
 
-  $$(selector) {
-    return $(selector, { root: this.originalDOM.content });
+  $$(...args) {
+    if (!this.template) {
+      console.error('Cannot query DOM until element has rendered.');
+      return;
+    }
+    return this.template.$$(...args);
   }
 
   call(

--- a/packages/component/src/engines/native/base.js
+++ b/packages/component/src/engines/native/base.js
@@ -1,4 +1,3 @@
-import { $ } from '@semantic-ui/query';
 import { MARKER_VERSION } from '@semantic-ui/renderer';
 import { adoptStylesheet, isFunction, isServer, kebabToCamel } from '@semantic-ui/utils';
 
@@ -375,15 +374,28 @@ class WebComponentBase extends HTMLElementBase {
             DOM Helpers
   *******************************/
 
-  $(selector, { root = this.renderRoot || this.shadowRoot } = {}) {
-    if (!root) {
+  /*
+    el.$ and el.$$ are the consumer-facing DOM API, deliberately on the element
+    so they are discoverable without reaching through the internal el.template.
+    They delegate so external callers get the same template-range filtering an
+    author gets, rather than a raw renderRoot query that can return a sibling
+    subtemplate's nodes. The template only exists once the element upgrades, so
+    querying before that is a real mistake and says so.
+  */
+  $(...args) {
+    if (!this.template) {
       console.error('Cannot query DOM until element has rendered.');
+      return;
     }
-    return $(selector, { root });
+    return this.template.$(...args);
   }
 
-  $$(selector) {
-    return $(selector, { root: this.originalDOM.content });
+  $$(...args) {
+    if (!this.template) {
+      console.error('Cannot query DOM until element has rendered.');
+      return;
+    }
+    return this.template.$$(...args);
   }
 
   call(

--- a/packages/component/test/browser/element-dom-api.test.js
+++ b/packages/component/test/browser/element-dom-api.test.js
@@ -1,0 +1,74 @@
+import { $ } from '@semantic-ui/query';
+import { describe, expect, it, vi } from 'vitest';
+import { defineComponent } from '../../src/index.js';
+
+/*
+  el.$ / el.$$ are the DOM API for people consuming the elements this framework
+  ships, as opposed to Template.$ / Template.$$ which serve people authoring in
+  it. Both element methods delegate to the template so a consumer gets the same
+  scoping an author gets. That delegation has been lost twice in engine
+  refactors, so it is pinned here.
+*/
+
+let tagCounter = 0;
+const uniqueTag = () => `element-dom-api-${++tagCounter}`;
+
+const mount = async (config) => {
+  const tag = uniqueTag();
+  defineComponent({ tagName: tag, ...config });
+  const el = document.createElement(tag);
+  document.body.appendChild(el);
+  await $(el).onNext('rendered');
+  return el;
+};
+
+describe('element DOM API', () => {
+  describe('el.$', () => {
+    it('finds elements in the rendered tree', async () => {
+      const el = await mount({ template: '<div class="content">hello</div>' });
+      expect(el.$('.content').text()).toBe('hello');
+      el.remove();
+    });
+
+    it('does not reach into a nested component shadow root', async () => {
+      const innerTag = uniqueTag();
+      defineComponent({ tagName: innerTag, template: '<span class="buried">deep</span>' });
+      const el = await mount({ template: `<${innerTag}></${innerTag}>` });
+      await $(el.shadowRoot.querySelector(innerTag)).onNext('rendered');
+      expect(el.$('.buried').length).toBe(0);
+      el.remove();
+    });
+  });
+
+  describe('el.$$', () => {
+    it('pierces into a nested component shadow root', async () => {
+      const innerTag = uniqueTag();
+      defineComponent({ tagName: innerTag, template: '<span class="buried">deep</span>' });
+      const el = await mount({ template: `<${innerTag}></${innerTag}>` });
+      await $(el.shadowRoot.querySelector(innerTag)).onNext('rendered');
+      const found = Array.from(el.$$('.buried'));
+      expect(found.length).toBe(1);
+      expect(found[0].textContent).toBe('deep');
+      el.remove();
+    });
+  });
+
+  describe('before the element upgrades', () => {
+    it('reports that the element has not rendered rather than failing silently', async () => {
+      const tag = uniqueTag();
+      defineComponent({ tagName: tag, template: '<div class="content">hi</div>' });
+      const el = document.createElement(tag);
+      const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+      try {
+        // never appended, so no template exists yet
+        expect(el.$('.content')).toBeUndefined();
+        expect(el.$$('.content')).toBeUndefined();
+        expect(error).toHaveBeenCalledTimes(2);
+        expect(error.mock.calls[0][0]).toContain('rendered');
+      }
+      finally {
+        error.mockRestore();
+      }
+    });
+  });
+});

--- a/packages/query/types/query.d.ts
+++ b/packages/query/types/query.d.ts
@@ -381,7 +381,7 @@ export class Query {
   /**
    * Returns the index of the first element in the current set,
    * relative to its siblings (optionally filtered by a selector).
-   * @see https://next.semantic-ui.com/docs/api/query/size-and-position#index
+   * @see https://next.semantic-ui.com/docs/api/query/collections#index
    * @param siblingFilter - Optional CSS selector, predicate, element(s) or Query to filter the siblings.
    * @returns The index of the element, or -1 if not found.
    */
@@ -389,7 +389,7 @@ export class Query {
 
   /**
    * Find the index of the first element matching the filter within current Query set.
-   * @see https://next.semantic-ui.com/docs/api/query/size-and-position#index
+   * @see https://next.semantic-ui.com/docs/api/query/collections#index
    * @param filter - Optional CSS selector, predicate, element(s) or Query to identify element within selection.
    * @returns The index of the element, or -1 if not found.
    */
@@ -917,28 +917,28 @@ export class Query {
 
   /**
    * Returns the first element in the current set.
-   * @see https://next.semantic-ui.com/docs/api/query/utilities#el
+   * @see https://next.semantic-ui.com/docs/api/query/dom-access#el
    * @returns The first element, or `undefined` if the set is empty.
    */
   el(): Element | undefined;
 
   /**
    * Gets the element at the specified index.
-   * @see https://next.semantic-ui.com/docs/api/query/utilities#get
+   * @see https://next.semantic-ui.com/docs/api/query/dom-access#get
    * @param index - The index of the element to retrieve.
    * @returns The element at the specified index, or `undefined` when the index is out of range.
    */
   get(index: number): Element | undefined;
   /**
    * Gets every element in the current set.
-   * @see https://next.semantic-ui.com/docs/api/query/utilities#get
+   * @see https://next.semantic-ui.com/docs/api/query/dom-access#get
    * @returns An array of all elements.
    */
   get(): Element[];
 
   /**
    * Gets a new Query instance containing the element at the specified index.
-   * @see https://next.semantic-ui.com/docs/api/query/utilities#eq
+   * @see https://next.semantic-ui.com/docs/api/query/collections#eq
    * @param index - The index of the element.
    * @returns A new Query instance containing the element at the specified index.
    */
@@ -946,21 +946,21 @@ export class Query {
 
   /**
    * Gets a new Query instance containing the first element in the current set.
-   * @see https://next.semantic-ui.com/docs/api/query/utilities#first
+   * @see https://next.semantic-ui.com/docs/api/query/collections#first
    * @returns A new Query instance containing the first element.
    */
   first(): Query;
 
   /**
    * Gets a new Query instance containing the last element in the current set.
-   * @see https://next.semantic-ui.com/docs/api/query/utilities#last
+   * @see https://next.semantic-ui.com/docs/api/query/collections#last
    * @returns A new Query instance containing the last element.
    */
   last(): Query;
 
   /**
    * Sets a property on each element in the current set.
-   * @see https://next.semantic-ui.com/docs/api/query/utilities#prop
+   * @see https://next.semantic-ui.com/docs/api/query/dom-access#prop
    * @param name - The name of the property.
    * @param value - The value to set.
    * @returns The Query instance for chaining.
@@ -968,7 +968,7 @@ export class Query {
   prop(name: string, value: any): this;
   /**
    * Get a property of the first element in the set.
-   * @see https://next.semantic-ui.com/docs/api/query/utilities#prop
+   * @see https://next.semantic-ui.com/docs/api/query/dom-access#prop
    * @param name Name of the property to get.
    * @returns The property of the *first* element, or an array of values when the set holds more than one element.
    */
@@ -1101,7 +1101,7 @@ export class Query {
 
   /**
    * Creates a new Query collection combining the current elements with elements from the provided selector.
-   * @see https://next.semantic-ui.com/docs/api/query/utilities#add
+   * @see https://next.semantic-ui.com/docs/api/query/collections#add
    * @param selector - The selector, elements, or Query instance to add to the current collection.
    * @returns A new Query instance containing the combined elements with duplicates removed.
    */
@@ -1257,7 +1257,7 @@ export class Query {
 
   /**
    * Gets the number of elements in the current set.  Alias for `length`.
-   * @see https://next.semantic-ui.com/docs/api/query/size-and-position#count
+   * @see https://next.semantic-ui.com/docs/api/query/collections#count
    * @returns The number of elements.
    */
   count(): number;
@@ -1321,7 +1321,7 @@ export class Query {
 
   /**
    * Gets or sets data attributes on elements in the current set.
-   * @see https://next.semantic-ui.com/docs/api/query/data#data
+   * @see https://next.semantic-ui.com/docs/api/query/attributes#data
    * @param key - The data attribute key.
    * @param value - The value to set.
    * @returns If setting, the Query instance for chaining. If getting, the value(s).
@@ -1636,7 +1636,7 @@ export class Query {
 
   /**
    * Gets elements assigned to a named slot in a shadow DOM component.
-   * @see https://next.semantic-ui.com/docs/api/query/shadow-dom#getslot
+   * @see https://next.semantic-ui.com/docs/api/query/content#getslot
    * @param name - The slot name. If omitted, gets the default slot.
    * @returns The combined HTML content of the elements assigned to the slot.
    */
@@ -1644,7 +1644,7 @@ export class Query {
 
   /**
    * Sets content into a named slot.
-   * @see https://next.semantic-ui.com/docs/api/query/shadow-dom#setslot
+   * @see https://next.semantic-ui.com/docs/api/query/content#setslot
    * @param nameOrHTML - Slot name (when newHTML provided) or HTML string (for default slot).
    * @param newHTML - HTML content to set into the named slot.
    * @returns The Query instance for chaining.
@@ -1653,7 +1653,7 @@ export class Query {
 
   /**
    * Checks if a container element contains a target element, piercing shadow DOM boundaries.
-   * @see https://next.semantic-ui.com/docs/api/query/shadow-dom#containsdeep
+   * @see https://next.semantic-ui.com/docs/api/query/dom-traversal#contains
    * @param container - The potential container element.
    * @param target - The element to check for containment.
    * @returns `true` if container contains target (crossing shadow boundaries), `false` otherwise.

--- a/packages/reactivity/types/resource.d.ts
+++ b/packages/reactivity/types/resource.d.ts
@@ -49,7 +49,7 @@ export interface ResourceOptions<T> extends SignalOptions<T> {
  * and the rest of the Signal surface apply.
  * @see {@link https://next.semantic-ui.com/docs/api/reactivity/resource Resource Documentation}
  */
-export class Resource<T> extends Signal<T> {
+export class Resource<T> extends Signal<T | undefined> {
   /**
    * Creates a Resource backed by a fetcher. The fetcher runs immediately as an
    * async reaction and receives the backing Reaction as its argument. A promise

--- a/packages/specs/src/docs-spec-reader.js
+++ b/packages/specs/src/docs-spec-reader.js
@@ -620,37 +620,31 @@ export class DocsSpecReader extends SpecReader {
     joinWith = '=',
     quoteCharacter = `'`,
   } = {}) {
-    let attributeString;
-    let modifiers = [];
-    let categoryAttributes = clone(attributes);
-    let componentSpec = this.getWebComponentSpec();
-    each(attributes, (value, key) => {
-      const parentAttribute = componentSpec.optionAttributes[value];
-      if (parentAttribute) {
+    const componentSpec = this.getWebComponentSpec();
+    const modifiers = [];
+    const categoryAttributes = {};
+
+    // optionAttributes is a value → attribute lookup, so a value naming an
+    // option (`large`) is a modifier and everything else stays a pair
+    each(attributes, (value, attribute) => {
+      if (componentSpec?.optionAttributes?.[value]) {
         modifiers.push(value);
       }
       else {
-        categoryAttributes[key] = value;
+        categoryAttributes[attribute] = value;
       }
     });
-    if (modifiers.length) {
-      const modifierString = modifierAttributes.join(' ');
-      if (dialect == SpecReader.DIALECT_TYPES.standard) {
-        // <ui-button large red>
-        attributeString += ` ${modifierString}`;
-      }
-      else if (dialect == SpecReader.DIALECT_TYPES.classic) {
-        // <ui-button class="large red">
-        return ` class="${modifierString}"`;
-      }
-    }
-    else if (dialect == SpecReader.DIALECT_TYPES.verbose || keys(categoryAttributes)) {
-      let attributeString = ' ';
-      each(attributes, (value, attribute) => {
-        const singleAttr = this.getSingleAttributeString(attribute, value, { joinWith, quoteCharacter });
-        attributeString += ` ${singleAttr}`;
-      });
-    }
+
+    // modifiers route through the shared path so dialect rendering and the
+    // reserved-name collision rules stay defined in exactly one place
+    let attributeString = modifiers.length
+      ? this.getAttributeStringFromModifiers(modifiers.join(' '), { dialect, joinWith, quoteCharacter })
+      : '';
+
+    each(categoryAttributes, (value, attribute) => {
+      attributeString += ` ${this.getSingleAttributeString(attribute, value, { joinWith, quoteCharacter })}`;
+    });
+
     return attributeString;
   }
 

--- a/packages/specs/test/unit/readers.test.js
+++ b/packages/specs/test/unit/readers.test.js
@@ -1066,3 +1066,50 @@ describe('DocsSpecReader.parseAttributeString', () => {
     });
   });
 });
+
+/* ==================================================================
+   DocsSpecReader — getAttributeString
+   ================================================================== */
+
+describe('DocsSpecReader.getAttributeString', () => {
+  const reader = (dialect) => new DocsSpecReader(minimalButtonSpec(), { dialect });
+
+  it('renders option values as bare modifiers in the standard dialect', () => {
+    const result = reader('standard').getAttributeString({ emphasis: 'primary' });
+    expect(result).toBe(' primary');
+  });
+
+  it('collects option values into a class list in the classic dialect', () => {
+    const result = reader('classic').getAttributeString({ emphasis: 'primary' });
+    expect(result).toBe(' class="primary"');
+  });
+
+  it('names the parent attribute in the verbose dialect', () => {
+    // quoteCharacter defaults to ' here, while getAttributeStringFromModifiers defaults to "
+    const result = reader('verbose').getAttributeString({ emphasis: 'primary' });
+    expect(result.trim()).toBe(`emphasis='primary'`);
+  });
+
+  it('honors an explicit quote character', () => {
+    const result = reader('verbose').getAttributeString({ emphasis: 'primary' }, { quoteCharacter: '"' });
+    expect(result.trim()).toBe(`emphasis="primary"`);
+  });
+
+  it('keeps values that are not options as ordinary attribute pairs', () => {
+    const result = reader('standard').getAttributeString({ icon: 'search' });
+    expect(result).toBe(` icon='search'`);
+  });
+
+  it('renders modifiers and plain attributes together', () => {
+    const result = reader('standard').getAttributeString({ emphasis: 'primary', icon: 'search' });
+    expect(result).toBe(` primary icon='search'`);
+  });
+
+  it('collapses a boolean attribute to its name', () => {
+    expect(reader('standard').getAttributeString({ disabled: true })).toBe(' disabled');
+  });
+
+  it('returns an empty string when there is nothing to render', () => {
+    expect(reader('standard').getAttributeString({})).toBe('');
+  });
+});

--- a/packages/templating/src/template.js
+++ b/packages/templating/src/template.js
@@ -989,7 +989,7 @@ export const Template = class Template {
   // 4th arg matches the native addEventListener shape (passive/capture/once/...);
   // querySettings is the only namespaced key.
   attachEvent(selector, eventName, eventHandler, { querySettings = { pierceShadow: true }, ...eventSettings } = {}) {
-    return $(selector, document, querySettings).on(eventName, eventHandler, {
+    return $(selector, { root: document, ...querySettings }).on(eventName, eventHandler, {
       abortController: this.abortController,
       returnHandler: true,
       eventSettings,

--- a/packages/templating/test/browser/events.test.js
+++ b/packages/templating/test/browser/events.test.js
@@ -774,6 +774,44 @@ RENDER_TARGETS.forEach(({ name, target }) => {
         externalTarget.remove();
       });
 
+      it('passes options to query rather than leaking them onto the global document', async () => {
+        // `$` takes (selector, options), so passing `document` positionally put it
+        // in the options slot: query then wrote `root` onto the global Document
+        // and the caller's querySettings were dropped on the floor.
+        const handler = vi.fn();
+        const fixture = await mountTemplate({ target });
+        const externalTarget = document.createElement('div');
+        document.body.appendChild(externalTarget);
+        try {
+          fixture.template.attachEvent(externalTarget, 'click', handler);
+          expect(Object.hasOwn(document, 'root')).toBe(false);
+        }
+        finally {
+          externalTarget.remove();
+          fixture.cleanup();
+        }
+      });
+
+      it('reaches into a shadow root, since querySettings defaults to pierceShadow', async () => {
+        const handler = vi.fn();
+        const fixture = await mountTemplate({ target });
+        const host = document.createElement('div');
+        document.body.appendChild(host);
+        const shadow = host.attachShadow({ mode: 'open' });
+        const inner = document.createElement('button');
+        inner.className = 'inside-shadow';
+        shadow.appendChild(inner);
+        try {
+          fixture.template.attachEvent('.inside-shadow', 'click', handler);
+          clickOn(inner);
+          expect(handler).toHaveBeenCalledTimes(1);
+        }
+        finally {
+          host.remove();
+          fixture.cleanup();
+        }
+      });
+
       it('binds a listener attached from inside onCreated and cleans up on destroy', async () => {
         // onCreated fires before attachEvents() sets up eventController. The auto-cleanup
         // contract still has to hold — attachEvent ties to the template's lifetime

--- a/packages/templating/types/template.d.ts
+++ b/packages/templating/types/template.d.ts
@@ -3,6 +3,25 @@ import { EventHandler, Query, QueryOptions } from '@semantic-ui/query';
 import { Matcher, Reaction, Signal, SignalOptions } from '@semantic-ui/reactivity';
 import { TemplateHelpers } from './template-helpers.js';
 
+/**
+ * The value a declared property holds, derived from its `type` constructor.
+ * `properties` is authored as definitions (`{ count: { type: Number } }`) but
+ * reaches a component as coerced values, so settings report `number` rather
+ * than the definition object.
+ */
+export type PropertyValue<TDefinition> = TDefinition extends { type: NumberConstructor; } ? number
+  : TDefinition extends { type: StringConstructor; } ? string
+  : TDefinition extends { type: BooleanConstructor; } ? boolean
+  : TDefinition extends { type: ArrayConstructor; } ? any[]
+  : TDefinition extends { type: ObjectConstructor; } ? Record<string, any>
+  : TDefinition extends { type: FunctionConstructor; } ? (...args: any[]) => any
+  : any;
+
+/** Maps a `properties` definition object onto the values a component receives. */
+export type PropertyValues<TProperties> = {
+  [Key in keyof TProperties]: PropertyValue<TProperties[Key]>;
+};
+
 /** Anything the `$` and `$$` helpers accept as a starting point for a query. */
 export type QuerySelector =
   | string
@@ -352,7 +371,7 @@ export interface CallParams<
    *
    * @see https://next.semantic-ui.com/docs/guides/components/settings
    */
-  settings: TSettings & TProperties;
+  settings: TSettings & PropertyValues<TProperties>;
 
   /**
    * Reactive state variables for the component.


### PR DESCRIPTION
Grab bag of changes from looking around code.

## Changes
- Fix `attachEvent` passing wrong args
- Fix `el.$` and `el.$$` to use template query instance
- Fix `getAttributeString` in Specs
- Various type fixes

## Risk
2/10  - `attachEvents`  is the only one that could cause issues.

## How to Test
- New tests in `packages/component/test/browser/element-dom-api.test.js` i
- `attachEvent` tests in `packages/templating/test/browser/events.test.js` 
