### PR TITLE
Feat: Add 'Report' Option to Errors

### DIFF
--- a/ai/skills/authoring/utility-functions.md
+++ b/ai/skills/authoring/utility-functions.md
@@ -997,13 +997,16 @@ const { error, throwError } = createErrors({ layer: 'sync' });       // ErrorCla
 const { throwError: typeError } = createErrors({ layer: 'schema', ErrorClass: TypeError });
 
 // report and continue — raises asynchronously through globalThis.onError when an
-// app installs one, throws otherwise. returns the Error it reported
+// app installs one, falls back to console.error otherwise. returns the Error it reported
 const reported = error('forbidden', 'todos:secret.field', {
   explanation: isDevelopment ? 'the field is private — write the fields you mean' : 0,
   detail: { collection: 'todos', field: 'secret.field' },
 });
 reported.code;    // 'forbidden'
 reported.detail;  // { collection: 'todos', field: 'secret.field' }
+
+// the error as a value — report: false builds and returns without reporting
+const rejection = error('timedOut', 'todos:pull', { report: false });
 
 // same arguments, throws synchronously
 throwError('unknownCollection', 'invoices');

--- a/docs/src/pages/docs/api/utils/debug.mdx
+++ b/docs/src/pages/docs/api/utils/debug.mdx
@@ -138,6 +138,8 @@ error(code, at, { explanation, detail } = {})
 
 Returned by [`createErrors`](#createerrors). Reports a coded error through the error channel **without interrupting the caller** — `log`'s sibling for things that went wrong. The raise is asynchronous, so the current call stack completes first: it routes to `globalThis.onError` when an app installs one, and falls back to `console.error` otherwise, so a report is never silently lost.
 
+Sometimes the error is a value — handed to a promise rejection, attached to a result — and reporting is someone else's job. `report: false` builds and returns the same coded error without reporting it, making `error` the family's builder without a third function.
+
 #### Parameters
 
 | Name    | Type   | Description |
@@ -153,6 +155,7 @@ Returned by [`createErrors`](#createerrors). Reports a coded error through the e
 | explanation | string \| `0` | undefined | The development teaching message. When present it follows the production line on its own line; when folded away the line is the whole message. See [Development Messages](#development-messages) |
 | detail      | any           | undefined | Structured data attached to the error as `error.detail` |
 | verb        | string        | `'refused'` | The line's verb — any word, your classification of the line. Nullish falls back to `'refused'` |
+| report      | boolean       | `true`    | Set `false` to build and return the coded error without reporting it — no `onError` routing, no console fallback |
 
 #### Returns
 
@@ -177,6 +180,11 @@ console.log(reported.code);    // 'writeRejected'
 console.log(reported.at);      // 'todos:a7f2'
 console.log(reported.message); // 'sync refused [writeRejected] todos:a7f2',
                                // with the explanation beneath it in development
+
+// the error as a value — built, never reported: the rejection is the report
+const timeout = new Promise((resolve, reject) => {
+  setTimeout(() => reject(error('timedOut', 'todos:pull', { report: false })), 5000);
+});
 ```
 
 ### throwError
@@ -189,7 +197,7 @@ Returned by [`createErrors`](#createerrors). Same arguments as [`error`](#error)
 
 #### Parameters
 
-Identical to [`error`](#error).
+Identical to [`error`](#error), minus `report` — the throw is the delivery.
 
 #### Returns
 

--- a/packages/utils/src/debug.js
+++ b/packages/utils/src/debug.js
@@ -120,9 +120,14 @@ export const createErrors = ({
   // the raise is asynchronous so the current call stack completes: it routes to
   // globalThis.onError when an app installs one, and falls back to
   // console.error otherwise so a report is never silently lost. returns the
-  // Error it reported.
+  // Error it reported. report: false builds and returns without raising — for
+  // when the error is a value (a rejection, a result) and reporting is the
+  // consumer's job.
   const error = (code, at, options) => {
     const built = build(code, at, options);
+    if (options?.report === false) {
+      return built;
+    }
     const raise = () => {
       if (typeof globalThis.onError === 'function') {
         globalThis.onError(built);

--- a/packages/utils/test/dom/debug.test.js
+++ b/packages/utils/test/dom/debug.test.js
@@ -254,6 +254,48 @@ describe('createErrors', () => {
       expect(errorSpy).toHaveBeenCalledTimes(1);
       expect(errorSpy).toHaveBeenCalledWith(returned);
     });
+
+    it('should only build when report is false', async () => {
+      const { error } = createErrors({ layer: 'demo' });
+      const returned = error('write-conflict', 'commit()', { report: false, detail: { id: 7 } });
+      expect(returned).toBeInstanceOf(Error);
+      expect(returned.message).toBe('demo refused [write-conflict] commit()');
+      expect(returned.code).toBe('write-conflict');
+      expect(returned.at).toBe('commit()');
+      expect(returned.detail).toEqual({ id: 7 });
+      await flushMicrotasks();
+      expect(globalThis.onError).not.toHaveBeenCalled();
+    });
+
+    it('should skip the console fallback when report is false', async () => {
+      delete globalThis.onError;
+      // the suite-wide spy throws on stray console.error calls, so a leaked
+      // report would fail the test on its own — the count makes it explicit
+      errorSpy.mockClear();
+      const { error } = createErrors({ layer: 'demo' });
+      error('write-conflict', 'commit()', { report: false });
+      await flushMicrotasks();
+      expect(errorSpy).not.toHaveBeenCalled();
+    });
+
+    it('should build report: false errors identical to reported ones', async () => {
+      const { error } = createErrors({ layer: 'demo' });
+      const options = {
+        verb: 'declined',
+        explanation: 'the server refused the write',
+        detail: { id: 7 },
+      };
+      const reported = error('write-conflict', 'commit()', options);
+      const returned = error('write-conflict', 'commit()', { ...options, report: false });
+      expect(returned.message).toBe(reported.message);
+      expect(returned.code).toBe(reported.code);
+      expect(returned.at).toBe(reported.at);
+      expect(returned.detail).toEqual(reported.detail);
+      await flushMicrotasks();
+      // only the reported one reaches the channel
+      expect(globalThis.onError).toHaveBeenCalledTimes(1);
+      expect(globalThis.onError).toHaveBeenCalledWith(reported);
+    });
   });
 });
 

--- a/packages/utils/types/debug.d.ts
+++ b/packages/utils/types/debug.d.ts
@@ -32,14 +32,26 @@ export interface CodedError extends Error {
 }
 
 /**
+ * Options for the reporting door — the construction options plus the report
+ * switch
+ */
+export interface ErrorReportOptions extends ErrorOptions {
+  /** Set `false` to build and return the coded error without reporting it —
+   * no `onError` routing, no console fallback — for when the error is a value
+   * (a rejection, a result) and reporting is the consumer's job */
+  report?: boolean;
+}
+
+/**
  * The reporting door: builds the coded error and reports it through the error
  * channel WITHOUT interrupting the caller. The raise is asynchronous — it
  * routes to `globalThis.onError` when an app installs one and falls back to
  * `console.error` otherwise so a report is never silently lost. Returns the
- * Error it reported.
+ * Error it reported. `report: false` skips the raise and returns the built
+ * error alone.
  */
 export interface ErrorReporter {
-  (code: string, at: string, options?: ErrorOptions): CodedError;
+  (code: string, at: string, options?: ErrorReportOptions): CodedError;
   /** The production one-liner alone — `<layer> <verb> [<code>] <at>` — for console seats */
   line(code: string, at: string, options?: { verb?: string; }): string;
 }


### PR DESCRIPTION
Adds `report: false` to `error()` so an error can choose not to throw but instead return the actual `Error` #337 #336 #335 #334 

## Changes
- `error(code, at, { report: false })` 