### PR TITLE
[Bug] Fix Bug In HTML Entity Treatment in SSR Attribues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ xx.xx.xxxx
 * **Bug** - Fixed `checked` and `selected` attributes not syncing DOM properties after user interaction — programmatic updates via reactivity (e.g. toggle-all) now correctly update checkbox/select state
 * **Bug** - Fixed `{#async}` blocks without `{loading}` or `{error}` sections briefly clearing visible content when reactive dependencies changed
 * **Bug** - Fixed `{#async}` blocks showing stale data when reactive dependencies changed rapidly before a previous request resolved
+* **Bug** - Fixed a bound attribute value containing `<` or `>` corrupting server-rendered output — the raw character read as the tag's end, so the element's next binding was emitted as text with a hydration marker inside the tag. Bound attribute values are now escaped with the full HTML entity set
 
 ### Reactivity
 * **Bug** - Fixed `instanceof` brand check on `Signal` to use prototype getter instead of class field — ensures cross-realm and prototype-created instances pass `instanceof` reliably.

--- a/packages/renderer/src/engines/native/server.js
+++ b/packages/renderer/src/engines/native/server.js
@@ -394,24 +394,7 @@ export class ServerRenderer {
         return REMOVE_ATTR;
       }
 
-      let strValue = stringifyAttrValue(value).replace(/&/g, '&amp;').replace(/"/g, '&quot;');
-
-      // Check if we're inside a quoted attribute value by counting quotes
-      // in the current tag fragment. Odd count = inside quotes, even = unquoted.
-      const tagStart = scope.htmlBuffer.lastIndexOf('<');
-      const tagFragment = scope.htmlBuffer.slice(tagStart);
-      const doubleQuotes = (tagFragment.match(/"/g) || []).length;
-      const insideQuotes = doubleQuotes % 2 === 1;
-
-      // Unquoted attribute (e.g. style={expr}) — wrap in quotes so the
-      // value survives HTML parsing when it contains spaces or newlines
-      if (!insideQuotes) {
-        scope.htmlBuffer += `"${strValue}"`;
-        return `"${strValue}"`;
-      }
-
-      scope.htmlBuffer += strValue;
-      return strValue;
+      return this.emitAttributeValue(stringifyAttrValue(value), scope);
     }
 
     // Text position — hydration marker + evaluated value
@@ -440,7 +423,7 @@ export class ServerRenderer {
   // Emit a block's evaluated string value inline as an attribute value.
   // Mirrors renderExpression's insideTag branch: registers the entry in
   // scope.tagBindings so data-sui-bind gets stamped on the element, then
-  // escapes and emits the value with the quote-aware wrapping.
+  // hands the string to emitAttributeValue.
   emitAttributeBlock(id, value, scope) {
     const classification = analyzePosition(scope.htmlBuffer);
     if (classification.type === 'property' || classification.type === 'event') {
@@ -457,21 +440,24 @@ export class ServerRenderer {
       scope.tagBindings[resolvedAttr] = id;
     }
 
-    const strValue = String(value ?? '')
-      .replace(/&/g, '&amp;')
-      .replace(/"/g, '&quot;');
+    return this.emitAttributeValue(String(value ?? ''), scope);
+  }
 
+  // escapes the full escapeHTML set, not only & and ": a raw > in the tag buffer
+  // reads as the tag's end to analyzePosition and pushes the element's next
+  // binding into text position, and a raw < moves where the quote count starts.
+  // an odd count of " in the current tag fragment means the value sits inside
+  // quotes, an unquoted attribute (style={expr}) is wrapped so the value survives
+  // parsing when it holds spaces or newlines
+  emitAttributeValue(strValue, scope) {
+    const escaped = escapeHTML(strValue);
     const tagStart = scope.htmlBuffer.lastIndexOf('<');
     const tagFragment = scope.htmlBuffer.slice(tagStart);
     const doubleQuotes = (tagFragment.match(/"/g) || []).length;
     const insideQuotes = doubleQuotes % 2 === 1;
-
-    if (!insideQuotes) {
-      scope.htmlBuffer += `"${strValue}"`;
-      return `"${strValue}"`;
-    }
-    scope.htmlBuffer += strValue;
-    return strValue;
+    const out = insideQuotes ? escaped : `"${escaped}"`;
+    scope.htmlBuffer += out;
+    return out;
   }
 
   renderConditional(node, data, scope) {

--- a/packages/renderer/test/browser/ssr-hydration.test.js
+++ b/packages/renderer/test/browser/ssr-hydration.test.js
@@ -194,6 +194,32 @@ describe('SSR hydration — attribute expressions', () => {
 
     expect(el.shadowRoot.querySelector('div').getAttribute('class')).toBe('base extra');
   });
+
+  it('hydrates a bound attribute carrying > to the value the server wrote', async () => {
+    const el = await ssrAndHydrate({
+      template: '<div first="{first}" second="{second}">text</div>',
+      defaultState: { first: 'a>b', second: 'ok' },
+      createComponent: ({ state }) => ({
+        swap() {
+          state.first.set('c<d>e');
+          state.second.set('changed');
+        },
+      }),
+    });
+
+    const div = el.shadowRoot.querySelector('div');
+    expect(div.getAttribute('first')).toBe('a>b');
+    expect(div.getAttribute('second')).toBe('ok');
+
+    // the client writes with setAttribute, which stores the string as is with
+    // no re-parse, so the escaping lives in the server renderer alone
+    const updated = $(el).onNext('updated');
+    el.component.swap();
+    await updated;
+
+    expect(div.getAttribute('first')).toBe('c<d>e');
+    expect(div.getAttribute('second')).toBe('changed');
+  });
 });
 
 /*******************************

--- a/packages/renderer/test/unit/server.test.js
+++ b/packages/renderer/test/unit/server.test.js
@@ -679,7 +679,7 @@ describe('attribute value escaping', () => {
   it('escapes double quotes inside attribute values', () => {
     const ast = compile('<div title="{name}">x</div>');
     const html = render({ ast, data: { name: 'a"b' } });
-    // Anchor: server.js — .replace(/"/g, '&quot;')
+    // Anchor: server.js — emitAttributeValue, escapeHTML
     expect(html).toContain('title="a&quot;b"');
     expect(html).not.toContain('title="a"b"');
   });
@@ -690,14 +690,14 @@ describe('attribute value escaping', () => {
     expect(html).toContain('href="https://x.com/?a=1&amp;b=2"');
   });
 
-  it('keeps quotes intact when value contains < or > (browser parses quoted attribute literally)', () => {
-    // HTML5 quoted-attribute parsing treats `<` and `>` as literal text
-    // inside a quoted attribute. The server's escape chain (only `&` and
-    // `"`) is therefore sufficient. Document the safety contract.
+  it('escapes < and > in attribute values so the tag scanner never sees a raw >', () => {
+    // HTML5 parses a quoted attribute's < and > as literal text, so the browser
+    // alone would be safe with only & and " escaped. The server's own position
+    // scanner is not: a raw > reads as the tag's end and the element's next
+    // binding lands in text position. The entities decode to the same value.
     const ast = compile('<div title="{name}">x</div>');
     const html = render({ ast, data: { name: '<script>alert(1)</script>' } });
-    // The quote stays closed; the value is HTML-safe.
-    expect(html).toContain('title="<script>alert(1)</script>"');
+    expect(html).toContain('title="&lt;script&gt;alert(1)&lt;/script&gt;"');
     // No unescaped & — that would be the actual escape gap.
     const ast2 = compile('<div title="{name}">x</div>');
     const html2 = render({ ast: ast2, data: { name: 'a&b' } });

--- a/packages/renderer/test/unit/server.test.js
+++ b/packages/renderer/test/unit/server.test.js
@@ -1,5 +1,6 @@
 import { TemplateCompiler } from '@semantic-ui/compiler';
 import { TemplateHelpers } from '@semantic-ui/templating';
+import { escapeHTML } from '@semantic-ui/utils';
 import { describe, expect, it } from 'vitest';
 
 import {
@@ -188,6 +189,35 @@ describe('renderToString', () => {
       const content = stripMarkers(dsdContent(result));
       expect(content).not.toContain('disabled');
       expect(content).toContain('Go');
+    });
+
+    it('escapes > in a bound attribute value so the next binding stays in the tag', () => {
+      const ast = compile('<div first="{first}" second="{second}">x</div>');
+      const html = render({ ast, data: { first: 'a>b', second: 'ok' } });
+      // a raw > in the tag buffer reads as the tag's end to analyzePosition, which
+      // pushes `second` into text position: a marker and String(value) inside the tag
+      expect(html).toContain('first="a&gt;b"');
+      expect(html).toContain('second="ok"');
+      expect(html).toContain(`${DATA_SUI_BIND}="first=0,second=1"`);
+      expect(html).not.toContain(COMMENT_MARKER);
+    });
+
+    it('escapes a bound attribute value as escapeHTML does', () => {
+      const value = 'a<b>c"d&e';
+      const ast = compile('<div first="{first}" second="{second}">x</div>');
+      const html = render({ ast, data: { first: value, second: 'ok' } });
+      // a raw < moves the quote count's start, so `second` was wrapped again: second=""ok""
+      expect(html).toContain(`first="${escapeHTML(value)}"`);
+      expect(html).toContain('second="ok"');
+    });
+
+    it('escapes a block value in attribute position the same way', () => {
+      const ast = compile('<div first="{#if on}{first}{/if}" second="{second}">x</div>');
+      const html = render({ ast, data: { on: true, first: 'a>b', second: 'ok' } });
+      expect(html).toContain('first="a&gt;b"');
+      expect(html).toContain('second="ok"');
+      expect(html).toContain(`${DATA_SUI_BIND}="first=0,second=1"`);
+      expect(html).not.toContain(COMMENT_MARKER);
     });
   });
 


### PR DESCRIPTION
This fixes a bug where `>` could behave abnormally when used inside an attribute tag during SSR

## Risk
3/10 - Hot path modifies how SSR renders attributes but only when `>` is present

## How to Test
Tested included in PR
