### PR TITLE
Bug: Fix issue in reconcile with subtemplate data

### DIFF
--- a/packages/renderer/src/engines/native/scope-context.js
+++ b/packages/renderer/src/engines/native/scope-context.js
@@ -31,6 +31,8 @@
 
 */
 
+import { unwrap } from '../../helpers.js';
+
 export const SCOPE_OWNER = Symbol('sui-scope-owner');
 export const SCOPE_END = Symbol('sui-scope-end');
 
@@ -53,9 +55,14 @@ function getLayer(owner) {
   if (!keys) {
     return data;
   }
+  // an arg passed as a bare as-key ({>row row=row}) reads back as the each
+  // block's item-tracking proxy, a live view that empties when reconcile
+  // disposes the record behind it. a handler keeps what it captures, so the
+  // item has to leave the framework here. getEventData runs nonreactive, so
+  // the unwrap read registers no dependency
   const layer = {};
   for (const key of keys) {
-    layer[key] = data[key];
+    layer[key] = unwrap(data[key]);
   }
   return layer;
 }

--- a/packages/renderer/test/browser/event-scope-blocks.test.js
+++ b/packages/renderer/test/browser/event-scope-blocks.test.js
@@ -116,6 +116,42 @@ RENDERING_ENGINES.forEach((engine) => {
         expect(captured.item.name).toBe('Beta v2');
       });
 
+      // what a handler keeps is the item, not a view onto a record that
+      // reconcile can retire out from under it
+      it.skipIf(isLit)('hands over the item itself, so a captured row outlives its removal', async () => {
+        const tag = uniqueTag();
+        let captured;
+        defineComponent({
+          tagName: tag,
+          renderingEngine: engine,
+          template: '<ul>{#each item in items}<li class="row">{item.name}</li>{/each}</ul>',
+          defaultState: {
+            items: [
+              { id: 'a', name: 'Alpha' },
+              { id: 'b', name: 'Beta' },
+              { id: 'c', name: 'Gamma' },
+            ],
+          },
+          events: {
+            'click .row'({ data }) {
+              captured = data.item;
+            },
+          },
+        });
+        const el = await mount(tag);
+        clickOn(el.shadowRoot.querySelectorAll('.row')[1]);
+        expect(captured).toEqual({ id: 'b', name: 'Beta' });
+
+        el.template.state.items.set([
+          { id: 'a', name: 'Alpha' },
+          { id: 'c', name: 'Gamma' },
+        ]);
+        await waitForUpdate(el);
+
+        expect(Object.keys(captured)).toEqual(['id', 'name']);
+        expect(captured.id).toBe('b');
+      });
+
       it.skipIf(isLit)('resolves nested each with the inner layer winning', async () => {
         const tag = uniqueTag();
         let captured;
@@ -316,6 +352,87 @@ RENDERING_ENGINES.forEach((engine) => {
         expect(el.shadowRoot.querySelector('.lbl')).toBeNull();
         clickOn(el.shadowRoot.querySelector('.after'));
         expect(captured).toEqual({});
+      });
+
+      // the arg record's getters run at dispatch, so the layer reports the row
+      // sitting there now, not the one bound when the subtemplate mounted
+      it.skipIf(isLit)('reads a whole-item arg at dispatch, not at mount', async () => {
+        const tag = uniqueTag();
+        const a = { id: 'a', name: 'Alpha' };
+        const b = { id: 'b', name: 'Beta' };
+        let captured;
+        const rowItem = defineComponent({
+          renderingEngine: engine,
+          template: '<li class="row">{row.name}</li>',
+        });
+        defineComponent({
+          tagName: tag,
+          renderingEngine: engine,
+          template: '<ul>{#each row in rows}{>rowItem row=row}{/each}</ul>',
+          subTemplates: { rowItem },
+          defaultState: { rows: [a, b] },
+          events: {
+            'click .row'({ data }) {
+              captured = data.row;
+            },
+          },
+        });
+        const el = await mount(tag);
+
+        el.template.state.rows.set([b, a]);
+        await waitForUpdate(el);
+        clickOn(el.shadowRoot.querySelectorAll('.row')[0]);
+        expect(captured.id).toBe('b');
+
+        el.template.state.rows.peek()[0].name = 'Beta v2';
+        el.template.state.rows.notify();
+        await waitForUpdate(el);
+        clickOn(el.shadowRoot.querySelectorAll('.row')[0]);
+        expect(captured.name).toBe('Beta v2');
+      });
+
+      // as-mode routes the item through a tracking proxy so dotted reads
+      // register per-field deps. that proxy is a live view onto the record:
+      // reaching a handler, it would read back empty once reconcile disposes
+      // the row it fronts
+      it.skipIf(isLit)('hands over the item itself when a whole-item arg crosses the boundary', async () => {
+        const tag = uniqueTag();
+        let captured;
+        const rowItem = defineComponent({
+          renderingEngine: engine,
+          template: '<li class="row">{row.name}</li>',
+          defaultSettings: { row: null },
+        });
+        defineComponent({
+          tagName: tag,
+          renderingEngine: engine,
+          template: '<ul>{#each row in rows}{>rowItem row=row}{/each}</ul>',
+          subTemplates: { rowItem },
+          defaultState: {
+            rows: [
+              { id: 'a', name: 'Alpha' },
+              { id: 'b', name: 'Beta' },
+              { id: 'c', name: 'Gamma' },
+            ],
+          },
+          events: {
+            'click .row'({ data }) {
+              captured = data.row;
+            },
+          },
+        });
+        const el = await mount(tag);
+        clickOn(el.shadowRoot.querySelectorAll('.row')[1]);
+        expect(captured).toEqual({ id: 'b', name: 'Beta' });
+
+        el.template.state.rows.set([
+          { id: 'a', name: 'Alpha' },
+          { id: 'c', name: 'Gamma' },
+        ]);
+        await waitForUpdate(el);
+
+        expect(Object.keys(captured)).toEqual(['id', 'name']);
+        expect(captured.id).toBe('b');
       });
     });
 

--- a/packages/renderer/test/browser/subtree-spurious.test.js
+++ b/packages/renderer/test/browser/subtree-spurious.test.js
@@ -1431,5 +1431,99 @@ RENDERING_ENGINES.forEach(engine => {
         expect(fires.title).toBe(1);
       });
     });
+
+    describe.skipIf(isLit)('FGR contract: whole-item subtemplate arg', () => {
+      // `{>rowItem row=row}` hands the entire as-key item across the boundary.
+      // the bench-todo composition above passes fields instead, so its child
+      // reads land on primitives and never touch the item-tracking proxy
+      it('mutating one item field re-fires only the child binding reading that field', async () => {
+        let nameFires = 0;
+        let doneFires = 0;
+        const rowItem = defineComponent({
+          renderingEngine: engine,
+          template: '<span>{readName}</span><span>{readDone}</span>',
+          createComponent: ({ data }) => ({
+            readName() {
+              nameFires++;
+              return data.row.name;
+            },
+            readDone() {
+              doneFires++;
+              return String(data.row.done);
+            },
+          }),
+        });
+        const tag = uniqueTag();
+        defineComponent({
+          renderingEngine: engine,
+          tagName: tag,
+          template: '{#each row in getRows}{>rowItem row=row}{/each}',
+          subTemplates: { rowItem },
+          createComponent: ({ signal }) => {
+            const rows = signal([{ _id: 'a', name: 'first', done: false }]);
+            return {
+              rows,
+              getRows: () => rows.get(),
+              toggle: () => rows.toggleItemProperty('a', 'done'),
+            };
+          },
+        });
+        const el = document.createElement(tag);
+        const rendered = $(el).onNext('rendered');
+        document.body.appendChild(el);
+        await rendered;
+
+        expect(nameFires).toBe(1);
+        expect(doneFires).toBe(1);
+
+        const updated = $(el).onNext('updated');
+        el.component.toggle();
+        await updated;
+
+        expect(doneFires).toBe(2);
+        expect(nameFires).toBe(1);
+      });
+
+      // a reactiveData key that matches a declared defaultSetting activates the
+      // settings mirror, a second write path carrying the same whole-item arg
+      it('renders an in-place field mutation when the child declares the arg as a setting', async () => {
+        const rowItem = defineComponent({
+          renderingEngine: engine,
+          template: '<li class="row">{row.name}</li>',
+          defaultSettings: { row: null },
+        });
+        const tag = uniqueTag();
+        defineComponent({
+          renderingEngine: engine,
+          tagName: tag,
+          template: '<ul>{#each row in getRows}{>rowItem row=row}{/each}</ul>',
+          subTemplates: { rowItem },
+          createComponent: ({ signal }) => {
+            const rows = signal([
+              { _id: 'a', name: 'Alpha' },
+              { _id: 'b', name: 'Beta' },
+            ]);
+            return {
+              rows,
+              getRows: () => rows.get(),
+              rename: () => rows.setItemProperty('b', 'name', 'Beta v2'),
+            };
+          },
+        });
+        const el = document.createElement(tag);
+        const rendered = $(el).onNext('rendered');
+        document.body.appendChild(el);
+        await rendered;
+
+        expect(shadowText(el)).toContain('Beta');
+
+        const updated = $(el).onNext('updated');
+        el.component.rename();
+        await updated;
+
+        expect(shadowText(el)).toContain('Beta v2');
+        expect(shadowText(el)).toContain('Alpha');
+      });
+    });
   }); // describe(engine)
 }); // RENDERING_ENGINES.forEach


### PR DESCRIPTION
Fixes a bug where using `{#each} {>subtemplate} {/each}` would fail to handle reconcile properly when the entire array is replaced.

## Changes
- One liner in reconcile

## Risk
1/10

## How to Test
New suite tests