### PR TITLE
Feat: Error Utils Remove Debug Frames

### DIFF
--- a/docs/src/pages/docs/api/utils/debug.mdx
+++ b/docs/src/pages/docs/api/utils/debug.mdx
@@ -193,6 +193,8 @@ Exported top-level, and returned bound by [`createErrors`](#createerrors) with t
 
 Sometimes the error is a value — handed to a promise rejection, attached to a result — and reporting is someone else's job. `report: false` builds and returns the same coded error without reporting it, making `error` the family's builder without a third function.
 
+On engines with `Error.captureStackTrace` (V8 among them) the stack opens at your callsite, with the library's own construction frames trimmed — other engines keep the full stack.
+
 #### Parameters
 
 | Name    | Type   | Description |

--- a/packages/utils/src/debug.js
+++ b/packages/utils/src/debug.js
@@ -151,6 +151,10 @@ const build = (code, at, { namespace = '', ErrorClass = Error, explanation, deta
 // consumer's job.
 export const error = (code, at, options) => {
   const built = build(code, at, options);
+  // open the stack at the caller — captureStackTrace (V8) drops every frame
+  // above and including the named function, so each public door captures
+  // against itself. engines without it keep the full stack
+  Error.captureStackTrace?.(built, error);
   if (options?.report === false) {
     return built;
   }
@@ -175,17 +179,29 @@ error.line = (code, at, { namespace = '', verb } = {}) => errorLine(namespace, v
 
 // the throwing form: same arguments, never returns
 export const throwError = (code, at, options) => {
-  throw build(code, at, options);
+  const built = build(code, at, options);
+  Error.captureStackTrace?.(built, throwError);
+  throw built;
 };
 
 // the binder over the pair, mirroring createLogger over log — pre-fills the
-// options into every call, callsite options win
+// options into every call, callsite options win. the bound forms capture the
+// stack against themselves so the wrapper frame folds away too
 export const createErrors = (defaults = {}) => {
   const merged = (options) => ({ ...defaults, ...options });
-  const bound = (code, at, options) => error(code, at, merged(options));
+  const bound = (code, at, options) => {
+    const built = error(code, at, merged(options));
+    Error.captureStackTrace?.(built, bound);
+    return built;
+  };
   bound.line = (code, at, options) => error.line(code, at, merged(options));
+  const boundThrow = (code, at, options) => {
+    const built = build(code, at, merged(options));
+    Error.captureStackTrace?.(built, boundThrow);
+    throw built;
+  };
   return {
     error: bound,
-    throwError: (code, at, options) => throwError(code, at, merged(options)),
+    throwError: boundThrow,
   };
 };

--- a/packages/utils/test/debug.test.js
+++ b/packages/utils/test/debug.test.js
@@ -1,4 +1,4 @@
-import { createLogger, isServer, log } from '@semantic-ui/utils';
+import { createErrors, createLogger, error, isServer, log, throwError } from '@semantic-ui/utils';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -57,5 +57,85 @@ describe('log (server posture)', () => {
       namespace: 'test',
       message: 'message',
     });
+  });
+});
+
+// node runs on V8, where Error.captureStackTrace trims the library's own
+// construction frames — the stack opens at the caller. engines without it
+// (no captureStackTrace) keep the full stack, so these pins live here
+
+describe('coded error stacks (V8 posture)', () => {
+  const firstFrame = (built) => built.stack.split('\n').find((line) => line.trim().startsWith('at '));
+
+  let originalOnError;
+
+  beforeEach(() => {
+    originalOnError = globalThis.onError;
+    globalThis.onError = vi.fn();
+  });
+
+  afterEach(async () => {
+    // let the deferred report flush before the handler is restored
+    await new Promise((resolve) => queueMicrotask(resolve));
+    if (originalOnError === undefined) {
+      delete globalThis.onError;
+    }
+    else {
+      globalThis.onError = originalOnError;
+    }
+  });
+
+  it('should open at the caller from error()', () => {
+    const frame = firstFrame(error('code', 'at', { namespace: 'demo' }));
+    expect(frame).not.toContain('debug.js');
+    expect(frame).toContain('debug.test.js');
+  });
+
+  it('should open at the caller from throwError()', () => {
+    let thrown;
+    try {
+      throwError('code', 'at', { namespace: 'demo' });
+    }
+    catch (caught) {
+      thrown = caught;
+    }
+    const frame = firstFrame(thrown);
+    expect(frame).not.toContain('debug.js');
+    expect(frame).toContain('debug.test.js');
+  });
+
+  it('should open at the caller from the bound error', () => {
+    const { error: bound } = createErrors({ namespace: 'demo' });
+    const frame = firstFrame(bound('code', 'at'));
+    expect(frame).not.toContain('debug.js');
+    expect(frame).toContain('debug.test.js');
+  });
+
+  it('should open at the caller from the bound throwError', () => {
+    const { throwError: bound } = createErrors({ namespace: 'demo' });
+    let thrown;
+    try {
+      bound('code', 'at');
+    }
+    catch (caught) {
+      thrown = caught;
+    }
+    const frame = firstFrame(thrown);
+    expect(frame).not.toContain('debug.js');
+    expect(frame).toContain('debug.test.js');
+  });
+
+  it('should carry the trimmed stack on a report: false build', () => {
+    const frame = firstFrame(error('code', 'at', { namespace: 'demo', report: false }));
+    expect(frame).not.toContain('debug.js');
+    expect(frame).toContain('debug.test.js');
+  });
+
+  it('should keep the stack present and the message shape intact', () => {
+    const built = error('write-conflict', 'commit()', { namespace: 'demo', report: false });
+    expect(typeof built.stack).toBe('string');
+    expect(built.stack.length).toBeGreaterThan(0);
+    expect(built.message).toBe('demo refused [write-conflict] commit()');
+    expect(built.stack.startsWith('Error: demo refused [write-conflict] commit()')).toBe(true);
   });
 });


### PR DESCRIPTION
This adds support for removing stack frames that show the actual debugger from stack traces passed through utils error helpers like `error` `throwError` and `createErrors`. Requires browsers that support `captureStackTrace`

## Changes
- Engines without `captureStackTrace` keep the full stack

## Risk
1/10 - safe change to a util only called when errored