### PR TITLE
Bug: Resolve Data Functions in JS-Style Expressions

### DIFF
--- a/ai/skills/contributing/author-pull-requests.md
+++ b/ai/skills/contributing/author-pull-requests.md
@@ -141,7 +141,7 @@ Same as Medium, plus:
 
 The single most common drift in AI-authored bullets is verbosity. A bullet that takes 15 words to say what 5 words could say is performing thoroughness. Humans don't write that way when describing state — they say the thing and stop.
 
-### Three terseness rules
+### Four terseness rules
 
 **1. Cut justification clauses.** When you remove something, don't explain why in the bullet. The "why" goes in the commit message or PR conversation if it matters. Bullets just name the thing.
 
@@ -169,6 +169,20 @@ If a bullet's outcome is the obvious consequence of bullets above it, drop it.
 | CI-only bench tooling lives under `tools/ci/bench/` so the top-level `tools/` directory only contains developer-runnable harnesses. | CI bench tooling lives under `tools/ci/bench/`. |
 
 If the framing sentence has a "so that" / "plus the X that follows" / "in order to" tail, the tail is usually padding.
+
+A syntax or API change frames itself with the before/after, so the reader gets the new form in hand instead of a description of it.
+
+| ❌ Describes the fix | ✅ Shows the gain |
+|---|---|
+| Template expressions written in JS syntax never resolved a data-context function, so `{getIndex + 1}` rendered the function source. | Instead of the verbose `{getIndex() + 1}` you can now write `{getIndex + 1}`. |
+
+**4. Cut machinery bullets.** One feature is one bullet. A memoization, a redundant walk you removed, a cache keyed differently — those are how the single outcome works, not outcomes of their own. They live in the diff, and anyone who wants them reads there.
+
+| ❌ Machinery as features | ✅ The feature |
+|---|---|
+| - Resolve data-context functions in JS expressions, except in callee position<br>- Memoize per evaluation so an identifier written twice still invokes once<br>- Skip the speculative path walk for tokens that aren't pure dotted paths | - Data-context functions now resolve in JS expressions when not in callee positions |
+
+This is the hardest class to spot in your own draft: after hours inside the machinery it reads as the achievement. Test: would this bullet exist if the feature had been trivial to build? If not, it's machinery.
 
 ### Subgroup long sections
 

--- a/packages/renderer/src/expression-evaluator.js
+++ b/packages/renderer/src/expression-evaluator.js
@@ -31,7 +31,12 @@ export class ExpressionEvaluator {
   static SIMPLE_PATH_REGEXP = /^[a-zA-Z_$][0-9a-zA-Z_$]*(\.[a-zA-Z_$][0-9a-zA-Z_$]*)*$/;
   static JS_OPERATOR_REGEXP = /[+\-*/%=<>!&|?:~^`()[\]]/;
   static QUOTED_STRING_REGEXP = /('[^']*'|"[^"]*")/g;
+  static CALLEE_REGEXP = /([A-Za-z_$][0-9a-zA-Z_$]*)\s*\(/g;
   static fnCache = createCache({ maxSize: 5000, eviction: 'flush' });
+
+  // Identifiers written with a call in a given expression. Deterministic per
+  // expression string, same as the parse and classify caches.
+  static calleeCache = createCache({ maxSize: 5000, eviction: 'flush' });
 
   // Expression classification cache — shared across all instances since
   // classification depends only on the expression string, not data context
@@ -52,6 +57,8 @@ export class ExpressionEvaluator {
 
     // Reusable Proxy for JS expression evaluation — avoids per-eval spread + new Proxy
     this.jsContext = null;
+    this.jsCallees = new Set();
+    this.jsResolved = null;
     this.jsProxy = new Proxy(
       // Dummy target — the handler reads from jsContext/helpers directly
       Object.create(null),
@@ -67,6 +74,9 @@ export class ExpressionEvaluator {
             : this.helpers[prop];
           if (value instanceof Signal) {
             return value.get();
+          }
+          if (typeof value === 'function' && !this.jsCallees.has(prop)) {
+            return this.resolveJsIdentifier(prop, value);
           }
           return unwrap(value);
         },
@@ -166,6 +176,7 @@ export class ExpressionEvaluator {
       // Reuse the cached Proxy — just swap which context object it reads from
       if (includeHelpers) {
         this.jsContext = context || null;
+        this.jsCallees = this.getCallees(code);
       }
       const proxy = includeHelpers ? this.jsProxy : new Proxy(context || {}, jsNoHelpersHandler);
       let fn = ExpressionEvaluator.fnCache.get(code);
@@ -180,8 +191,40 @@ export class ExpressionEvaluator {
     }
     finally {
       this.jsContext = null;
+      this.jsResolved = null;
     }
     return result;
+  }
+
+  getCallees(code) {
+    let callees = ExpressionEvaluator.calleeCache.get(code);
+    if (callees !== undefined) {
+      return callees;
+    }
+    callees = new Set();
+    const stripped = code.replace(ExpressionEvaluator.QUOTED_STRING_REGEXP, '');
+    for (const match of stripped.matchAll(ExpressionEvaluator.CALLEE_REGEXP)) {
+      callees.add(match[1]);
+    }
+    ExpressionEvaluator.calleeCache.set(code, callees);
+    return callees;
+  }
+
+  // a function in the data context is an accessor here, same as in path syntax.
+  // memoized for the evaluation so an identifier written twice still runs its
+  // side effects once
+  resolveJsIdentifier(name, accessor) {
+    const resolved = (this.jsResolved ??= new Map());
+    if (resolved.has(name)) {
+      return resolved.get(name);
+    }
+    let value = accessor();
+    if (value instanceof Signal) {
+      value = value.get();
+    }
+    value = unwrap(value);
+    resolved.set(name, value);
+    return value;
   }
 
   lookupExpressionValue(expression = '', data = {}, visited) {
@@ -318,6 +361,7 @@ export class ExpressionEvaluator {
   // receiver unwraps
   lookupDottedValue(data, token) {
     const segments = this.getPathSegments(token);
+    if (segments === null) { return undefined; }
     const last = segments.length - 1;
 
     let container = this.walkPath(data, segments, last);
@@ -330,12 +374,15 @@ export class ExpressionEvaluator {
     return (value instanceof Signal) ? value.value : value;
   }
 
+  // null for anything that isn't a pure dotted path. a JS expression can carry a
+  // dot ({board.count + 1}) and walking it speculatively would run an accessor
+  // that the JS evaluator is about to run properly
   getPathSegments(path) {
     let segments = ExpressionEvaluator.pathSegmentsCache.get(path);
     if (segments !== undefined) {
       return segments;
     }
-    segments = path.split('.');
+    segments = ExpressionEvaluator.SIMPLE_PATH_REGEXP.test(path) ? path.split('.') : null;
     ExpressionEvaluator.pathSegmentsCache.set(path, segments);
     return segments;
   }
@@ -351,6 +398,7 @@ export class ExpressionEvaluator {
     }
 
     const segments = this.getPathSegments(path);
+    if (segments === null) { return undefined; }
     return this.walkPath(obj, segments, segments.length);
   }
 

--- a/packages/renderer/src/expression-evaluator.js
+++ b/packages/renderer/src/expression-evaluator.js
@@ -16,6 +16,17 @@ const jsNoHelpersHandler = {
   },
 };
 
+// Identifiers written with a call. {addOne(1)} needs the function itself, not
+// the value it returns with no arguments.
+const calleesFrom = (code) => {
+  const callees = new Set();
+  const stripped = code.replace(/('[^']*'|"[^"]*")/g, '');
+  for (const match of stripped.matchAll(/([A-Za-z_$][0-9a-zA-Z_$]*)\s*\(/g)) {
+    callees.add(match[1]);
+  }
+  return callees;
+};
+
 // Rough expression distribution (2026-04-12) — weight optimizations by hot paths:
 //
 //   ~60%  simple identifier   — direct property lookup
@@ -31,12 +42,7 @@ export class ExpressionEvaluator {
   static SIMPLE_PATH_REGEXP = /^[a-zA-Z_$][0-9a-zA-Z_$]*(\.[a-zA-Z_$][0-9a-zA-Z_$]*)*$/;
   static JS_OPERATOR_REGEXP = /[+\-*/%=<>!&|?:~^`()[\]]/;
   static QUOTED_STRING_REGEXP = /('[^']*'|"[^"]*")/g;
-  static CALLEE_REGEXP = /([A-Za-z_$][0-9a-zA-Z_$]*)\s*\(/g;
   static fnCache = createCache({ maxSize: 5000, eviction: 'flush' });
-
-  // Identifiers written with a call in a given expression. Deterministic per
-  // expression string, same as the parse and classify caches.
-  static calleeCache = createCache({ maxSize: 5000, eviction: 'flush' });
 
   // Expression classification cache — shared across all instances since
   // classification depends only on the expression string, not data context
@@ -173,16 +179,18 @@ export class ExpressionEvaluator {
   evaluateJavascript(code, context, { includeHelpers = true } = {}) {
     let result;
     try {
-      // Reuse the cached Proxy — just swap which context object it reads from
-      if (includeHelpers) {
-        this.jsContext = context || null;
-        this.jsCallees = this.getCallees(code);
-      }
       const proxy = includeHelpers ? this.jsProxy : new Proxy(context || {}, jsNoHelpersHandler);
       let fn = ExpressionEvaluator.fnCache.get(code);
       if (!fn) {
         fn = new Function('ctx', `with(ctx){return ${code}}`);
+        // rides on the compiled function so the hot path pays one cache lookup
+        fn.callees = calleesFrom(code);
         ExpressionEvaluator.fnCache.set(code, fn);
+      }
+      // Reuse the cached Proxy — just swap which context object it reads from
+      if (includeHelpers) {
+        this.jsContext = context || null;
+        this.jsCallees = fn.callees;
       }
       result = fn(proxy);
     }
@@ -194,20 +202,6 @@ export class ExpressionEvaluator {
       this.jsResolved = null;
     }
     return result;
-  }
-
-  getCallees(code) {
-    let callees = ExpressionEvaluator.calleeCache.get(code);
-    if (callees !== undefined) {
-      return callees;
-    }
-    callees = new Set();
-    const stripped = code.replace(ExpressionEvaluator.QUOTED_STRING_REGEXP, '');
-    for (const match of stripped.matchAll(ExpressionEvaluator.CALLEE_REGEXP)) {
-      callees.add(match[1]);
-    }
-    ExpressionEvaluator.calleeCache.set(code, callees);
-    return callees;
   }
 
   // a function in the data context is an accessor here, same as in path syntax.

--- a/packages/renderer/test/browser/js-expression-corpus.test.js
+++ b/packages/renderer/test/browser/js-expression-corpus.test.js
@@ -1,0 +1,67 @@
+import { defineComponent } from '@semantic-ui/component';
+import { describe, expect, it } from 'vitest';
+
+/*
+  JS-style expressions taken verbatim from the shipped corpus — src/components,
+  src/primitives, and docs/src/examples. Resolving a data-context function to its
+  value changes what identifiers mean inside these, so this is the net the change
+  has to pass through. Each renders in its own component because each came from
+  one, and two of them name `items` with different shapes.
+*/
+
+const baseState = { index: 2, activeIndex: 1, width: 5, status: 'success', filter: 'all' };
+
+const baseData = {
+  scores: [10, 20, 30],
+  prices: [1.5, 2.5, 3],
+  items: ['Apple', 'Banana', 'Blueberry'],
+  field: { placeholder: '' },
+  item: { packed: true },
+  user: { profile: { bio: 'Hi' } },
+  stats: { successCount: 4 },
+  formatScore: (n) => `#${n}`,
+  getMax: (list) => Math.max(...list),
+};
+
+const cases = [
+  ['{index + 1}', '3'],
+  ['{scores.length * 2}', '6'],
+  ['{width > 0 ? width : 0}', '5'],
+  ['{status === "success" ? "Success" : "Failed"}', 'Success'],
+  ['{activeIndex == index ? "0" : "-1"}', '-1'],
+  ['{filter != "all" ? filter : "none"}', 'none'],
+  ['{field.placeholder || "Select..."}', 'Select...'],
+  ['{item.packed ? "circle-check" : "circle"}', 'circle-check'],
+  ['{user?.profile?.bio ?? "No bio"}', 'Hi'],
+  ['{stats[status + "Count"] || 0}', '4'],
+  ['{Math.max(...scores)}', '30'],
+  ['{items.filter(item => item.startsWith("B")).join(" and ")}', 'Banana and Blueberry'],
+  ['{(prices.reduce((a, b) => a + b, 0) / prices.length).toFixed(2)}', '2.33'],
+  ['{formatScore(scores[0])}', '#10'],
+  ['{getMax(scores)}', '30'],
+  ['{items.find(i => i.active).name}', 'B', { items: [{ active: false, name: 'A' }, { active: true, name: 'B' }] }],
+];
+
+const renderCase = async (index, expr, extraData) => {
+  const tagName = `js-corpus-${index}`;
+  defineComponent({
+    tagName,
+    template: `<b class="c">${expr}</b>`,
+    defaultState: baseState,
+    createComponent: () => ({ ...baseData, ...extraData }),
+  });
+  const element = document.createElement(tagName);
+  document.body.appendChild(element);
+  await element.rendered;
+  const text = element.shadowRoot.querySelector('.c').textContent;
+  element.remove();
+  return text;
+};
+
+describe('native — JS expressions from the shipped corpus', () => {
+  cases.forEach(([expr, want, extraData], index) => {
+    it(`renders ${expr}`, async () => {
+      expect(await renderCase(index, expr, extraData)).toBe(want);
+    });
+  });
+});

--- a/packages/renderer/test/browser/js-expression-values.test.js
+++ b/packages/renderer/test/browser/js-expression-values.test.js
@@ -1,0 +1,116 @@
+import { defineComponent } from '@semantic-ui/component';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+/*
+  What a data-context function resolves to inside a JS-style expression. Path
+  syntax already resolves one for you ({num} renders its value), and the JS
+  proxy already resolves the other container kind (signals), so a function
+  consumed by a JS operator is the remaining gap. It reads as a plausible value
+  rather than an error: a computed returning false tests as truthy, and a
+  computed returning a number concatenates as source text.
+
+  Callee position is the one place the raw function is still wanted, since
+  {addOne(1)} has to keep calling it.
+*/
+
+let boardCalls = 0;
+const boardModel = { id: 'main', count: 2 };
+
+const build = (tagName, template) => {
+  defineComponent({
+    tagName,
+    template,
+    defaultState: { sig: 42, dragging: false, currentPercentage: 7 },
+    createComponent: () => ({
+      num: () => 42,
+      isFalse: () => false,
+      addOne: (v = 0) => v + 1,
+      value: 1,
+      list: ['Apple', 'Banana', 'Blueberry'],
+      ratingPercentage: () => 60,
+      board: () => {
+        boardCalls += 1;
+        return boardModel;
+      },
+    }),
+  });
+};
+
+const render = async (tagName, template) => {
+  boardCalls = 0;
+  build(tagName, template);
+  const element = document.createElement(tagName);
+  document.body.appendChild(element);
+  await element.rendered;
+  const text = element.shadowRoot.textContent.trim();
+  element.remove();
+  return text;
+};
+
+describe('native — data functions inside JS-style expressions', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  /*******************************
+        Consumed by an operator
+  *******************************/
+
+  it('resolves a computed used in arithmetic', async () => {
+    expect(await render('jsx-arith', '{num + 1}')).toBe('43');
+  });
+
+  it('resolves a computed used as a boolean test', async () => {
+    expect(await render('jsx-ternary', '{isFalse ? "y" : "n"}')).toBe('n');
+  });
+
+  it('resolves a computed used under negation', async () => {
+    expect(await render('jsx-negate', '{!isFalse}')).toBe('true');
+  });
+
+  it('resolves an accessor member used in arithmetic', async () => {
+    expect(await render('jsx-member-arith', '{board.count + 1}')).toBe('3');
+  });
+
+  it('resolves an accessor member used in a comparison', async () => {
+    expect(await render('jsx-member-compare', '{board.id == "main" ? "y" : "n"}')).toBe('y');
+  });
+
+  it('invokes a path accessor once per expression, not once per mention', async () => {
+    expect(await render('jsx-once', '{board.count + board.count}')).toBe('4');
+    expect(boardCalls).toBe(1);
+  });
+
+  /*******************************
+          Callee position
+  *******************************/
+
+  it('still calls a component method written with arguments', async () => {
+    expect(await render('jsx-callee', '{addOne(1)}')).toBe('2');
+  });
+
+  it('still calls a framework helper written with arguments', async () => {
+    expect(await render('jsx-helper-callee', '{activeIf(value == 1)}')).toBe('active');
+  });
+
+  it('leaves an inline arrow argument alone', async () => {
+    const out = await render('jsx-arrow', '{list.filter(item => item.startsWith("B")).join(" and ")}');
+    expect(out).toBe('Banana and Blueberry');
+  });
+
+  /*******************************
+       Already resolving today
+  *******************************/
+
+  it('keeps invoking a computed returned from a JS expression', async () => {
+    expect(await render('jsx-returned', '{dragging ? currentPercentage : ratingPercentage}')).toBe('60');
+  });
+
+  it('keeps unwrapping a signal in arithmetic', async () => {
+    expect(await render('jsx-signal', '{sig + 1}')).toBe('43');
+  });
+
+  it('keeps resolving the same member through path syntax', async () => {
+    expect(await render('jsx-path', '{board.id}')).toBe('main');
+  });
+});

--- a/packages/renderer/test/browser/js-expression-values.test.js
+++ b/packages/renderer/test/browser/js-expression-values.test.js
@@ -27,6 +27,7 @@ const build = (tagName, template) => {
       addOne: (v = 0) => v + 1,
       value: 1,
       list: ['Apple', 'Banana', 'Blueberry'],
+      getFiltered: () => ['Apple', 'Banana', 'Blueberry'].filter((n) => n.startsWith('B')),
       ratingPercentage: () => 60,
       board: () => {
         boardCalls += 1;
@@ -91,6 +92,15 @@ describe('native — data functions inside JS-style expressions', () => {
 
   it('still calls a framework helper written with arguments', async () => {
     expect(await render('jsx-helper-callee', '{activeIf(value == 1)}')).toBe('active');
+  });
+
+  // a bare identifier handed to a higher-order method resolves like any other, so
+  // it arrives as its value and the call fails. no template in the corpus writes
+  // that shape — every one uses an inline arrow — and a computed is the way to
+  // pass a function through. the degraded output is an artifact of the fallback
+  // chain, so only the working form is pinned
+  it('passes a function through a computed', async () => {
+    expect(await render('jsx-graduated', '{getFiltered.length}')).toBe('2');
   });
 
   it('leaves an inline arrow argument alone', async () => {


### PR DESCRIPTION
This fixes JS expressions so it can optimistically unwrap functions, instead of requiring the verbose `{getIndex() + 1}` you can now write `{getIndex + 1}`

Other complex JS expressions can also be written without unwrapping at boundaries. i.e. `{getBoard().count + 1}` is now `{getBoard.count + 1}`

## Changes
- Data-context functions now resolve in JS expressions when not in callee positions

## Risk
5/10

Same machinery as #324, this time on the JS eval path

## How to Test
Run renderer suite with new tests.
