### PR TITLE
Build: Fix Benchmark CI to Permit New Packages

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -135,17 +135,30 @@ jobs:
       # a sidecar (baseline-sha.txt). The reporter pins each metric's
       # percent_delta_ci to that SHA — required for cross-iteration drift
       # detection (see tools/ci/bench/reporter/reporter.js:computeBaselineDrift).
+      #
+      # Only the source directories the baseline has are checked out: a package
+      # the PR adds has none there, and one missing path fails the whole
+      # pathspec. Files the PR adds inside an existing package are dropped, and
+      # the directories that leaves empty removed, so the baseline bundle is the
+      # baseline's.
       - name: Build baseline
         run: |
           if [ '${{ github.event_name }}' = 'push' ]; then
             # Fetch enough history to reach the parent commit locally.
             git fetch origin main --depth=2
             BASELINE_SHA=$(git rev-parse HEAD~1)
-            git checkout HEAD~1 -- packages/*/src/
           else
             git fetch origin ${{ github.event.pull_request.base.ref }} --depth=1
             BASELINE_SHA=$(git rev-parse FETCH_HEAD)
-            git checkout FETCH_HEAD -- packages/*/src/
+          fi
+          SRC=$(git ls-tree -d --name-only "$BASELINE_SHA" -- packages/*/src)
+          if [ -n "$SRC" ]; then
+            git checkout "$BASELINE_SHA" -- $SRC
+          fi
+          ADDED=$(git diff --name-only --diff-filter=A "$BASELINE_SHA" HEAD -- packages/*/src || true)
+          if [ -n "$ADDED" ]; then
+            echo "$ADDED" | xargs -r rm -f
+            echo "$ADDED" | xargs -r -n1 dirname | sort -ur | xargs -r rmdir -p --ignore-fail-on-non-empty 2>/dev/null || true
           fi
           node packages/${{ matrix.entry.package }}/bench/tachometer/build-ci.js baseline
           git checkout HEAD -- packages/*/src/

--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -67,8 +67,9 @@ jobs:
       # measure. node_modules is reused — a faithful-enough baseline, since
       # dep bumps rarely move first-party bundle bytes. Files the PR adds are
       # dropped so the lines-of-code delta counts new files honestly, and the
-      # empty directories they leave behind are pruned: a build script that
-      # walks packages/ trips on a package folder with no package.json.
+      # directories that leaves empty are removed, those and no others, since a
+      # build script that walks packages/ trips on a package folder with no
+      # package.json.
       #
       # Root package.json and the lockfile are swapped too: build:packages
       # lists each package's :build explicitly, so a PR that adds (or removes)
@@ -82,7 +83,7 @@ jobs:
           git checkout FETCH_HEAD -- packages src internal-packages package.json package-lock.json 2>/dev/null || true
           if [ -n "$ADDED" ]; then
             echo "$ADDED" | xargs -r rm -f
-            find packages src internal-packages -type d -empty -delete
+            echo "$ADDED" | xargs -r -n1 dirname | sort -ur | xargs -r rmdir -p --ignore-fail-on-non-empty 2>/dev/null || true
           fi
           npm run build
           node tools/ci/size/collect.js --root . --label baseline --out results/baseline.json

--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -67,9 +67,11 @@ jobs:
       # measure. node_modules is reused — a faithful-enough baseline, since
       # dep bumps rarely move first-party bundle bytes. Files the PR adds are
       # dropped so the lines-of-code delta counts new files honestly, and the
-      # directories that leaves empty are removed, those and no others, since a
-      # build script that walks packages/ trips on a package folder with no
-      # package.json.
+      # directories that leaves empty are removed, those and no others. The new
+      # package's folder itself survives on its build output, and that is fine:
+      # what tripped was the playground's asset build, which takes any folder
+      # holding a types/ directory for a package and reads its package.json, and
+      # the emptied types/ folder is gone.
       #
       # Root package.json and the lockfile are swapped too: build:packages
       # lists each package's :build explicitly, so a PR that adds (or removes)

--- a/.github/workflows/memory.yml
+++ b/.github/workflows/memory.yml
@@ -84,8 +84,9 @@ jobs:
 
       # Swap shipped source to the merge base, rebuild the baseline bundle, and
       # measure. node_modules is reused. Files the PR adds are dropped, and the
-      # directories that leaves empty removed, those and no others: a build
-      # script that walks packages/ trips on a package folder with no package.json.
+      # directories that leaves empty removed, those and no others. What tripped
+      # was the playground's asset build, which takes any folder holding a types/
+      # directory for a package and reads its package.json.
       #
       # Root package.json and the lockfile are swapped too (the #264 fix): a PR
       # that adds or removes a package would otherwise leave the base build

--- a/.github/workflows/memory.yml
+++ b/.github/workflows/memory.yml
@@ -83,7 +83,9 @@ jobs:
           node tools/ci/memory/collect.js --label current --side current --out results/current.json
 
       # Swap shipped source to the merge base, rebuild the baseline bundle, and
-      # measure. node_modules is reused. Files the PR adds are dropped.
+      # measure. node_modules is reused. Files the PR adds are dropped, and the
+      # directories that leaves empty removed, those and no others: a build
+      # script that walks packages/ trips on a package folder with no package.json.
       #
       # Root package.json and the lockfile are swapped too (the #264 fix): a PR
       # that adds or removes a package would otherwise leave the base build
@@ -96,7 +98,7 @@ jobs:
           git checkout FETCH_HEAD -- packages package.json package-lock.json 2>/dev/null || true
           if [ -n "$ADDED" ]; then
             echo "$ADDED" | xargs -r rm -f
-            find packages -type d -empty -delete
+            echo "$ADDED" | xargs -r -n1 dirname | sort -ur | xargs -r rmdir -p --ignore-fail-on-non-empty 2>/dev/null || true
           fi
           # Keep the bench driver from the PR head on both sides: it's the
           # measurement instrument, not the measured code, and on a PR that


### PR DESCRIPTION
This fixes the benchmark CI to not fail when you add a new package.