### PR TITLE
Bug(renderer): Fix Double Render Output on Async on Initial Render

### DIFF
--- a/packages/renderer/src/engines/native/blocks/each.js
+++ b/packages/renderer/src/engines/native/blocks/each.js
@@ -115,7 +115,7 @@ function extractRangeToFragment(startMarker, endMarker, fragment) {
 
 function clearRecords(records) {
   for (const record of records) {
-    record.scope.dispose();
+    record.scope?.dispose();
     if (record.dataContext) { record.dataContext.dispose(); }
     disposeRecordDOM(record);
   }
@@ -193,9 +193,34 @@ function createRecord({ key, item, index, collectionType, node, data, scope, ren
 }
 
 function disposeRecord(record) {
-  record.scope.dispose();
+  // a held record disposes with nothing wired: no scope, no data context
+  record.scope?.dispose();
   if (record.dataContext) { record.dataContext.dispose(); }
   disposeRecordDOM(record);
+}
+
+// a held record (server DOM between its anchors, nothing wired) meets its
+// first data: build the item's context and scope and render into the existing
+// markers — the naive update path, aimed at the anchors the hold minted
+function materializeRecord(record, { item, index, collectionType, node, data, scope, renderAST, isSVG }) {
+  const eachData = getEachData(item, index, collectionType, node);
+  const itemScope = scope.child();
+  const dataContext = new ReactiveDataContext(data, {
+    registerItemContext: true,
+    sealKeysAfterReplace: !!node.as,
+    asKey: node.as,
+  });
+  dataContext.replace(eachData);
+  const fragment = renderAST({ ast: node.content, data: dataContext.proxy, scope: itemScope, isSVG });
+  removeRangeContent(record.startMarker, record.endMarker);
+  record.startMarker.after(fragment);
+  record.item = item;
+  record.index = index;
+  record.dataContext = dataContext;
+  record.scope = itemScope;
+  record.snapshot = snapshotForRecord(item, collectionType);
+  record.fresh = false;
+  markScopeRange(record.startMarker, record.endMarker, record);
 }
 
 // Survivors to leave untouched in Phase 2: the LIS of their old DOM positions.
@@ -407,6 +432,10 @@ function reconcile({ records, items, collectionType, node, data, scope, region, 
   for (let i = 0; i < newRecords.length; i++) {
     const record = newRecords[i];
     const item = items[i];
+    if (record.dataContext === null && !record.isElse) {
+      materializeRecord(record, { item, index: i, collectionType, node, data, scope, renderAST, isSVG });
+      continue;
+    }
     const refChanged = record.item !== item || record.index !== i;
     const isObjectItem = typeof item === 'object' && item !== null;
 
@@ -731,6 +760,48 @@ const eachBlock = defineBlock({
     const { items, collectionType } = resolveItems(node, lookupExpression);
 
     if (items.length === 0) {
+      const serverGroups = extractServerItemGroups(region.ownedNodes);
+      // the server drew items the client cannot resolve yet (a fetch still in
+      // flight, a sync snapshot not yet applied). convert each group's comment
+      // handshake into the block's own text-node anchors NOW — the durable
+      // references every record lives by — and keep the server DOM on screen
+      // between them, unwired. the resolveItems read above registered the
+      // items dependency, so the first real change reconciles by the server's
+      // own keys and renders each item into its anchors exactly like the
+      // naive non-SSR update path. a client resolving different data than the
+      // server drew is the ordinary hydration-mismatch class, and it heals
+      // here the ordinary way: the keyed re-render
+      if (serverGroups.length > 0) {
+        let insertAfter = region.anchor;
+        for (const group of serverGroups) {
+          const startMarker = document.createTextNode('');
+          const endMarker = document.createTextNode('');
+          group.startComment.replaceWith(startMarker);
+          const fragment = document.createDocumentFragment();
+          fragment.append(startMarker, ...group.nodes, endMarker);
+          insertAfter.after(fragment);
+          insertAfter = endMarker;
+          const record = {
+            key: group.key,
+            item: undefined,
+            index: -1,
+            // no data context and no scope: nothing is wired. the first
+            // reconcile renders into the markers and builds both
+            dataContext: null,
+            startMarker,
+            endMarker,
+            fragment: null,
+            scope: null,
+            isElse: false,
+            snapshot: null,
+            fresh: true,
+          };
+          self.records.push(record);
+        }
+        return;
+      }
+      // no item markers: the server resolved empty too and rendered the else
+      // branch (or nothing) — hydrate what it actually drew
       if (node.elseContent) {
         const elseScope = hydrateInto({ innerAST: node.elseContent });
         self.records.push({
@@ -782,7 +853,7 @@ const eachBlock = defineBlock({
       }
       for (const record of self.records) {
         if (record.isElse) { continue; }
-        record.scope.dispose();
+        record.scope?.dispose();
         if (record.dataContext) { record.dataContext.dispose(); }
         disposeRecordDOM(record);
       }

--- a/packages/renderer/src/engines/native/blocks/each.js
+++ b/packages/renderer/src/engines/native/blocks/each.js
@@ -772,15 +772,15 @@ const eachBlock = defineBlock({
       // server drew is the ordinary hydration-mismatch class, and it heals
       // here the ordinary way: the keyed re-render
       if (serverGroups.length > 0) {
-        let insertAfter = region.anchor;
         for (const group of serverGroups) {
+          // in place: nothing moves, unlike adoption (whose hydrateInnerContent
+          // detaches nodes into a fragment). the anchors take the positions the
+          // server's own markup dictates
           const startMarker = document.createTextNode('');
           const endMarker = document.createTextNode('');
           group.startComment.replaceWith(startMarker);
-          const fragment = document.createDocumentFragment();
-          fragment.append(startMarker, ...group.nodes, endMarker);
-          insertAfter.after(fragment);
-          insertAfter = endMarker;
+          const lastNode = group.nodes.length > 0 ? group.nodes[group.nodes.length - 1] : startMarker;
+          lastNode.after(endMarker);
           const record = {
             key: group.key,
             item: undefined,

--- a/packages/renderer/test/browser/ssr-each-late-data.test.js
+++ b/packages/renderer/test/browser/ssr-each-late-data.test.js
@@ -1,0 +1,184 @@
+import { defineComponent, renderToString } from '@semantic-ui/component';
+import { $ } from '@semantic-ui/query';
+import { flush, signal } from '@semantic-ui/reactivity';
+import { Template } from '@semantic-ui/templating';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+/*******************************
+    SSR Each — Late Data
+*******************************/
+
+// A server-rendered each hydrated against data that has not arrived yet (a
+// fetch in flight, a sync snapshot pending) holds the server DOM between the
+// block's own text anchors and, when the data lands, renders each item into
+// its anchors keyed by the server's markers — the naive update path, no
+// duplication, no whole-list teardown, no else flash. The two failure shapes
+// were reproduced red before the hold landed: duplication (no else branch)
+// and full teardown (else branch). Items resolvable at hydrate keep the
+// eager adopt-in-place path untouched; only the cold path re-renders innards,
+// which is invisible when the arriving data matches what the server drew.
+
+let tagCounter = 0;
+function uniqueTag() {
+  return `ssr-late-${++tagCounter}`;
+}
+
+async function ssrAndHydrate(opts) {
+  const tag = uniqueTag();
+  const Component = defineComponent({ tagName: tag, renderingEngine: 'native', ...opts });
+  const wasServer = Template.isServer;
+  Template.isServer = true;
+  let html;
+  try {
+    html = renderToString(Component, {});
+  }
+  finally {
+    Template.isServer = wasServer;
+  }
+  const wrapper = document.createElement('div');
+  wrapper.setHTMLUnsafe(html);
+  const el = wrapper.firstElementChild;
+  const serverItems = [...el.shadowRoot.querySelectorAll('li')];
+  const rendered = $(el).onNext('rendered');
+  document.body.appendChild(el);
+  await rendered;
+  return { el, serverItems };
+}
+
+const settle = () => new Promise((resolve) => setTimeout(resolve, 20));
+const itemsOf = (el) => [...el.shadowRoot.querySelectorAll('li')];
+
+beforeEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('each hydration with late-arriving data', () => {
+  it('items resolvable at hydrate keep the eager adopt-in-place path', async () => {
+    const items = signal(['a', 'b', 'c']);
+    const { el, serverItems } = await ssrAndHydrate({
+      template: '<ul>{#each item in items}<li>{item}</li>{/each}</ul>',
+      createComponent: () => ({ items }),
+    });
+    await settle();
+    const after = itemsOf(el);
+    expect(after.length).toBe(3);
+    expect(after[0]).toBe(serverItems[0]);
+    expect(after[1]).toBe(serverItems[1]);
+    expect(after[2]).toBe(serverItems[2]);
+  });
+
+  it('empty at hydrate, no else: the server list holds, then re-renders keyed at data arrival', async () => {
+    const serverData = signal(['a', 'b', 'c']);
+    const clientData = signal([]);
+    const { el, serverItems } = await ssrAndHydrate({
+      template: '<ul>{#each item in items}<li>{item}</li>{/each}</ul>',
+      createComponent: ({ isServer }) => ({ items: isServer ? serverData : clientData }),
+    });
+    await settle();
+    expect(itemsOf(el).length).toBe(3); // held, not destroyed
+
+    clientData.set(['a', 'b', 'c']);
+    flush();
+    await settle();
+    const after = itemsOf(el);
+    expect(after.length).toBe(3); // no duplication beside the held DOM
+    expect(after.map((n) => n.textContent)).toEqual(['a', 'b', 'c']);
+    // the innards re-render into the held anchors (the naive path): the
+    // server's nodes are replaced, never orphaned
+    expect(serverItems.every((n) => !n.isConnected)).toBe(true);
+  });
+
+  it('empty at hydrate, with else: same hold, no else flash, keyed render at arrival', async () => {
+    const serverData = signal(['a', 'b', 'c']);
+    const clientData = signal([]);
+    const { el, serverItems } = await ssrAndHydrate({
+      template: '<ul>{#each item in items}<li>{item}</li>{else}<p class="empty">none</p>{/each}</ul>',
+      createComponent: ({ isServer }) => ({ items: isServer ? serverData : clientData }),
+    });
+    await settle();
+    expect(itemsOf(el).length).toBe(3);
+    expect(el.shadowRoot.querySelector('.empty')).toBeNull();
+
+    clientData.set(['a', 'b', 'c']);
+    flush();
+    await settle();
+    const after = itemsOf(el);
+    expect(after.length).toBe(3);
+    expect(after.map((n) => n.textContent)).toEqual(['a', 'b', 'c']);
+    expect(el.shadowRoot.querySelector('.empty')).toBeNull();
+  });
+
+  it('arrival is keyed: survivors render into their anchors, dropped items dispose, new items append', async () => {
+    const serverData = signal([{ id: 1, label: 'a' }, { id: 2, label: 'b' }, { id: 3, label: 'c' }]);
+    const clientData = signal([]);
+    const { el, serverItems } = await ssrAndHydrate({
+      template: '<ul>{#each item in items}<li>{item.label}</li>{/each}</ul>',
+      createComponent: ({ isServer }) => ({ items: isServer ? serverData : clientData }),
+    });
+    await settle();
+
+    clientData.set([{ id: 2, label: 'b' }, { id: 3, label: 'c' }, { id: 4, label: 'd' }]);
+    flush();
+    await settle();
+    const after = itemsOf(el);
+    expect(after.map((n) => n.textContent)).toEqual(['b', 'c', 'd']);
+    expect(serverItems[0].isConnected).toBe(false); // dropped id's DOM is gone, no orphans
+  });
+
+  it('materialized items are wired: a later field change updates in place', async () => {
+    const serverData = signal([{ id: 1, label: 'a' }]);
+    const clientData = signal([]);
+    const { el, serverItems } = await ssrAndHydrate({
+      template: '<ul>{#each item in items}<li>{item.label}</li>{/each}</ul>',
+      createComponent: ({ isServer }) => ({ items: isServer ? serverData : clientData }),
+    });
+    await settle();
+    clientData.set([{ id: 1, label: 'a' }]);
+    flush();
+    await settle();
+
+    clientData.set([{ id: 1, label: 'A' }]);
+    flush();
+    await settle();
+    const after = itemsOf(el);
+    expect(after.length).toBe(1);
+    expect(after[0].textContent).toBe('A');
+  });
+
+  it('a change whose truth is empty releases the held DOM into the else branch', async () => {
+    const serverData = signal(['a', 'b', 'c']);
+    const clientData = signal([]);
+    const { el } = await ssrAndHydrate({
+      template: '<ul>{#each item in items}<li>{item}</li>{else}<p class="empty">none</p>{/each}</ul>',
+      createComponent: ({ isServer }) => ({ items: isServer ? serverData : clientData }),
+    });
+    await settle();
+    // the only way truth-empty can ARRIVE is via a real change (an equal []
+    // never notifies) — data comes and goes again
+    clientData.set(['x']);
+    flush();
+    await settle();
+    clientData.set([]);
+    flush();
+    await settle();
+    expect(itemsOf(el).length).toBe(0);
+    expect(el.shadowRoot.querySelector('.empty')).not.toBeNull();
+  });
+
+  it('a server-rendered else branch still hydrates, and items arriving later replace it', async () => {
+    const serverData = signal([]);
+    const clientData = signal([]);
+    const { el } = await ssrAndHydrate({
+      template: '<ul>{#each item in items}<li>{item}</li>{else}<p class="empty">none</p>{/each}</ul>',
+      createComponent: ({ isServer }) => ({ items: isServer ? serverData : clientData }),
+    });
+    await settle();
+    expect(el.shadowRoot.querySelector('.empty')).not.toBeNull();
+
+    clientData.set(['x']);
+    flush();
+    await settle();
+    expect(itemsOf(el).map((n) => n.textContent)).toEqual(['x']);
+    expect(el.shadowRoot.querySelector('.empty')).toBeNull();
+  });
+});


### PR DESCRIPTION
This fixes an issue where async on initialize could cause double rendering from SSRed components.

This is of the shape
```javascript
defineComponent({
  tagName: 'comment-list',
  template,
  settings: { postId: '' },
  defaultState: { comments: [] },
  createComponent: ({ state, settings }) => ({
    async initialize() {
      const response = await fetch(`/api/comments?post=${settings.postId}`);
      state.comments.set(await response.json());
    },
  }),
});
```

## Changes
- Added new late attach branch to renderer `each`

## Risk
5/10

SSR / Hydration hot path

## How to Test

New tests added with red/green