### PR TITLE
Bug: Fix Expression Unwrapping in Degenerate Cases

### DIFF
--- a/ai/skills/contributing/extend-bench-suite.md
+++ b/ai/skills/contributing/extend-bench-suite.md
@@ -39,6 +39,8 @@ A CI-gated bench is three files working together:
 
 The `build-ci.js` script bundles the bench JS files with esbuild into `dist/current/` and `dist/baseline/` (baseline uses the PR's base-branch `packages/*/src/`). The CI workflow at `.github/workflows/benchmarks.yml` spawns one parallel matrix cell per `tachometer-ci*.json` config discovered in changed packages.
 
+**A metric you add in a PR does not run on that PR.** The workflow checks out `packages/*/bench/` from `origin/main` for both sides, so bench code, tachometer configs, and `build-ci.js` always come from main and the PR contributes only `packages/*/src/`. That's what stops a PR from tuning the benchmark it's being judged by. A new metric starts measuring once it lands on main, which makes the local floor read below the only signal you get before merging.
+
 ---
 
 ## The Authoring Pattern
@@ -353,15 +355,20 @@ node build-ci.js baseline             # same source both sides → zero delta
 npx tachometer --config tachometer-ci-<suite>.json
 ```
 
-`tachometer --config <file>` honors every knob in the JSON. Override at the CLI when iterating:
+`tachometer --config <file>` takes every knob from the JSON and rejects the CLI flags that would contradict it. `--root`, `--browser`, `--sample-size`, `--timeout`, `--auto-sample-conditions`, `--measure`, `--resolve-bare-modules`, and `--window-size` each throw `cannot be specified when using --config`. Change the value in a scratch copy of the JSON instead:
 
-| CLI flag | Config key | Use locally for |
-|---|---|---|
-| `--sample-size=N` / `-n N` | `sampleSize` | Quicker passes during iteration. Drop below 30 only for a smoke test, never for committed numbers |
-| `--timeout=M` | `timeout` (minutes) | Cap wall-clock per config |
-| `--auto-sample-conditions=0%` | `autoSampleConditions` | Zero-delta dry runs converge fastest with `0%` |
-| `--json-file=out.json` | — | Save raw output for offline inspection |
-| `--csv-file=stats.csv` | — | Per-metric summary table |
+| Config key | Use locally for |
+|---|---|
+| `sampleSize` | Quicker passes during iteration. Drop below 30 only for a smoke test, never for committed numbers |
+| `timeout` | Cap wall-clock per config, in minutes |
+| `autoSampleConditions` | `["0%"]` for a zero-delta dry run |
+
+Two output flags do compose with `--config`:
+
+| CLI flag | Use locally for |
+|---|---|
+| `--json-file=out.json` | Save raw output for offline inspection |
+| `--csv-file=stats.csv` | Per-metric summary table |
 
 ### Reading the zero-delta output
 
@@ -378,12 +385,13 @@ The headline number to record is **CI half-width as a percentage of the mean**. 
 For a fast read on whether a single new metric is shaped right (without sampling the whole suite):
 
 ```sh
-# temporary tachometer-noise-floor.json that lists ONLY the new metrics
-# in both this-change and tip-of-tree arrays; don't commit it
-npx tachometer --config tachometer-noise-floor.json --auto-sample-conditions=0% --timeout=2
+# temporary tachometer-noise-floor.json listing ONLY the new metrics in both
+# this-change and tip-of-tree arrays, with "autoSampleConditions": ["0%"] and
+# "timeout": 2 set inside it. don't commit it
+npx tachometer --config tachometer-noise-floor.json
 ```
 
-This converges in under two minutes on a typical metric and reads the floor without re-running everything in the suite. Delete the temporary config before pushing.
+Two minutes gets a usable floor on a typical metric without re-running the suite. `["0%"]` asks for a resolution no run can reach, so this always ends on `Hit 2 minute auto-sample timeout` — that line is the loop working as intended, not a failure. Read the CI half-width it printed and ignore the note. Delete the temporary config before pushing.
 
 ### Environment gotchas
 

--- a/ai/skills/contributing/testing-internals.md
+++ b/ai/skills/contributing/testing-internals.md
@@ -34,7 +34,8 @@ tests/configs/vitest/
 ├── projects/                    # Composable environment definitions
 │   ├── node.js                  # test/unit/ + test/*.test — pure Node
 │   ├── jsdom.js                 # test/dom/ — simulated DOM (no Shadow DOM)
-│   └── browser.js               # test/browser/ — real Chromium via Playwright
+│   ├── browser.js               # test/browser/ — real Chromium via Playwright
+│   └── exclude.js               # shared exclusions, spread by all three
 ├── vitest.config.js             # npm test (watch: false)
 ├── vitest-watch.config.js       # npm run test:watch
 ├── vitest-all.config.js         # npm run test:all (HTML reporter + coverage UI)
@@ -98,6 +99,8 @@ This must be in configs (not setup files) because it operates at the Vitest leve
 **Setup files:** `tests/setup/{node,dom,browser}-setup.js` exist as empty stubs referenced by project files. Add setup logic there when needed.
 
 **Coverage provider:** Istanbul (not v8). Coverage includes only `packages/**/src/**/*.js`.
+
+**Shared exclusions:** every project spreads `exclude` from `projects/exclude.js`, which carries Vitest's `configDefaults.exclude` plus `.claude/**` and `docs/**`. The `.claude/**` entry is load-bearing: agent worktrees live at `.claude/worktrees/<name>` as whole repo checkouts, and Vitest does not read `.gitignore`, so an include glob like `**/test/unit/**` otherwise collects the entire suite a second time from whatever branch is checked out there. Package configs need no equivalent — their root is the package directory, out of reach of the repo-root `.claude/`.
 
 ---
 

--- a/ai/skills/contributing/testing.md
+++ b/ai/skills/contributing/testing.md
@@ -162,7 +162,7 @@ npx vitest --c tests/configs/vitest/vitest.config.js --run --project node equali
 
 ### Wall-clock budget and stuck-process cleanup
 
-The full repo suite (`npm test` from root, ~3600 tests across 82 files) finishes in **~28s**.
+The full repo suite (`npm test` from root, ~5100 tests across 135 files) finishes in **~31s**.
 A **60-second timeout is plenty**; anything longer means something's stuck — almost always
 a leftover Vitest watcher (or its Playwright/Chromium spawns) holding ports from a previous
 session. A single package's browser suite should finish in well under 15s; if it doesn't,

--- a/docs/src/examples/templates/expressions-kitchen-sink/component.html
+++ b/docs/src/examples/templates/expressions-kitchen-sink/component.html
@@ -40,6 +40,18 @@
       <td>1</td>
     </tr>
     <tr>
+      <td>Path reaching through a function</td>
+      <td>pet.name</td>
+      <td>{pet.name}</td>
+      <td>Simon</td>
+    </tr>
+    <tr>
+      <td>Method keeps its own object as this</td>
+      <td>pet.describe</td>
+      <td>{pet.describe}</td>
+      <td>Simon has 3 treats</td>
+    </tr>
+    <tr>
       <td>Inline arithmetic</td>
       <td>value + 2 * 5</td>
       <td>{value + 2 * 5}</td>

--- a/docs/src/examples/templates/expressions-kitchen-sink/component.js
+++ b/docs/src/examples/templates/expressions-kitchen-sink/component.js
@@ -23,6 +23,13 @@ const createComponent = ({ settings, self, interval }) => ({
   getValue(obj = {}, prop) {
     return obj[prop];
   },
+  pet: () => ({
+    name: 'Simon',
+    treats: 3,
+    describe() {
+      return `${this.name} has ${this.treats} treats`;
+    },
+  }),
 });
 
 export const TestComponent = defineComponent({

--- a/packages/renderer/bench/tachometer/bench-renderer-micros.js
+++ b/packages/renderer/bench/tachometer/bench-renderer-micros.js
@@ -153,6 +153,29 @@ const data = {
   });
 }
 
+// expr-dotted-method-25k — dotted path landing on a method, reached through
+// a computed accessor. Only this shape walks for a receiver and binds, and
+// only here can a path accessor be invoked more than once per expression.
+// The plain field alongside it holds the same walk without the bind.
+{
+  const board = {
+    id: 'main',
+    count: 2,
+    cheerCount() {
+      return this.count;
+    },
+  };
+  const boardData = { ...data, board: () => board };
+  const evaluator = new ExpressionEvaluator({ data: boardData, helpers });
+  // purpose: Evaluates a dotted method and a dotted field through an accessor 100000 times each. Receiver walk and bind.
+  await measureOp('expr-dotted-method-100k', () => {
+    for (let i = 0; i < 100_000; i++) {
+      evaluator.evaluate('board.cheerCount', boardData);
+      evaluator.evaluate('board.id', boardData);
+    }
+  });
+}
+
 /*******************************
       buildHTMLString throughput
 *******************************/

--- a/packages/renderer/bench/tachometer/bench-renderer-micros.js
+++ b/packages/renderer/bench/tachometer/bench-renderer-micros.js
@@ -153,7 +153,7 @@ const data = {
   });
 }
 
-// expr-dotted-method-25k — dotted path landing on a method, reached through
+// expr-dotted-method-100k — dotted path landing on a method, reached through
 // a computed accessor. Only this shape walks for a receiver and binds, and
 // only here can a path accessor be invoked more than once per expression.
 // The plain field alongside it holds the same walk without the bind.

--- a/packages/renderer/bench/tachometer/tachometer-ci-renderer-micros.json
+++ b/packages/renderer/bench/tachometer/tachometer-ci-renderer-micros.json
@@ -13,6 +13,7 @@
         { "mode": "performance", "entryName": "expr-simple-100k" },
         { "mode": "performance", "entryName": "expr-lisp-50k" },
         { "mode": "performance", "entryName": "expr-js-10k" },
+        { "mode": "performance", "entryName": "expr-dotted-method-100k" },
         { "mode": "performance", "entryName": "build-html-string-10k" },
         { "mode": "performance", "entryName": "dom-walker-1000x15" }
       ]
@@ -25,6 +26,7 @@
         { "mode": "performance", "entryName": "expr-simple-100k" },
         { "mode": "performance", "entryName": "expr-lisp-50k" },
         { "mode": "performance", "entryName": "expr-js-10k" },
+        { "mode": "performance", "entryName": "expr-dotted-method-100k" },
         { "mode": "performance", "entryName": "build-html-string-10k" },
         { "mode": "performance", "entryName": "dom-walker-1000x15" }
       ]

--- a/packages/renderer/src/expression-evaluator.js
+++ b/packages/renderer/src/expression-evaluator.js
@@ -290,8 +290,7 @@ export class ExpressionEvaluator {
       }
     }
     else {
-      let dataValue = this.getDeepDataValue(data, token);
-      let value = this.accessTokenValue(dataValue, token, data);
+      const value = this.lookupDottedValue(data, token);
       if (value !== undefined) {
         return value;
       }
@@ -312,6 +311,23 @@ export class ExpressionEvaluator {
     if (jsValue !== undefined) {
       return this.accessTokenValue(jsValue, token, data);
     }
+  }
+
+  // one walk, so an accessor on the path runs once per expression. the last segment
+  // reads off the container to keep an {#each} item's per-field dep, and only the
+  // receiver unwraps
+  lookupDottedValue(data, token) {
+    const segments = this.getPathSegments(token);
+    const last = segments.length - 1;
+
+    let container = this.walkPath(data, segments, last);
+    if (container instanceof Signal) { container = container.get(); }
+    else if (typeof container === 'function') { container = container(); }
+    if (container == null) { return undefined; }
+
+    const value = container[segments[last]];
+    if (typeof value === 'function') { return value.bind(unwrap(container)); }
+    return (value instanceof Signal) ? value.value : value;
   }
 
   getPathSegments(path) {
@@ -335,8 +351,12 @@ export class ExpressionEvaluator {
     }
 
     const segments = this.getPathSegments(path);
+    return this.walkPath(obj, segments, segments.length);
+  }
+
+  walkPath(obj, segments, count) {
     let current = obj;
-    for (let i = 0; i < segments.length; i++) {
+    for (let i = 0; i < count; i++) {
       if (current instanceof Signal) {
         current = current.get();
       }
@@ -354,7 +374,8 @@ export class ExpressionEvaluator {
   accessTokenValue(tokenValue, token, data) {
     if (typeof tokenValue === 'function' && token.includes('.')) {
       const lastDot = token.lastIndexOf('.');
-      tokenValue = tokenValue.bind(this.getThisContext(data, token.substring(0, lastDot)));
+      const thisContext = this.getThisContext(data, token.substring(0, lastDot));
+      tokenValue = tokenValue.bind(thisContext);
     }
 
     if (tokenValue !== undefined) {

--- a/packages/renderer/src/expression-evaluator.js
+++ b/packages/renderer/src/expression-evaluator.js
@@ -354,8 +354,7 @@ export class ExpressionEvaluator {
   accessTokenValue(tokenValue, token, data) {
     if (typeof tokenValue === 'function' && token.includes('.')) {
       const lastDot = token.lastIndexOf('.');
-      const thisContext = this.getDeepDataValue(data, token.substring(0, lastDot));
-      tokenValue = tokenValue.bind(thisContext);
+      tokenValue = tokenValue.bind(this.getThisContext(data, token.substring(0, lastDot)));
     }
 
     if (tokenValue !== undefined) {
@@ -364,6 +363,15 @@ export class ExpressionEvaluator {
         : tokenValue;
     }
     return undefined;
+  }
+
+  // getDeepDataValue unwraps what it walks through but not what it lands on, and an
+  // {#each x in xs} as-key lands on the item proxy. neither is the receiver
+  getThisContext(data, path) {
+    let parent = this.getDeepDataValue(data, path);
+    if (parent instanceof Signal) { parent = parent.value; }
+    else if (typeof parent === 'function') { parent = parent(); }
+    return unwrap(parent);
   }
 
   addParensToExpression(expression = '') {

--- a/packages/renderer/test/browser/method-receiver.test.js
+++ b/packages/renderer/test/browser/method-receiver.test.js
@@ -1,0 +1,133 @@
+import { defineComponent } from '@semantic-ui/component';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+/*
+  What `this` is when a template calls a method on a model. Templates reach a
+  model two ways — through a zero-arg accessor returned by createComponent, or
+  as an {#each} item — and in both the method is bound to whatever the parent
+  path resolved to. When that is a container (the accessor itself, a Signal) or
+  the each block's item proxy, the method still runs and still returns a
+  plausible value, so a wrong receiver reads as real data on the screen.
+*/
+
+const cheers = [
+  { boardId: 'main' },
+  { boardId: 'main' },
+  { boardId: 'archive' },
+];
+
+const boardFor = (id) => ({
+  id,
+  closedAt: (id === 'archive') ? new Date() : null,
+  cheerCount() {
+    return cheers.filter((cheer) => cheer.boardId === this.id).length;
+  },
+  isClosed() {
+    return this.closedAt != null;
+  },
+});
+
+// a model that keeps its collection private — the shape any class-based model
+// takes. the receiver has to be the instance itself, not a stand-in that
+// forwards property reads
+class PrivateBoard {
+  #cheers;
+
+  constructor(id, all) {
+    this.id = id;
+    this.#cheers = all.filter((cheer) => cheer.boardId === id);
+  }
+
+  cheerCount() {
+    return this.#cheers.length;
+  }
+}
+
+const textOf = (root, selector) => Array.from(root.querySelectorAll(selector)).map((node) => node.textContent);
+
+const mount = async (tagName) => {
+  const element = document.createElement(tagName);
+  document.body.appendChild(element);
+  await element.rendered;
+  return element.shadowRoot;
+};
+
+describe('native — method receivers in templates', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('calls a model helper reached through a createComponent accessor', async () => {
+    const tagName = 'test-receiver-accessor';
+    defineComponent({
+      tagName,
+      template: '<b class="count">{board.cheerCount}</b><i class="closed">{archived.isClosed}</i>',
+      createComponent: () => ({
+        board: () => boardFor('main'),
+        // closedAt is a Date here, so a wrong receiver reads undefined and
+        // reports false — the assertion only discriminates on the archived board
+        archived: () => boardFor('archive'),
+      }),
+    });
+
+    const shadow = await mount(tagName);
+    expect(shadow.querySelector('.count').textContent).toBe('2');
+    expect(shadow.querySelector('.closed').textContent).toBe('true');
+  });
+
+  it('calls a model helper on an {#each ... as} item', async () => {
+    const tagName = 'test-receiver-each-as';
+    defineComponent({
+      tagName,
+      template: '<ul>{#each board in boards}<li>{board.cheerCount}</li>{/each}</ul>',
+      defaultState: {
+        boards: [boardFor('main'), boardFor('archive')],
+      },
+    });
+
+    const shadow = await mount(tagName);
+    expect(textOf(shadow, 'li')).toEqual(['2', '1']);
+  });
+
+  it('calls a model helper on a spread {#each} item through this', async () => {
+    const tagName = 'test-receiver-each-spread';
+    defineComponent({
+      tagName,
+      template: '<ul>{#each boards}<li>{this.cheerCount}</li>{/each}</ul>',
+      defaultState: {
+        boards: [boardFor('main'), boardFor('archive')],
+      },
+    });
+
+    const shadow = await mount(tagName);
+    expect(textOf(shadow, 'li')).toEqual(['2', '1']);
+  });
+
+  it('calls a built-in method on an {#each ... as} item', async () => {
+    const tagName = 'test-receiver-each-builtin';
+    defineComponent({
+      tagName,
+      template: '<ul>{#each date in dates}<li>{date.getFullYear}</li>{/each}</ul>',
+      defaultState: {
+        dates: [new Date('2024-03-01T12:00:00Z'), new Date('2026-07-29T12:00:00Z')],
+      },
+    });
+
+    const shadow = await mount(tagName);
+    expect(textOf(shadow, 'li')).toEqual(['2024', '2026']);
+  });
+
+  it('calls a helper that reads a private field on an {#each ... as} item', async () => {
+    const tagName = 'test-receiver-each-private';
+    defineComponent({
+      tagName,
+      template: '<ul>{#each board in boards}<li>{board.cheerCount}</li>{/each}</ul>',
+      defaultState: {
+        boards: [new PrivateBoard('main', cheers), new PrivateBoard('archive', cheers)],
+      },
+    });
+
+    const shadow = await mount(tagName);
+    expect(textOf(shadow, 'li')).toEqual(['2', '1']);
+  });
+});

--- a/packages/renderer/test/browser/subtree-spurious.test.js
+++ b/packages/renderer/test/browser/subtree-spurious.test.js
@@ -98,6 +98,82 @@ RENDERING_ENGINES.forEach(engine => {
     });
 
     /*******************************
+         Accessor call counts
+    *******************************/
+
+    describe('accessor invoked once per expression', () => {
+      // an accessor is user code and can log, fetch, or mutate. calling it twice for
+      // one expression reads as a spurious render and sends people hunting for one
+      const board = {
+        id: 'main',
+        title: 'Main',
+        cheerCount() {
+          return this.id === 'main' ? 2 : 0;
+        },
+        isClosed() {
+          return this.id === 'archive';
+        },
+      };
+
+      function spanText(el) {
+        return Array.from(el.shadowRoot.querySelectorAll('span')).map((node) => node.textContent);
+      }
+
+      it('calls an accessor once per expression, not once more per method read', async () => {
+        let calls = 0;
+        const tag = uniqueTag();
+        defineComponent({
+          tagName: tag,
+          renderingEngine: engine,
+          template: [
+            '<span>{board.cheerCount}</span>',
+            '<span>{board.isClosed}</span>',
+            '<span>{board.id}</span>',
+            '<span>{board.title}</span>',
+          ].join(''),
+          createComponent: () => ({
+            board: () => {
+              calls++;
+              return board;
+            },
+          }),
+        });
+        const el = document.createElement(tag);
+        const rendered = $(el).onNext('rendered');
+        document.body.appendChild(el);
+        await rendered;
+
+        expect(spanText(el)).toEqual(['2', 'false', 'main', 'Main']);
+        expect(calls).toBe(4);
+      });
+
+      it('calls an accessor sitting mid path once per expression', async () => {
+        let calls = 0;
+        const tag = uniqueTag();
+        defineComponent({
+          tagName: tag,
+          renderingEngine: engine,
+          template: '<span>{outer.board.cheerCount}</span><span>{outer.board.id}</span>',
+          createComponent: () => ({
+            outer: {
+              board: () => {
+                calls++;
+                return board;
+              },
+            },
+          }),
+        });
+        const el = document.createElement(tag);
+        const rendered = $(el).onNext('rendered');
+        document.body.appendChild(el);
+        await rendered;
+
+        expect(spanText(el)).toEqual(['2', 'main']);
+        expect(calls).toBe(2);
+      });
+    });
+
+    /*******************************
         Outside vs inside each
     *******************************/
 

--- a/packages/renderer/test/unit/expression-evaluator.test.js
+++ b/packages/renderer/test/unit/expression-evaluator.test.js
@@ -425,6 +425,53 @@ describe('accessTokenValue', () => {
     // Should be bound — calling it returns the parent's value
     expect(result()).toBe('hi');
   });
+
+  it('binds dotted method whose parent is an accessor', () => {
+    const row = {
+      greeting: 'hi',
+      greet() {
+        return this.greeting;
+      },
+    };
+    const result = ee.accessTokenValue(row.greet, 'parent.greet', { parent: () => row });
+    expect(result()).toBe('hi');
+  });
+});
+
+/*******************************
+   Helpers Behind An Accessor
+*******************************/
+
+describe('helper methods reached through a parent accessor', () => {
+  // a collection row reaches the data context behind a zero-arg accessor, and its
+  // helpers read `this`. bound to the accessor instead of the row they still return a
+  // plausible value rather than throwing — a count of zero, a flag of false — so a
+  // wrong `this` reads as real data all the way to the screen
+  const cheers = [{ boardId: 'main' }, { boardId: 'main' }];
+  const row = {
+    id: 'main',
+    closedAt: new Date(),
+    cheerCount() {
+      return cheers.filter((cheer) => cheer.boardId === this.id).length;
+    },
+    isClosed() {
+      return this.closedAt != null;
+    },
+  };
+  const boardData = { board: () => row };
+  const ee = make({ data: boardData });
+
+  it('counts through the accessor instead of reporting zero', () => {
+    expect(ee.evaluate('board.cheerCount', boardData)).toBe(2);
+  });
+
+  it('reads a flag through the accessor instead of reporting false', () => {
+    expect(ee.evaluate('board.isClosed', boardData)).toBe(true);
+  });
+
+  it('resolves a plain field through the same accessor', () => {
+    expect(ee.evaluate('board.id', boardData)).toBe('main');
+  });
 });
 
 /*******************************

--- a/packages/renderer/test/unit/expression-evaluator.test.js
+++ b/packages/renderer/test/unit/expression-evaluator.test.js
@@ -475,6 +475,59 @@ describe('helper methods reached through a parent accessor', () => {
 });
 
 /*******************************
+     Parent Path Depth
+*******************************/
+
+describe('binding a method whose parent path ends in a container', () => {
+  // the walk already unwraps a container it passes through, so a shallow fix can look
+  // complete. the gap is the last segment of the parent path: wherever a container sits
+  // there, `this` lands on the wrapper instead of the row, at any depth
+  const ee = make();
+  const model = {
+    greeting: 'hi',
+    greet() {
+      return this.greeting;
+    },
+  };
+
+  it('depth 1: accessor at the parent', () => {
+    expect(ee.evaluate('row.greet', { row: () => model })).toBe('hi');
+  });
+
+  it('depth 1: signal at the parent', () => {
+    expect(ee.evaluate('row.greet', { row: new Signal(model) })).toBe('hi');
+  });
+
+  it('depth 2: accessor at the end of the parent path', () => {
+    expect(ee.evaluate('a.row.greet', { a: { row: () => model } })).toBe('hi');
+  });
+
+  it('depth 2: signal at the end of the parent path', () => {
+    expect(ee.evaluate('a.row.greet', { a: { row: new Signal(model) } })).toBe('hi');
+  });
+
+  it('depth 2: accessor passed through, plain object at the end', () => {
+    expect(ee.evaluate('a.row.greet', { a: () => ({ row: model }) })).toBe('hi');
+  });
+
+  it('depth 2: accessor at both segments', () => {
+    expect(ee.evaluate('a.row.greet', { a: () => ({ row: () => model }) })).toBe('hi');
+  });
+
+  it('depth 3: accessor at the end of the parent path', () => {
+    expect(ee.evaluate('a.b.row.greet', { a: { b: { row: () => model } } })).toBe('hi');
+  });
+
+  it('depth 3: signal at the end of the parent path', () => {
+    expect(ee.evaluate('a.b.row.greet', { a: { b: { row: new Signal(model) } } })).toBe('hi');
+  });
+
+  it('depth 3: plain fields resolve through the same deep accessor', () => {
+    expect(ee.evaluate('a.b.row.greeting', { a: { b: { row: () => model } } })).toBe('hi');
+  });
+});
+
+/*******************************
     lookupExpressionValue
 *******************************/
 

--- a/tests/configs/vitest/projects/browser.js
+++ b/tests/configs/vitest/projects/browser.js
@@ -1,10 +1,10 @@
 import { playwright } from '@vitest/browser-playwright';
-import { configDefaults } from 'vitest/config';
+import { exclude } from './exclude.js';
 
 export default {
   test: {
     include: ['**/test/browser/**/*.test.{ts,js}'],
-    exclude: [...configDefaults.exclude, 'docs/**', 'tools/cdn/**'],
+    exclude: [...exclude, 'tools/cdn/**'],
     name: 'browser',
     testTimeout: 30000,
     fileParallelism: false,

--- a/tests/configs/vitest/projects/exclude.js
+++ b/tests/configs/vitest/projects/exclude.js
@@ -1,0 +1,9 @@
+import { configDefaults } from 'vitest/config';
+
+export const exclude = [
+  ...configDefaults.exclude,
+  // agent worktrees are whole repo checkouts so every suite would collect twice
+  // gitignored, but vitest doesnt read gitignore
+  '**/.claude/**',
+  'docs/**',
+];

--- a/tests/configs/vitest/projects/jsdom.js
+++ b/tests/configs/vitest/projects/jsdom.js
@@ -1,7 +1,9 @@
+import { exclude } from './exclude.js';
+
 export default {
   test: {
     include: ['**/test/dom/**/*.test.{ts,js}'],
-    exclude: ['**/node_modules/**', 'docs/**'],
+    exclude,
     name: 'jsdom',
     environment: 'jsdom',
     setupFiles: ['tests/setup/dom-setup.js'],

--- a/tests/configs/vitest/projects/node.js
+++ b/tests/configs/vitest/projects/node.js
@@ -1,10 +1,12 @@
+import { exclude } from './exclude.js';
+
 export default {
   test: {
     include: [
       '**/test/unit/**/*.test.{ts,js}',
       '**/test/*.test.{ts,js}'
     ],
-    exclude: ['**/node_modules/**', 'docs/**'],
+    exclude,
     name: 'node',
     environment: 'node',
     setupFiles: ['tests/setup/node-setup.js'],


### PR DESCRIPTION
Fixes bugs related to `this` unwrapping in expression evaluator that emerged from testing as well as deep expressions sometimes double invoking intermediate expressions.

Adds fix for worktree tests running on `npm test`

## Changes
- Fix how `this` is determined for deep expressions. 
- Add caching layer for intermediate expressions to avoid double invocation
- Fix excludes list for Vitest
- Updates some skills related to testing/bench

## Risk
5/10

Inside the deep machinery of expression evaluation, but the blast radius is just on the margins, degenerate expression cases.

## How to Test
Run renderer suite with new tests.
