### PR TITLE
Perf(renderer): Skip DOM Updates with Last Value is Equal

### DIFF
--- a/packages/renderer/src/engines/native/attribute-binding.js
+++ b/packages/renderer/src/engines/native/attribute-binding.js
@@ -124,7 +124,9 @@ export function bindAttribute({
           value += evaluateMarkerToString(entries[part.markerId], data, renderer);
         }
       }
-      element.setAttribute(attrName, value);
+      // the single-expression branch above compares before it writes, and a multi-part value is a
+      // string all the same: an equal write invalidates style for the element for nothing
+      if (element.getAttribute(attrName) !== value) { element.setAttribute(attrName, value); }
     });
   }
 }

--- a/packages/renderer/src/engines/native/attribute-binding.js
+++ b/packages/renderer/src/engines/native/attribute-binding.js
@@ -103,10 +103,7 @@ export function bindAttribute({
     });
   }
   else {
-    // what this binding last wrote, so a re-fire that computes the same string skips the write
-    // without a getAttribute: on a first render the read can only miss, and these bindings are
-    // created by the thousand
-    let lastValue;
+    let lastValue; // remembered rather than read back, a getAttribute on mount can only miss
     scope.reaction(element, (comp) => {
       if (skipFirstWrite && comp.firstRun) {
         // Evaluate all markers to register Signal dependencies, skip DOM

--- a/packages/renderer/src/engines/native/attribute-binding.js
+++ b/packages/renderer/src/engines/native/attribute-binding.js
@@ -103,6 +103,10 @@ export function bindAttribute({
     });
   }
   else {
+    // what this binding last wrote, so a re-fire that computes the same string skips the write
+    // without a getAttribute: on a first render the read can only miss, and these bindings are
+    // created by the thousand
+    let lastValue;
     scope.reaction(element, (comp) => {
       if (skipFirstWrite && comp.firstRun) {
         // Evaluate all markers to register Signal dependencies, skip DOM
@@ -124,9 +128,9 @@ export function bindAttribute({
           value += evaluateMarkerToString(entries[part.markerId], data, renderer);
         }
       }
-      // the single-expression branch above compares before it writes, and a multi-part value is a
-      // string all the same: an equal write invalidates style for the element for nothing
-      if (element.getAttribute(attrName) !== value) { element.setAttribute(attrName, value); }
+      if (lastValue === value) { return; }
+      lastValue = value;
+      element.setAttribute(attrName, value);
     });
   }
 }

--- a/packages/renderer/src/engines/native/define-block.js
+++ b/packages/renderer/src/engines/native/define-block.js
@@ -259,7 +259,12 @@ function commitText(state, comp) {
     state.compute(state);
     return;
   }
-  state.anchor.data = unwrap(state.compute(state)) ?? '';
+  const value = unwrap(state.compute(state)) ?? '';
+  // a signal holding an object notifies every binding that reads it, so a field that did not move
+  // still re-fires here. writing the same data invalidates the text node, so compare first, and
+  // coerce the way the assignment would (a template literal throws on a Symbol exactly as it does)
+  const next = typeof value === 'string' ? value : `${value}`;
+  if (state.anchor.data !== next) { state.anchor.data = next; }
 }
 
 // mutable fields (ownedNodes, endAnchor) live on state so re-fires can update them

--- a/packages/renderer/src/engines/native/define-block.js
+++ b/packages/renderer/src/engines/native/define-block.js
@@ -262,9 +262,9 @@ function commitText(state, comp) {
   const value = unwrap(state.compute(state)) ?? '';
   // a signal holding an object notifies every binding that reads it, so a field that did not move
   // still re-fires here, and writing the same data invalidates the text node for nothing. compare
-  // against what this binding last wrote rather than against anchor.data: the anchor is ours between
-  // the markers, and a cached string costs nothing on the first render where a DOM read can only miss.
-  // coerce the way the assignment would, so a Symbol still throws exactly where it did
+  // against what this binding last wrote rather than against anchor.data: the anchor is ours
+  // between the markers, and a DOM read on a first render can only miss. coerce the way the
+  // assignment would, so a Symbol still throws exactly where it did
   const next = typeof value === 'string' ? value : `${value}`;
   if (state.lastText === next) { return; }
   state.lastText = next;
@@ -370,6 +370,9 @@ function defineValueBlock(config) {
       self,
       ownedNodes,
       endAnchor: null,
+      // declared here, not on first write: a property added later moves out of the object's
+      // shape and every access after it pays the indirection
+      lastText: undefined,
     };
 
     // Static dispatches skip Reaction wiring. Hydration is a no-op —

--- a/packages/renderer/src/engines/native/define-block.js
+++ b/packages/renderer/src/engines/native/define-block.js
@@ -260,13 +260,8 @@ function commitText(state, comp) {
     return;
   }
   const value = unwrap(state.compute(state)) ?? '';
-  // a signal holding an object notifies every binding that reads it, so a field that did not move
-  // still re-fires here, and writing the same data invalidates the text node for nothing. compare
-  // against what this binding last wrote rather than against anchor.data: the anchor is ours
-  // between the markers, and a DOM read on a first render can only miss. coerce the way the
-  // assignment would, so a Symbol still throws exactly where it did
   const next = typeof value === 'string' ? value : `${value}`;
-  if (state.lastText === next) { return; }
+  if (state.lastText === next) { return; } // remembered rather than read back, an anchor.data read on mount can only miss
   state.lastText = next;
   state.anchor.data = next;
 }
@@ -370,8 +365,6 @@ function defineValueBlock(config) {
       self,
       ownedNodes,
       endAnchor: null,
-      // declared here, not on first write: a property added later moves out of the object's
-      // shape and every access after it pays the indirection
       lastText: undefined,
     };
 

--- a/packages/renderer/src/engines/native/define-block.js
+++ b/packages/renderer/src/engines/native/define-block.js
@@ -261,10 +261,14 @@ function commitText(state, comp) {
   }
   const value = unwrap(state.compute(state)) ?? '';
   // a signal holding an object notifies every binding that reads it, so a field that did not move
-  // still re-fires here. writing the same data invalidates the text node, so compare first, and
-  // coerce the way the assignment would (a template literal throws on a Symbol exactly as it does)
+  // still re-fires here, and writing the same data invalidates the text node for nothing. compare
+  // against what this binding last wrote rather than against anchor.data: the anchor is ours between
+  // the markers, and a cached string costs nothing on the first render where a DOM read can only miss.
+  // coerce the way the assignment would, so a Symbol still throws exactly where it did
   const next = typeof value === 'string' ? value : `${value}`;
-  if (state.anchor.data !== next) { state.anchor.data = next; }
+  if (state.lastText === next) { return; }
+  state.lastText = next;
+  state.anchor.data = next;
 }
 
 // mutable fields (ownedNodes, endAnchor) live on state so re-fires can update them

--- a/packages/renderer/src/engines/native/define-block.js
+++ b/packages/renderer/src/engines/native/define-block.js
@@ -261,7 +261,7 @@ function commitText(state, comp) {
   }
   const value = unwrap(state.compute(state)) ?? '';
   const next = typeof value === 'string' ? value : `${value}`;
-  if (state.lastText === next) { return; } // remembered rather than read back, an anchor.data read on mount can only miss
+  if (state.lastText === next) { return; } // anchor.data read on mount can only miss 
   state.lastText = next;
   state.anchor.data = next;
 }

--- a/packages/renderer/test/browser/equal-value-writes.test.js
+++ b/packages/renderer/test/browser/equal-value-writes.test.js
@@ -2,22 +2,12 @@ import { defineComponent } from '@semantic-ui/component';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { RENDERING_ENGINES, waitForUpdate } from './test-utils.js';
 
-/*
-  A binding whose value did not change must not touch the DOM. The shape that exposes it is one
-  signal holding an object that a tick replaces wholesale: a dashboard's sampler, a store's
-  snapshot. The signal's own equality skips a replacement that is deep-equal, so the case worth
-  pinning is the mixed one, where some other field moved and this binding's string did not.
-
-  Equal-value writes are not cosmetic. A text write invalidates the node and a class write
-  invalidates style for the element, so a steady field on a busy signal pays layout and paint
-  on every tick.
-*/
+// a binding whose field did not move must not touch the DOM, counted rather than asserted
 
 RENDERING_ENGINES.forEach((engine) => {
   let tagCounter = 0;
   const uniqueTag = () => `test-equal-writes-${engine}-${++tagCounter}`;
 
-  // characterData and attribute records whose value came back the same
   function countRewrites(root) {
     const seen = { text: 0, multiPartAttribute: 0, singleExpressionAttribute: 0, moved: 0 };
     const observer = new MutationObserver((records) => {
@@ -81,7 +71,6 @@ RENDERING_ENGINES.forEach((engine) => {
         await waitForUpdate(el);
       }
       stop();
-      // the signal's own equality skips the set, so nothing downstream runs at all
       expect(seen).toEqual({ text: 0, multiPartAttribute: 0, singleExpressionAttribute: 0, moved: 0 });
     });
 
@@ -93,8 +82,6 @@ RENDERING_ENGINES.forEach((engine) => {
         await waitForUpdate(el);
       }
       stop();
-      // before the guards the native engine wrote the same string 9 times to the text node and 9
-      // times to the multi-part class, while the single-expression class was already quiet
       expect(seen.text).toBe(0);
       expect(seen.multiPartAttribute).toBe(0);
       expect(seen.singleExpressionAttribute).toBe(0);
@@ -110,7 +97,6 @@ RENDERING_ENGINES.forEach((engine) => {
         await waitForUpdate(el);
       }
       stop();
-      // three moves across a text node and two class attributes, and no equal-value write
       expect(seen.moved).toBe(states.length * 3);
       expect(seen.text + seen.multiPartAttribute + seen.singleExpressionAttribute).toBe(0);
       expect(el.shadowRoot.querySelector('b').textContent).toBe('active');

--- a/packages/renderer/test/browser/equal-value-writes.test.js
+++ b/packages/renderer/test/browser/equal-value-writes.test.js
@@ -1,0 +1,120 @@
+import { defineComponent } from '@semantic-ui/component';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { RENDERING_ENGINES, waitForUpdate } from './test-utils.js';
+
+/*
+  A binding whose value did not change must not touch the DOM. The shape that exposes it is one
+  signal holding an object that a tick replaces wholesale: a dashboard's sampler, a store's
+  snapshot. The signal's own equality skips a replacement that is deep-equal, so the case worth
+  pinning is the mixed one, where some other field moved and this binding's string did not.
+
+  Equal-value writes are not cosmetic. A text write invalidates the node and a class write
+  invalidates style for the element, so a steady field on a busy signal pays layout and paint
+  on every tick.
+*/
+
+RENDERING_ENGINES.forEach((engine) => {
+  let tagCounter = 0;
+  const uniqueTag = () => `test-equal-writes-${engine}-${++tagCounter}`;
+
+  // characterData and attribute records whose value came back the same
+  function countRewrites(root) {
+    const seen = { text: 0, multiPartAttribute: 0, singleExpressionAttribute: 0, moved: 0 };
+    const observer = new MutationObserver((records) => {
+      for (const record of records) {
+        const now = record.type === 'characterData'
+          ? record.target.data
+          : record.target.getAttribute(record.attributeName);
+        if (record.oldValue !== now) {
+          seen.moved += 1;
+          continue;
+        }
+        if (record.type === 'characterData') { seen.text += 1; }
+        else if (record.target.dataset.binding === 'single') { seen.singleExpressionAttribute += 1; }
+        else { seen.multiPartAttribute += 1; }
+      }
+    });
+    observer.observe(root, {
+      subtree: true,
+      characterData: true,
+      characterDataOldValue: true,
+      attributes: true,
+      attributeOldValue: true,
+      attributeFilter: ['class'],
+    });
+    return {
+      seen,
+      stop: () => {
+        observer.takeRecords();
+        observer.disconnect();
+      },
+    };
+  }
+
+  async function mount() {
+    const tag = uniqueTag();
+    defineComponent({
+      renderingEngine: engine,
+      tagName: tag,
+      template: `
+        <div class="stat conn {metrics.connection}" data-binding="multi"><b>{metrics.connection}</b></div>
+        <div class="{metrics.connection}" data-binding="single"></div>
+      `,
+      defaultState: { metrics: { connection: 'active', fps: 60 } },
+    });
+    const el = document.createElement(tag);
+    document.body.appendChild(el);
+    await el.rendered;
+    return el;
+  }
+
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  describe(`${engine}: a binding whose value did not change`, () => {
+    it('writes nothing when the whole object is replaced with a deep-equal one', async () => {
+      const el = await mount();
+      const { seen, stop } = countRewrites(el.shadowRoot);
+      for (let i = 0; i < 10; i += 1) {
+        el.template.state.metrics.set({ connection: 'active', fps: 60 });
+        await waitForUpdate(el);
+      }
+      stop();
+      // the signal's own equality skips the set, so nothing downstream runs at all
+      expect(seen).toEqual({ text: 0, multiPartAttribute: 0, singleExpressionAttribute: 0, moved: 0 });
+    });
+
+    it('writes nothing when another field moved and this one did not', async () => {
+      const el = await mount();
+      const { seen, stop } = countRewrites(el.shadowRoot);
+      for (let i = 0; i < 10; i += 1) {
+        el.template.state.metrics.set({ connection: 'active', fps: 60 + i });
+        await waitForUpdate(el);
+      }
+      stop();
+      // before the guards the native engine wrote the same string 9 times to the text node and 9
+      // times to the multi-part class, while the single-expression class was already quiet
+      expect(seen.text).toBe(0);
+      expect(seen.multiPartAttribute).toBe(0);
+      expect(seen.singleExpressionAttribute).toBe(0);
+      expect(seen.moved).toBe(0);
+    });
+
+    it('still writes when the value itself moves', async () => {
+      const el = await mount();
+      const states = ['waiting', 'retrying', 'active'];
+      const { seen, stop } = countRewrites(el.shadowRoot);
+      for (const connection of states) {
+        el.template.state.metrics.set({ connection, fps: 60 });
+        await waitForUpdate(el);
+      }
+      stop();
+      // three moves across a text node and two class attributes, and no equal-value write
+      expect(seen.moved).toBe(states.length * 3);
+      expect(seen.text + seen.multiPartAttribute + seen.singleExpressionAttribute).toBe(0);
+      expect(el.shadowRoot.querySelector('b').textContent).toBe('active');
+      expect(el.shadowRoot.querySelector('[data-binding="multi"]').getAttribute('class')).toBe('stat conn active');
+    });
+  });
+});


### PR DESCRIPTION
This updates the native rendered to store `lastValue` to avoid updating DOM even in cases where signal's own `isEqual` might fire equality but the update is a `noop`. 

## Changes
- Updates text value bindings to use `lastValue`
- Updates multi-part attribute which call `setAttribute` to use `lastValue

## Risk
4/10 

Key paths in the native renderer but small line count and easy to comprehend downstream effects.

## How to Test
`packages/renderer/test/browser/equal-value-writes.test.js` 