### PR TITLE
Build: Fold isDevelopment Out of the Minified Browser Artifacts

### DIFF
--- a/ai/skills/contributing/build-system.md
+++ b/ai/skills/contributing/build-system.md
@@ -88,7 +88,7 @@ CDN format uses the `esbuild-resolve-bare-imports` plugin to rewrite bare import
 // input
 import { Signal } from '@semantic-ui/reactivity';
 // output (version from package.json dependencies)
-import { Signal } from 'https://cdn.jsdelivr.net/npm/@semantic-ui/reactivity@0.18.0/dist/cdn/index.min.js';
+import { Signal } from 'https://cdn.jsdelivr.net/npm/@semantic-ui/reactivity@0.18.0/dist/cdn/reactivity.min.js';
 ```
 
 Each format builds both minified and unminified (e.g., `dist/semantic-ui.js` + `dist/semantic-ui.min.js`).
@@ -158,8 +158,8 @@ export default {
   ".": {
     "types": "./types/index.d.ts",
     "import": "./src/index.js",
-    "browser": "./dist/bundle/index.min.js",
-    "importmap": "./dist/cdn/index.min.js"
+    "browser": "./dist/bundle/reactivity.min.js",
+    "importmap": "./dist/cdn/reactivity.min.js"
   }
 }
 ```

--- a/internal-packages/scripts/src/lib/build.js
+++ b/internal-packages/scripts/src/lib/build.js
@@ -93,6 +93,13 @@ export const getESBuildConfig = async function({
     platform,
   };
 
+  // the browser artifacts fold isDevelopment at build time: the readable build keeps every
+  // explanation and the minified one drops them. the esm output stays undefined, so a bundler's
+  // own define decides for the app it builds
+  if (type == 'javascript' && (bundle || cdn)) {
+    config.define = { __DEV__: minify ? 'false' : 'true', ...config.define };
+  }
+
   if ((cdn || readEntrypoints || addBanner || addLog || addOutfile) && !packageFile) {
     packageFile = await getPackageFile();
   }

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -15,8 +15,8 @@
     ".": {
       "types": "./types/index.d.ts",
       "import": "./src/index.js",
-      "browser": "./dist/bundle/index.min.js",
-      "importmap": "./dist/cdn/index.min.js"
+      "browser": "./dist/bundle/compiler.min.js",
+      "importmap": "./dist/cdn/compiler.min.js"
     }
   },
   "scripts": {

--- a/packages/component/package.json
+++ b/packages/component/package.json
@@ -17,8 +17,8 @@
     ".": {
       "types": "./types/index.d.ts",
       "import": "./src/index.js",
-      "browser": "./dist/bundle/index.min.js",
-      "importmap": "./dist/cdn/index.min.js"
+      "browser": "./dist/bundle/component.min.js",
+      "importmap": "./dist/cdn/component.min.js"
     },
     "./bare": "./src/bare.js",
     "./lit": "./src/engines/lit/register.js"

--- a/packages/dates/package.json
+++ b/packages/dates/package.json
@@ -18,8 +18,8 @@
     ".": {
       "types": "./types/index.d.ts",
       "import": "./src/index.js",
-      "browser": "./dist/bundle/index.min.js",
-      "importmap": "./dist/cdn/index.min.js"
+      "browser": "./dist/bundle/dates.min.js",
+      "importmap": "./dist/cdn/dates.min.js"
     }
   },
   "scripts": {

--- a/packages/query/package.json
+++ b/packages/query/package.json
@@ -15,8 +15,8 @@
     ".": {
       "types": "./types/index.d.ts",
       "import": "./src/index.js",
-      "browser": "./dist/bundle/index.min.js",
-      "importmap": "./dist/cdn/index.min.js"
+      "browser": "./dist/bundle/query.min.js",
+      "importmap": "./dist/cdn/query.min.js"
     }
   },
   "scripts": {

--- a/packages/reactivity/package.json
+++ b/packages/reactivity/package.json
@@ -17,8 +17,8 @@
     ".": {
       "types": "./types/index.d.ts",
       "import": "./src/index.js",
-      "browser": "./dist/bundle/index.min.js",
-      "importmap": "./dist/cdn/index.min.js"
+      "browser": "./dist/bundle/reactivity.min.js",
+      "importmap": "./dist/cdn/reactivity.min.js"
     }
   },
   "scripts": {

--- a/packages/renderer/package.json
+++ b/packages/renderer/package.json
@@ -15,8 +15,8 @@
     ".": {
       "types": "./types/index.d.ts",
       "import": "./src/index.js",
-      "browser": "./dist/bundle/index.min.js",
-      "importmap": "./dist/cdn/index.min.js"
+      "browser": "./dist/bundle/renderer.min.js",
+      "importmap": "./dist/cdn/renderer.min.js"
     },
     "./lit": "./src/engines/lit/renderer.js"
   },

--- a/packages/templating/package.json
+++ b/packages/templating/package.json
@@ -15,8 +15,8 @@
     ".": {
       "types": "./types/index.d.ts",
       "import": "./src/index.js",
-      "browser": "./dist/bundle/index.min.js",
-      "importmap": "./dist/cdn/index.min.js"
+      "browser": "./dist/bundle/templating.min.js",
+      "importmap": "./dist/cdn/templating.min.js"
     },
     "./template": {
       "types": "./types/template.d.ts",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -18,8 +18,8 @@
     ".": {
       "types": "./types/index.d.ts",
       "import": "./src/index.js",
-      "browser": "./dist/bundle/index.min.js",
-      "importmap": "./dist/cdn/index.min.js"
+      "browser": "./dist/bundle/utils.min.js",
+      "importmap": "./dist/cdn/utils.min.js"
     }
   },
   "scripts": {


### PR DESCRIPTION
This handles proper tree shaking in builds for `__DEV__`, which is handled internally with `isDevelopment`.

Shaves 14% off for dates.

Full report from [bundle-bot](https://github.com/Semantic-Org/Semantic-Next/pull/360#issuecomment-5578225754) below

